### PR TITLE
Weekly stacktrace reports: ingest CSVs, dedupe stacks, link OPM issues

### DIFF
--- a/stacktrace-reports/README.md
+++ b/stacktrace-reports/README.md
@@ -1,0 +1,44 @@
+---
+title: Stacktrace Reports
+permalink: /stacktrace-reports/
+layout: default
+---
+
+# Stacktrace Reports
+
+Weekly ResInsight crash telemetry, deduplicated by call-stack signature and cross-linked to upstream issues on [OPM/ResInsight](https://github.com/OPM/ResInsight/issues).
+
+## Contents
+
+- [Incoming CSVs](./incoming-csvs.md) — every raw CSV received, with row counts and a link to its weekly report.
+- [Weekly reports](./index.md) — list of per-week analyses, newest first.
+- [Analyzer](./analyze_crashes.py) — the Python script that groups raw stack traces into unique signatures.
+- [Analyzer usage](./analyzer-README.md) — full command-line reference for the script.
+
+## Workflow
+
+A new CSV lands every week. Processing it is five steps:
+
+1. **Save the CSV.** Copy the weekly export into `stacktrace-reports/csv/` as `YYYY-MM-DD-query_data.csv`. Only the `timestamp` and `rawstack` columns are expected.
+2. **Run the analyzer in Markdown mode.**
+
+   ```
+   python stacktrace-reports/analyze_crashes.py \
+       stacktrace-reports/csv/YYYY-MM-DD-query_data.csv \
+       --format md \
+       --output stacktrace-reports/reports/YYYY-MM-DD.md
+   ```
+
+3. **Link to upstream issues.** For each unique stack in the generated report, search [OPM/ResInsight issues](https://github.com/OPM/ResInsight/issues) using the top ResInsight frame (function or file name). Paste the issue URL next to the stack, or write `none found` if no match.
+4. **Update `incoming-csvs.md`.** Add a new row with the CSV date, filename, total rows, unique stacks, and a link to the weekly report.
+5. **Update `index.md`.** Add a new row at the top of the weekly-reports table.
+
+Commit the CSV, the generated MD, and the two updated index pages together.
+
+## Jekyll integration
+
+The folder lives at the repo root (not as a Jekyll collection) so the folder name on disk matches the URL segment. Each Markdown file carries the standard `layout: default` front-matter used by pages in `_docs/`. CSV files are served as static assets by Jekyll.
+
+## Data scope
+
+CSVs are committed to the repo so reports remain reproducible. Before committing, confirm the CSV contains only non-identifying columns (currently `timestamp`, `rawstack`). If future exports add user-identifying fields, strip them before committing.

--- a/stacktrace-reports/README.md
+++ b/stacktrace-reports/README.md
@@ -35,7 +35,13 @@ A new CSV lands every week. Processing it is five steps:
    gh search issues --repo OPM/ResInsight "RimFileSummaryCase createSummaryReaderInterfaceThreadSafe" --limit 5
    ```
 
-   Replace `**OPM issue:** none found` with `**OPM issue:** [#NNNN](https://github.com/OPM/ResInsight/issues/NNNN)` when a match is found; leave `none found` otherwise so gaps stay visible.
+   Fetch the issue state at the same time:
+
+   ```
+   gh issue view 13883 --repo OPM/ResInsight --json number,state
+   ```
+
+   Replace `**OPM issue:** none found` with `**OPM issue:** [#NNNN](https://github.com/OPM/ResInsight/issues/NNNN) — OPEN` (or `CLOSED`) when a match is found; leave `none found` otherwise so gaps stay visible. The state is captured at link-time — rerun `gh issue view` for stale reports if the current state matters.
 
 4. **Update `incoming-csvs.md`.** Append a row using the total-rows and unique-stacks numbers printed by `analyze_crashes.py` (first two lines of its text output). Row template:
 

--- a/stacktrace-reports/README.md
+++ b/stacktrace-reports/README.md
@@ -29,11 +29,23 @@ A new CSV lands every week. Processing it is five steps:
        --output stacktrace-reports/reports/YYYY-MM-DD.md
    ```
 
-3. **Link to upstream issues.** For each unique stack in the generated report, search [OPM/ResInsight issues](https://github.com/OPM/ResInsight/issues) using the top ResInsight frame (function or file name). Paste the issue URL next to the stack, or write `none found` if no match.
-4. **Update `incoming-csvs.md`.** Add a new row with the CSV date, filename, total rows, unique stacks, and a link to the weekly report.
-5. **Update `index.md`.** Add a new row at the top of the weekly-reports table.
+3. **Link to upstream issues.** For each unique stack, search [OPM/ResInsight issues](https://github.com/OPM/ResInsight/issues) using the top ResInsight-specific frame (skip `performCrashLogging` / `manageSegFailure` — those are the crash handler). Example search:
 
-Commit the CSV, the generated MD, and the two updated index pages together.
+   ```
+   gh search issues --repo OPM/ResInsight "RimFileSummaryCase createSummaryReaderInterfaceThreadSafe" --limit 5
+   ```
+
+   Replace `**OPM issue:** none found` with `**OPM issue:** [#NNNN](https://github.com/OPM/ResInsight/issues/NNNN)` when a match is found; leave `none found` otherwise so gaps stay visible.
+
+4. **Update `incoming-csvs.md`.** Append a row using the total-rows and unique-stacks numbers printed by `analyze_crashes.py` (first two lines of its text output). Row template:
+
+   ```
+   | YYYY-MM-DD | [YYYY-MM-DD-query_data.csv](./csv/YYYY-MM-DD-query_data.csv) | <total> | <unique> | [YYYY-MM-DD](./reports/YYYY-MM-DD.md) |
+   ```
+
+5. **Update `index.md`.** Insert a new row at the top of the weekly-reports table with the same totals.
+
+Commit the CSV, the generated MD, and the two updated index pages together on a feature branch.
 
 ## Jekyll integration
 

--- a/stacktrace-reports/analyze_crashes.py
+++ b/stacktrace-reports/analyze_crashes.py
@@ -2,7 +2,7 @@
 analyze_crashes.py - Identify unique call stacks in ResInsight crash report CSV files.
 
 Usage:
-    python analyze_crashes.py <csv_file> [--min-count N] [--output FILE]
+    python analyze_crashes.py <csv_file> [--min-count N] [--format {text,md}] [--output FILE]
 """
 
 import argparse
@@ -82,6 +82,46 @@ def format_report(stacks: dict, min_count: int = 1) -> str:
     return "\n".join(lines)
 
 
+def format_report_md(stacks: dict, csv_path: Path, min_count: int = 1) -> str:
+    sorted_stacks = sorted(stacks.items(), key=lambda x: -x[1]["count"])
+    filtered = [(k, v) for k, v in sorted_stacks if v["count"] >= min_count]
+    total = sum(v["count"] for v in stacks.values())
+
+    date_stem = csv_path.stem.replace("-query_data", "")
+    csv_rel = f"../csv/{csv_path.name}"
+
+    lines = []
+    lines.append("---")
+    lines.append(f"title: Stacktrace report {date_stem}")
+    lines.append(f"permalink: /stacktrace-reports/reports/{date_stem}/")
+    lines.append("layout: default")
+    lines.append("---")
+    lines.append("")
+    lines.append(f"# Stacktrace report {date_stem}")
+    lines.append("")
+    lines.append(f"- **Source CSV:** [{csv_path.name}]({csv_rel})")
+    lines.append(f"- **Total crash reports:** {total}")
+    lines.append(f"- **Unique call stacks:** {len(stacks)}")
+    if min_count > 1:
+        lines.append(f"- **Showing stacks with ≥ {min_count} occurrences:** {len(filtered)}")
+    lines.append("")
+
+    for i, (_, info) in enumerate(filtered, 1):
+        lines.append(f"## Stack #{i} — count {info['count']}")
+        lines.append("")
+        lines.append(f"First seen: `{info['first_seen']}`")
+        lines.append("")
+        lines.append("```")
+        for frame in info["ri_frames"]:
+            lines.append(frame)
+        lines.append("```")
+        lines.append("")
+        lines.append("**OPM issue:** none found")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Identify unique call stacks in ResInsight crash report CSV files."
@@ -93,6 +133,12 @@ def main():
         default=1,
         metavar="N",
         help="Only show stacks with at least N occurrences (default: 1)",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("text", "md"),
+        default="text",
+        help="Output format: plain text (default) or Markdown page for the Jekyll site",
     )
     parser.add_argument(
         "--output",
@@ -108,7 +154,10 @@ def main():
 
     rows = parse_csv(str(csv_path))
     stacks = group_by_stack(rows)
-    report = format_report(stacks, min_count=args.min_count)
+    if args.format == "md":
+        report = format_report_md(stacks, csv_path, min_count=args.min_count)
+    else:
+        report = format_report(stacks, min_count=args.min_count)
 
     if args.output:
         Path(args.output).write_text(report, encoding="utf-8")

--- a/stacktrace-reports/analyze_crashes.py
+++ b/stacktrace-reports/analyze_crashes.py
@@ -45,17 +45,25 @@ def group_by_stack(rows: list[dict]) -> dict:
     stacks = {}
     for row in rows:
         raw_stack = row.get(stack_col, "")
+        ts = row.get(ts_col, "")
         lines = [l.strip() for l in raw_stack.strip().splitlines() if l.strip()]
         ri_lines = extract_ri_frames(lines)
         sig_key = "\n".join(ri_lines)
         if sig_key not in stacks:
             stacks[sig_key] = {
                 "count": 0,
-                "first_seen": row.get(ts_col, ""),
+                "first_seen": ts,
+                "last_seen": ts,
                 "stack": lines,
                 "ri_frames": ri_lines,
             }
-        stacks[sig_key]["count"] += 1
+        entry = stacks[sig_key]
+        entry["count"] += 1
+        # Timestamps in these CSVs are ISO-8601 UTC, so lexicographic ordering == chronological.
+        if ts and ts < entry["first_seen"]:
+            entry["first_seen"] = ts
+        if ts and ts > entry["last_seen"]:
+            entry["last_seen"] = ts
     return stacks
 
 
@@ -73,7 +81,11 @@ def format_report(stacks: dict, min_count: int = 1) -> str:
 
     for i, (key, info) in enumerate(filtered, 1):
         lines.append(f"{'=' * 70}")
-        lines.append(f"Stack #{i}  (count: {info['count']}, first seen: {info['first_seen']})")
+        lines.append(
+            f"Stack #{i}  (count: {info['count']}, "
+            f"first seen: {info['first_seen']}, "
+            f"last seen: {info['last_seen']})"
+        )
         lines.append(f"{'=' * 70}")
         for frame in info["ri_frames"]:
             lines.append(f"  {frame}")
@@ -109,7 +121,8 @@ def format_report_md(stacks: dict, csv_path: Path, min_count: int = 1) -> str:
     for i, (_, info) in enumerate(filtered, 1):
         lines.append(f"## Stack #{i} — count {info['count']}")
         lines.append("")
-        lines.append(f"First seen: `{info['first_seen']}`")
+        lines.append(f"First seen: `{info['first_seen']}`  ")
+        lines.append(f"Last seen: `{info['last_seen']}`")
         lines.append("")
         lines.append("```")
         for frame in info["ri_frames"]:

--- a/stacktrace-reports/analyze_crashes.py
+++ b/stacktrace-reports/analyze_crashes.py
@@ -1,0 +1,121 @@
+"""
+analyze_crashes.py - Identify unique call stacks in ResInsight crash report CSV files.
+
+Usage:
+    python analyze_crashes.py <csv_file> [--min-count N] [--output FILE]
+"""
+
+import argparse
+import csv
+import sys
+from pathlib import Path
+
+RI_PREFIXES = ("Rim", "Ria", "Rif", "Ric", "Riu", "Riv", "Rig")
+
+
+def is_resinsight_frame(line: str) -> bool:
+    return any(p in line for p in RI_PREFIXES) or "main at" in line
+
+
+def extract_ri_frames(lines: list[str]) -> list[str]:
+    return [l for l in lines if is_resinsight_frame(l)]
+
+
+def parse_csv(filepath: str) -> list[dict]:
+    rows = []
+    with open(filepath, "r", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            rows.append(row)
+    return rows
+
+
+def detect_columns(rows: list[dict]) -> tuple[str, str]:
+    """Return (stack_column, timestamp_column) based on available fields."""
+    if not rows:
+        return "rawstack", "timestamp"
+    keys = rows[0].keys()
+    stack_col = "rawstack" if "rawstack" in keys else "details_0_rawStack"
+    ts_col = "timestamp" if "timestamp" in keys else "timestamp [UTC]"
+    return stack_col, ts_col
+
+
+def group_by_stack(rows: list[dict]) -> dict:
+    stack_col, ts_col = detect_columns(rows)
+    stacks = {}
+    for row in rows:
+        raw_stack = row.get(stack_col, "")
+        lines = [l.strip() for l in raw_stack.strip().splitlines() if l.strip()]
+        ri_lines = extract_ri_frames(lines)
+        sig_key = "\n".join(ri_lines)
+        if sig_key not in stacks:
+            stacks[sig_key] = {
+                "count": 0,
+                "first_seen": row.get(ts_col, ""),
+                "stack": lines,
+                "ri_frames": ri_lines,
+            }
+        stacks[sig_key]["count"] += 1
+    return stacks
+
+
+def format_report(stacks: dict, min_count: int = 1) -> str:
+    lines = []
+    sorted_stacks = sorted(stacks.items(), key=lambda x: -x[1]["count"])
+    filtered = [(k, v) for k, v in sorted_stacks if v["count"] >= min_count]
+
+    total = sum(v["count"] for v in stacks.values())
+    lines.append(f"Total crash reports : {total}")
+    lines.append(f"Unique call stacks  : {len(stacks)}")
+    if min_count > 1:
+        lines.append(f"Showing stacks with >= {min_count} occurrences: {len(filtered)}")
+    lines.append("")
+
+    for i, (key, info) in enumerate(filtered, 1):
+        lines.append(f"{'=' * 70}")
+        lines.append(f"Stack #{i}  (count: {info['count']}, first seen: {info['first_seen']})")
+        lines.append(f"{'=' * 70}")
+        for frame in info["ri_frames"]:
+            lines.append(f"  {frame}")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Identify unique call stacks in ResInsight crash report CSV files."
+    )
+    parser.add_argument("csv_file", help="Path to the crash report CSV file")
+    parser.add_argument(
+        "--min-count",
+        type=int,
+        default=1,
+        metavar="N",
+        help="Only show stacks with at least N occurrences (default: 1)",
+    )
+    parser.add_argument(
+        "--output",
+        metavar="FILE",
+        help="Write report to FILE instead of stdout",
+    )
+    args = parser.parse_args()
+
+    csv_path = Path(args.csv_file)
+    if not csv_path.exists():
+        print(f"Error: file not found: {csv_path}", file=sys.stderr)
+        sys.exit(1)
+
+    rows = parse_csv(str(csv_path))
+    stacks = group_by_stack(rows)
+    report = format_report(stacks, min_count=args.min_count)
+
+    if args.output:
+        Path(args.output).write_text(report, encoding="utf-8")
+        print(f"Report written to {args.output}")
+    else:
+        print(report)
+
+
+if __name__ == "__main__":
+    main()

--- a/stacktrace-reports/analyzer-README.md
+++ b/stacktrace-reports/analyzer-README.md
@@ -1,0 +1,67 @@
+# Crash Report Analysis Tools
+
+Tools for analyzing ResInsight crash report CSV files exported from the telemetry system.
+
+## Prerequisites
+
+- Python 3.10 or newer
+- No third-party packages required (uses stdlib only)
+
+## analyze_crashes.py
+
+Groups crash reports by unique call stack and prints a ranked summary. The signature used for grouping is the set of ResInsight-specific frames (classes prefixed with `Rim`, `Ria`, `Rif`, `Ric`, `Riu`, `Riv`, `Rig`), so minor differences in lower-level system or Qt frames are ignored.
+
+### Basic usage
+
+```
+python analyze_crashes.py <csv_file>
+```
+
+Example — analyze today's export:
+
+```
+python analyze_crashes.py "..\2026-04-09-query_data.csv"
+```
+
+### Options
+
+| Option | Description |
+|---|---|
+| `--min-count N` | Only show stacks that appear at least N times |
+| `--output FILE` | Write the report to a file instead of printing to the terminal |
+
+### Examples
+
+Show only stacks with 2 or more occurrences:
+
+```
+python analyze_crashes.py "..\2026-04-09-query_data.csv" --min-count 2
+```
+
+Save the full report to a text file:
+
+```
+python analyze_crashes.py "..\2026-04-09-query_data.csv" --output "..\reports\2026-04-09-analysis.txt"
+```
+
+Combine both:
+
+```
+python analyze_crashes.py "..\2026-04-09-query_data.csv" --min-count 2 --output "..\reports\2026-04-09-analysis.txt"
+```
+
+### Output format
+
+```
+Total crash reports : 53
+Unique call stacks  : 13
+
+======================================================================
+Stack #1  (count: 32, first seen: 4/9/2026, 11:05:37.642 AM)
+======================================================================
+  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [13] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(...) at RimFileSummaryCase.cpp:121
+  ...
+```
+
+Stacks are sorted by occurrence count, highest first.

--- a/stacktrace-reports/csv/2026-04-14-query_data.csv
+++ b/stacktrace-reports/csv/2026-04-14-query_data.csv
@@ -1,0 +1,3788 @@
+timestamp,rawstack
+2026-04-13T08:14:54.995Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] __cxa_call_terminate at :0
+  [10] __gxx_personality_v0 at :0
+  [11] _Unwind_RaiseException_Phase2 at :0
+  [12] _Unwind_Resume at :0
+  [13] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:121
+  [14] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+  [15] GOMP_parallel at :0
+  [16] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:561
+  [17] RimSummaryCaseMainCollection::loadSummaryCaseData(std::vector<RimSummaryCase*, std::allocator<RimSummaryCase*> > const&, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:457
+  [18] RimSummaryCaseMainCollection::createSummaryCasesFromFileInfos(std::vector<RifSummaryCaseFileResultInfo, std::allocator<RifSummaryCaseFileResultInfo> > const&, bool, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:712
+  [19] RiaEnsembleImportTools::createSummaryCasesFromFiles(QList<QString> const&, RiaEnsembleImportTools::CreateConfig) at ResInsight/ApplicationLibCode/Application/Tools/Ensemble/RiaEnsembleImportTools.cpp:82
+  [20] RimSummaryFileSetEnsemble::createSummaryCasesFromEnsembleFileSet(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/Ensemble/RimSummaryFileSetEnsemble.cpp:168
+  [21] RimSummaryFileSetEnsemble::onLoadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/Ensemble/RimSummaryFileSetEnsemble.cpp:253
+  [22] RimEnsembleFileSetTools::createSummaryEnsemblesFromFileSets(std::vector<RimEnsembleFileSet*, std::allocator<RimEnsembleFileSet*> >) at ResInsight/ApplicationLibCode/ProjectDataModel/EnsembleFileSet/RimEnsembleFileSetTools.cpp:52
+  [23] RicImportEnsembleFeature::importSingleEnsembleFileSet(QList<QString> const&, bool, RiaDefines::EnsembleGroupingMode, RiaDefines::FileType, QString const&) at ResInsight/ApplicationLibCode/Commands/RicImportEnsembleFeature.cpp:185
+  [24] RicImportEnsembleFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/RicImportEnsembleFeature.cpp:108
+  [25] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+  [26]  at :0
+  [27] QAction::triggered(bool) at :0
+  [28] QAction::activate(QAction::ActionEvent) at :0
+  [29]  at :0
+  [30]  at :0
+  [31] QWidget::event(QEvent*) at :0
+  [32] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [33] QApplication::notify(QObject*, QEvent*) at :0
+  [34] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [35] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [36] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [37]  at :0
+  [38]  at :0
+  [39] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [40] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [41] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [42] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [43] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [44]  at :0
+  [45] g_main_context_dispatch at :0
+  [46] g_main_context_iterate.isra.20 at :0
+  [47] g_main_context_iteration at :0
+  [48] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [49] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [50]  at :0
+  [51] QMenu::exec(QPoint const&, QAction*) at :0
+  [52] RiuPlotMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp:1058
+  [53]  at :0
+  [54] QWidget::customContextMenuRequested(QPoint const&) at :0
+  [55] QWidget::event(QEvent*) at :0
+  [56] QFrame::event(QEvent*) at :0
+  [57] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [58] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [59] QApplication::notify(QObject*, QEvent*) at :0
+  [60] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [61] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [62]  at :0
+  [63]  at :0
+  [64] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [65] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [66] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [67] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [68] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [69]  at :0
+  [70] g_main_context_dispatch at :0
+  [71] g_main_context_iterate.isra.20 at :0
+  [72] g_main_context_iteration at :0
+  [73] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [74] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [75] QCoreApplication::exec() at :0
+  [76] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [77] __libc_start_main at :0
+  [78] _start at :0
+  [79]  at :0
+"
+2026-04-13T08:14:54.227Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] __cxa_call_terminate at :0
+  [10] __gxx_personality_v0 at :0
+  [11] _Unwind_RaiseException_Phase2 at :0
+  [12] _Unwind_Resume at :0
+  [13] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:121
+  [14] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+  [15] gomp_thread_start at :0
+  [16] start_thread at :0
+  [17] clone at :0
+  [18]  at :0
+"
+2026-04-13T07:26:09.516Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] __cxa_call_terminate at :0
+  [10] __gxx_personality_v0 at :0
+  [11] _Unwind_RaiseException_Phase2 at :0
+  [12] _Unwind_Resume at :0
+  [13] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:121
+  [14] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+  [15] GOMP_parallel at :0
+  [16] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:561
+  [17] RimSummaryCaseMainCollection::loadSummaryCaseData(std::vector<RimSummaryCase*, std::allocator<RimSummaryCase*> > const&, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:457
+  [18] RimSummaryCaseMainCollection::createSummaryCasesFromFileInfos(std::vector<RifSummaryCaseFileResultInfo, std::allocator<RifSummaryCaseFileResultInfo> > const&, bool, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:712
+  [19] RiaEnsembleImportTools::createSummaryCasesFromFiles(QList<QString> const&, RiaEnsembleImportTools::CreateConfig) at ResInsight/ApplicationLibCode/Application/Tools/Ensemble/RiaEnsembleImportTools.cpp:82
+  [20] RicImportSummaryCasesFeature::createAndAddSummaryCasesFromFiles(QList<QString> const&, bool) at ResInsight/ApplicationLibCode/Commands/RicImportSummaryCasesFeature.cpp:126
+  [21] RicImportGeneralDataFeature::openSummaryCaseFromFileNames(QList<QString> const&, bool) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:378
+  [22] RicImportGeneralDataFeature::openEclipseFilesFromFileNames(QList<QString> const&, bool, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:122
+  [23] RicImportGeneralDataFeature::openEclipseFilesFromFileNames(QList<QString> const&, bool, bool) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:55
+  [24] RicImportGeneralDataFeature::openFileDialog(RiaDefines::ImportFileType) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:339
+  [25] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+  [26]  at :0
+  [27] QAction::triggered(bool) at :0
+  [28] QAction::activate(QAction::ActionEvent) at :0
+  [29]  at :0
+  [30]  at :0
+  [31] QWidget::event(QEvent*) at :0
+  [32] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [33] QApplication::notify(QObject*, QEvent*) at :0
+  [34] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [35] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [36] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [37]  at :0
+  [38]  at :0
+  [39] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [40] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [41] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [42] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [43] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [44]  at :0
+  [45] g_main_context_dispatch at :0
+  [46] g_main_context_iterate.isra.20 at :0
+  [47] g_main_context_iteration at :0
+  [48] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [49] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [50] QCoreApplication::exec() at :0
+  [51] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [52] __libc_start_main at :0
+  [53] _start at :0
+  [54]  at :0
+"
+2026-04-10T13:26:29.41Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] QVariant::toDouble(bool*) const at :0
+  [4] RimCorrelationMatrixPlot::createMatrix() at ResInsight/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationMatrixPlot.cpp:555
+  [5] RimCorrelationMatrixPlot::onLoadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationMatrixPlot.cpp:377
+  [6] RimViewWindow::loadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimViewWindow.cpp:88
+  [7] RimCorrelationMatrixPlot::fieldChangedByUi(caf::PdmFieldHandle const*, QVariant const&, QVariant const&) at ResInsight/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationMatrixPlot.cpp:272
+  [8] caf::PdmUiFieldHandle::notifyFieldChanged(QVariant const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiFieldHandle.cpp:74
+  [9] caf::PdmFieldUiCap<caf::PdmField<bool> >::setValueFromUiEditor(QVariant const&, bool) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafInternalPdmUiFieldCapability.inl:110
+  [10] caf::CmdFieldChangeExec::redo() at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFieldChangeExec.cpp:139
+  [11] QUndoStack::push(QUndoCommand*) at :0
+  [12] caf::CmdUiCommandSystemImpl::fieldChangedCommand(std::vector<caf::PdmFieldHandle*, std::allocator<caf::PdmFieldHandle*> > const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdUiCommandSystemImpl.cpp:146
+  [13] caf::PdmUiCommandSystemProxy::setUiValueToField(caf::PdmUiFieldHandle*, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiCommandSystemProxy.cpp:113
+  [14] caf::PdmUiCheckBoxEditor::slotClicked(bool) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiCheckBoxEditor.cpp:127
+  [15]  at :0
+  [16] QAbstractButton::clicked(bool) at :0
+  [17]  at :0
+  [18]  at :0
+  [19] QAbstractButton::mouseReleaseEvent(QMouseEvent*) at :0
+  [20] QWidget::event(QEvent*) at :0
+  [21] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [22] QApplication::notify(QObject*, QEvent*) at :0
+  [23] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [24] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [25] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [26]  at :0
+  [27]  at :0
+  [28] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [29] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [30] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [31] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [32] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [33]  at :0
+  [34] g_main_context_dispatch at :0
+  [35] g_main_context_iterate.isra.20 at :0
+  [36] g_main_context_iteration at :0
+  [37] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [38] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [39] QCoreApplication::exec() at :0
+  [40] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [41] __libc_start_main at :0
+  [42] _start at :0
+  [43]  at :0
+"
+2026-04-10T13:22:59.604Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
+  [6] RifElementPropertyReader::readAllElementPropertiesInFileContainingField(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) at ResInsight/ApplicationLibCode/FileInterface/RifElementPropertyReader.cpp:103
+  [7] RigFemPartResultsCollection::findOrLoadScalarResult(int, RigFemResultAddress const&) at ResInsight/ApplicationLibCode/GeoMech/GeoMechDataModel/RigFemPartResultsCollection.cpp:451
+  [8] RigFemPartResultsCollection::assertResultsLoaded(RigFemResultAddress const&) at ResInsight/ApplicationLibCode/GeoMech/GeoMechDataModel/RigFemPartResultsCollection.cpp:1014
+  [9] RimGeoMechResultDefinition::hasResult() at ResInsight/ApplicationLibCode/ProjectDataModel/GeoMech/RimGeoMechResultDefinition.cpp:722
+  [10] RimGeoMechView::isTimeStepDependentDataVisible() const at ResInsight/ApplicationLibCode/ProjectDataModel/GeoMech/RimGeoMechView.cpp:838
+  [11] Rim3dView::isTimeStepDependentDataVisibleInThisOrComparisonView() const at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:603
+  [12] RiuMainWindow::refreshAnimationActions() at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:1035
+  [13] RiuMainWindow::selectedObjectsChanged() at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:1571
+  [14]  at :0
+  [15] caf::PdmUiTreeView::slotOnSelectionChanged() at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeView.cpp:154
+  [16]  at :0
+  [17]  at :0
+  [18] QItemSelectionModel::selectionChanged(QItemSelection const&, QItemSelection const&) at :0
+  [19] QItemSelectionModel::emitSelectionChanged(QItemSelection const&, QItemSelection const&) at :0
+  [20] QItemSelectionModel::select(QItemSelection const&, QFlags<QItemSelectionModel::SelectionFlag>) at :0
+  [21] QTreeViewPrivate::select(QModelIndex const&, QModelIndex const&, QFlags<QItemSelectionModel::SelectionFlag>) at :0
+  [22] QTreeView::setSelection(QRect const&, QFlags<QItemSelectionModel::SelectionFlag>) at :0
+  [23] QAbstractItemView::mousePressEvent(QMouseEvent*) at :0
+  [24] QWidget::event(QEvent*) at :0
+  [25] QFrame::event(QEvent*) at :0
+  [26] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [27] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [28] QApplication::notify(QObject*, QEvent*) at :0
+  [29] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [30] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [31] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [32]  at :0
+  [33]  at :0
+  [34] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [35] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [36] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [37] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [38] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [39]  at :0
+  [40] g_main_context_dispatch at :0
+  [41] g_main_context_iterate.isra.20 at :0
+  [42] g_main_context_iteration at :0
+  [43] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [44] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [45] QCoreApplication::exec() at :0
+  [46] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [47] __libc_start_main at :0
+  [48] _start at :0
+  [49]  at :0
+"
+2026-04-10T10:39:06.081Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
+  [6] RifElementPropertyReader::readAllElementPropertiesInFileContainingField(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) at ResInsight/ApplicationLibCode/FileInterface/RifElementPropertyReader.cpp:103
+  [7] RigFemPartResultsCollection::findOrLoadScalarResult(int, RigFemResultAddress const&) at ResInsight/ApplicationLibCode/GeoMech/GeoMechDataModel/RigFemPartResultsCollection.cpp:451
+  [8] RigFemPartResultsCollection::assertResultsLoaded(RigFemResultAddress const&) at ResInsight/ApplicationLibCode/GeoMech/GeoMechDataModel/RigFemPartResultsCollection.cpp:1014
+  [9] RimGeoMechResultDefinition::hasResult() at ResInsight/ApplicationLibCode/ProjectDataModel/GeoMech/RimGeoMechResultDefinition.cpp:722
+  [10] RimGeoMechView::isTimeStepDependentDataVisible() const at ResInsight/ApplicationLibCode/ProjectDataModel/GeoMech/RimGeoMechView.cpp:838
+  [11] Rim3dView::isTimeStepDependentDataVisibleInThisOrComparisonView() const at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:603
+  [12] RiuMainWindow::refreshAnimationActions() at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:1035
+  [13] RiuMainWindow::selectedObjectsChanged() at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:1571
+  [14]  at :0
+  [15] caf::PdmUiTreeView::slotOnSelectionChanged() at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeView.cpp:154
+  [16]  at :0
+  [17]  at :0
+  [18] QItemSelectionModel::selectionChanged(QItemSelection const&, QItemSelection const&) at :0
+  [19] QItemSelectionModel::select(QItemSelection const&, QFlags<QItemSelectionModel::SelectionFlag>) at :0
+  [20] QItemSelectionModel::select(QModelIndex const&, QFlags<QItemSelectionModel::SelectionFlag>) at :0
+  [21] QItemSelectionModel::setCurrentIndex(QModelIndex const&, QFlags<QItemSelectionModel::SelectionFlag>) at :0
+  [22] QAbstractItemView::setCurrentIndex(QModelIndex const&) at :0
+  [23] caf::PdmUiTreeViewEditor::selectAsCurrentItem(caf::PdmUiItem const*) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeViewEditor.cpp:449
+  [24] RiuMainWindowBase::selectAsCurrentItem(caf::PdmObject const*, bool) at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindowBase.cpp:273
+  [25] RiuViewerCommands::handlePickAction(int, int, QFlags<Qt::KeyboardModifier>) at ResInsight/ApplicationLibCode/UserInterface/RiuViewerCommands.cpp:807
+  [26] QWidget::event(QEvent*) at :0
+  [27] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [28] QApplication::notify(QObject*, QEvent*) at :0
+  [29] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [30] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [31] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [32]  at :0
+  [33]  at :0
+  [34] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [35] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [36] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [37] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [38] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [39]  at :0
+  [40] g_main_context_dispatch at :0
+  [41] g_main_context_iterate.isra.20 at :0
+  [42] g_main_context_iteration at :0
+  [43] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [44] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [45] RiaOpenTelemetryManager::reportCrash(int, std::basic_stacktrace<std::allocator<std::stacktrace_entry> > const&, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > const&) at ResInsight/ApplicationLibCode/Application/Tools/Telemetry/RiaOpenTelemetryManager.cpp:415
+  [46] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:174
+  [47] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [48]  at :0
+  [49] __GI_raise at :0
+  [50] __GI_abort at :0
+  [51] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
+  [52] RifElementPropertyReader::readAllElementPropertiesInFileContainingField(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) at ResInsight/ApplicationLibCode/FileInterface/RifElementPropertyReader.cpp:103
+  [53] RigFemPartResultsCollection::findOrLoadScalarResult(int, RigFemResultAddress const&) at ResInsight/ApplicationLibCode/GeoMech/GeoMechDataModel/RigFemPartResultsCollection.cpp:451
+  [54] RigFemPartResultsCollection::assertResultsLoaded(RigFemResultAddress const&) at ResInsight/ApplicationLibCode/GeoMech/GeoMechDataModel/RigFemPartResultsCollection.cpp:1014
+  [55] RimGeoMechResultDefinition::hasResult() at ResInsight/ApplicationLibCode/ProjectDataModel/GeoMech/RimGeoMechResultDefinition.cpp:722
+  [56] RiuSelectionChangedHandler::addResultCurveFromSelectionItem(RiuGeoMechSelectionItem const*) const at ResInsight/ApplicationLibCode/UserInterface/RiuSelectionChangedHandler.cpp:208
+  [57] RiuSelectionChangedHandler::handleItemAppended(RiuSelectionItem const*) const at ResInsight/ApplicationLibCode/UserInterface/RiuSelectionChangedHandler.cpp:119
+  [58] RiuCellAndNncPickEventHandler::handle3dPickEvent(Ric3dPickEvent const&) at ResInsight/ApplicationLibCode/UserInterface/RiuCellAndNncPickEventHandler.cpp:459
+  [59] RiuViewerCommands::handlePickAction(int, int, QFlags<Qt::KeyboardModifier>) at ResInsight/ApplicationLibCode/UserInterface/RiuViewerCommands.cpp:702
+  [60] QWidget::event(QEvent*) at :0
+  [61] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [62] QApplication::notify(QObject*, QEvent*) at :0
+  [63] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [64] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [65] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [66]  at :0
+  [67]  at :0
+  [68] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [69] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [70] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [71] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [72] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [73]  at :0
+  [74] g_main_context_dispatch at :0
+  [75] g_main_context_iterate.isra.20 at :0
+  [76] g_main_context_iteration at :0
+  [77] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [78] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [79] QCoreApplication::exec() at :0
+  [80] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [81] __libc_start_main at :0
+  [82] _start at :0
+  [83]  at :0
+"
+2026-04-10T10:39:05.787Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
+  [6] RifElementPropertyReader::readAllElementPropertiesInFileContainingField(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) at ResInsight/ApplicationLibCode/FileInterface/RifElementPropertyReader.cpp:103
+  [7] RigFemPartResultsCollection::findOrLoadScalarResult(int, RigFemResultAddress const&) at ResInsight/ApplicationLibCode/GeoMech/GeoMechDataModel/RigFemPartResultsCollection.cpp:451
+  [8] RigFemPartResultsCollection::assertResultsLoaded(RigFemResultAddress const&) at ResInsight/ApplicationLibCode/GeoMech/GeoMechDataModel/RigFemPartResultsCollection.cpp:1014
+  [9] RimGeoMechResultDefinition::hasResult() at ResInsight/ApplicationLibCode/ProjectDataModel/GeoMech/RimGeoMechResultDefinition.cpp:722
+  [10] RiuSelectionChangedHandler::addResultCurveFromSelectionItem(RiuGeoMechSelectionItem const*) const at ResInsight/ApplicationLibCode/UserInterface/RiuSelectionChangedHandler.cpp:208
+  [11] RiuSelectionChangedHandler::handleItemAppended(RiuSelectionItem const*) const at ResInsight/ApplicationLibCode/UserInterface/RiuSelectionChangedHandler.cpp:119
+  [12] RiuCellAndNncPickEventHandler::handle3dPickEvent(Ric3dPickEvent const&) at ResInsight/ApplicationLibCode/UserInterface/RiuCellAndNncPickEventHandler.cpp:459
+  [13] RiuViewerCommands::handlePickAction(int, int, QFlags<Qt::KeyboardModifier>) at ResInsight/ApplicationLibCode/UserInterface/RiuViewerCommands.cpp:702
+  [14] QWidget::event(QEvent*) at :0
+  [15] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [16] QApplication::notify(QObject*, QEvent*) at :0
+  [17] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [18] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [19] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [20]  at :0
+  [21]  at :0
+  [22] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [23] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [24] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [25] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [26] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [27]  at :0
+  [28] g_main_context_dispatch at :0
+  [29] g_main_context_iterate.isra.20 at :0
+  [30] g_main_context_iteration at :0
+  [31] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [32] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [33] QCoreApplication::exec() at :0
+  [34] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [35] __libc_start_main at :0
+  [36] _start at :0
+  [37]  at :0
+"
+2026-04-10T09:34:08.705Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] QWidgetPrivate::shouldPaintOnScreen() const at :0
+  [4] QWidgetRepaintManager::markNeedsFlush(QWidget*, QRegion const&, QPoint const&) at :0
+  [5] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [6] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [7] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [8] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [9] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [10] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [11] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [12] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [13] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [14] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [15] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [16] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [17] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [18] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [19] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [20] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [21] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [22] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [23] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [24] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [25] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [26] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [27] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [28] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [29] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [30] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [31] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [32] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [33] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [34] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [35] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [36] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [37] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [38] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [39] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [40] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [41] QWidgetRepaintManager::paintAndFlush() at :0
+  [42] QWidget::event(QEvent*) at :0
+  [43] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [44] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [45] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [46] QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*) at :0
+  [47]  at :0
+  [48] g_main_context_dispatch at :0
+  [49] g_main_context_iterate.isra.20 at :0
+  [50] g_main_context_iteration at :0
+  [51] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [52] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [53] QCoreApplication::exec() at :0
+  [54] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [55] __libc_start_main at :0
+  [56] _start at :0
+  [57]  at :0
+"
+2026-04-10T05:51:17.438Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI___poll at :0
+  [4] g_main_context_iterate.isra.20 at :0
+  [5] g_main_context_iteration at :0
+  [6] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [7] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [8] QCoreApplication::exec() at :0
+  [9] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [10] __libc_start_main at :0
+  [11] _start at :0
+  [12]  at :0
+"
+2026-04-09T16:57:31.451Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] std::terminate() at :0
+  [10] __cxa_rethrow at :0
+  [11] main at ResInsight/ApplicationExeCode/RiaMain.cpp:232
+  [12] __libc_start_main at :0
+  [13] _start at :0
+  [14]  at :0
+"
+2026-04-09T12:23:12.993Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] RifHdf5Exporter::RifHdf5Exporter(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) at ResInsight/ApplicationLibCode/FileInterface/RifHdf5Exporter.cpp:34
+  [4] RifHdf5SummaryExporter::ensureHdf5FileIsCreated(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool, unsigned long&) at ResInsight/ApplicationLibCode/FileInterface/RifHdf5SummaryExporter.cpp:139
+  [5] RifReaderEclipseSummary::open(QString const&, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseSummary.cpp:107
+  [6] RimFileSummaryCase::findRelatedFilesAndCreateReader(QString const&, bool, RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:238
+  [7] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:110
+  [8] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] clone at :0
+  [12]  at :0
+"
+2026-04-09T12:12:32.84Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] RifHdf5Exporter::RifHdf5Exporter(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) at ResInsight/ApplicationLibCode/FileInterface/RifHdf5Exporter.cpp:34
+  [4] RifHdf5SummaryExporter::ensureHdf5FileIsCreated(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool, unsigned long&) at ResInsight/ApplicationLibCode/FileInterface/RifHdf5SummaryExporter.cpp:139
+  [5] RifReaderEclipseSummary::open(QString const&, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseSummary.cpp:107
+  [6] RimFileSummaryCase::findRelatedFilesAndCreateReader(QString const&, bool, RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:238
+  [7] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:110
+  [8] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] clone at :0
+  [12]  at :0
+"
+2026-04-09T12:10:24.492Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] RifHdf5Exporter::RifHdf5Exporter(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) at ResInsight/ApplicationLibCode/FileInterface/RifHdf5Exporter.cpp:34
+  [4] RifHdf5SummaryExporter::ensureHdf5FileIsCreated(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool, unsigned long&) at ResInsight/ApplicationLibCode/FileInterface/RifHdf5SummaryExporter.cpp:139
+  [5] RifReaderEclipseSummary::open(QString const&, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseSummary.cpp:107
+  [6] RimFileSummaryCase::findRelatedFilesAndCreateReader(QString const&, bool, RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:238
+  [7] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:110
+  [8] RimFileSummaryCase::createSummaryReaderInterface() at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:129
+  [9] RiaSummaryTools::reloadSummaryCaseAndUpdateConnectedPlots(RimSummaryCase*) at ResInsight/ApplicationLibCode/Application/Tools/Summary/RiaSummaryTools.cpp:409
+  [10] RimReloadCaseTools::reloadEclipseData(RimEclipseCase*, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimReloadCaseTools.cpp:102
+  [11] RicReloadCaseFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/RicReloadCaseFeature.cpp:62
+  [12] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+  [13]  at :0
+  [14] QAction::triggered(bool) at :0
+  [15] QAction::activate(QAction::ActionEvent) at :0
+  [16]  at :0
+  [17]  at :0
+  [18] QWidget::event(QEvent*) at :0
+  [19] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [20] QApplication::notify(QObject*, QEvent*) at :0
+  [21] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [22] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [23] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [24]  at :0
+  [25]  at :0
+  [26] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [27] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [28] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [29] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [30] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [31]  at :0
+  [32] g_main_context_dispatch at :0
+  [33] g_main_context_iterate.isra.20 at :0
+  [34] g_main_context_iteration at :0
+  [35] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [36] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [37]  at :0
+  [38] QMenu::exec(QPoint const&, QAction*) at :0
+  [39] RiuMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:2056
+  [40]  at :0
+  [41] QWidget::customContextMenuRequested(QPoint const&) at :0
+  [42] QWidget::event(QEvent*) at :0
+  [43] QFrame::event(QEvent*) at :0
+  [44] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [45] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [46] QApplication::notify(QObject*, QEvent*) at :0
+  [47] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [48] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [49]  at :0
+  [50]  at :0
+  [51] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [52] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [53] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [54] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [55] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [56]  at :0
+  [57] g_main_context_dispatch at :0
+  [58] g_main_context_iterate.isra.20 at :0
+  [59] g_main_context_iteration at :0
+  [60] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [61] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [62] QCoreApplication::exec() at :0
+  [63] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [64] __libc_start_main at :0
+  [65] _start at :0
+  [66]  at :0
+"
+2026-04-09T12:06:55.492Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] RifHdf5Exporter::RifHdf5Exporter(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) at ResInsight/ApplicationLibCode/FileInterface/RifHdf5Exporter.cpp:34
+  [4] RifHdf5SummaryExporter::ensureHdf5FileIsCreated(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool, unsigned long&) at ResInsight/ApplicationLibCode/FileInterface/RifHdf5SummaryExporter.cpp:139
+  [5] RifReaderEclipseSummary::open(QString const&, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseSummary.cpp:107
+  [6] RimFileSummaryCase::findRelatedFilesAndCreateReader(QString const&, bool, RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:238
+  [7] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:110
+  [8] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] clone at :0
+  [12]  at :0
+"
+2026-04-09T12:06:09.707Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] RifHdf5Exporter::RifHdf5Exporter(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) at ResInsight/ApplicationLibCode/FileInterface/RifHdf5Exporter.cpp:34
+  [4] RifHdf5SummaryExporter::ensureHdf5FileIsCreated(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool, unsigned long&) at ResInsight/ApplicationLibCode/FileInterface/RifHdf5SummaryExporter.cpp:139
+  [5] RifReaderEclipseSummary::open(QString const&, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseSummary.cpp:107
+  [6] RimFileSummaryCase::findRelatedFilesAndCreateReader(QString const&, bool, RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:238
+  [7] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:110
+  [8] RimFileSummaryCase::createSummaryReaderInterface() at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:129
+  [9] RiaSummaryTools::reloadSummaryCaseAndUpdateConnectedPlots(RimSummaryCase*) at ResInsight/ApplicationLibCode/Application/Tools/Summary/RiaSummaryTools.cpp:409
+  [10] RimReloadCaseTools::reloadEclipseData(RimEclipseCase*, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimReloadCaseTools.cpp:102
+  [11] RicReloadCaseFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/RicReloadCaseFeature.cpp:62
+  [12] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+  [13]  at :0
+  [14] QAction::triggered(bool) at :0
+  [15] QAction::activate(QAction::ActionEvent) at :0
+  [16]  at :0
+  [17]  at :0
+  [18] QWidget::event(QEvent*) at :0
+  [19] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [20] QApplication::notify(QObject*, QEvent*) at :0
+  [21] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [22] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [23] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [24]  at :0
+  [25]  at :0
+  [26] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [27] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [28] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [29] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [30] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [31]  at :0
+  [32] g_main_context_dispatch at :0
+  [33] g_main_context_iterate.isra.20 at :0
+  [34] g_main_context_iteration at :0
+  [35] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [36] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [37]  at :0
+  [38] QMenu::exec(QPoint const&, QAction*) at :0
+  [39] RiuMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:2056
+  [40]  at :0
+  [41] QWidget::customContextMenuRequested(QPoint const&) at :0
+  [42] QWidget::event(QEvent*) at :0
+  [43] QFrame::event(QEvent*) at :0
+  [44] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [45] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [46] QApplication::notify(QObject*, QEvent*) at :0
+  [47] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [48] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [49]  at :0
+  [50]  at :0
+  [51] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [52] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [53] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [54] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [55] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [56]  at :0
+  [57] g_main_context_dispatch at :0
+  [58] g_main_context_iterate.isra.20 at :0
+  [59] g_main_context_iteration at :0
+  [60] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [61] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [62] QCoreApplication::exec() at :0
+  [63] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [64] __libc_start_main at :0
+  [65] _start at :0
+  [66]  at :0
+"
+2026-04-09T11:05:37.642Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] __cxa_call_terminate at :0
+  [10] __gxx_personality_v0 at :0
+  [11] _Unwind_RaiseException_Phase2 at :0
+  [12] _Unwind_Resume at :0
+  [13] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:121
+  [14] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+  [15] GOMP_parallel at :0
+  [16] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:561
+  [17] RimSummaryCaseMainCollection::loadSummaryCaseData(std::vector<RimSummaryCase*, std::allocator<RimSummaryCase*> > const&, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:457
+  [18] RimSummaryCaseMainCollection::createSummaryCasesFromFileInfos(std::vector<RifSummaryCaseFileResultInfo, std::allocator<RifSummaryCaseFileResultInfo> > const&, bool, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:712
+  [19] RiaEnsembleImportTools::createSummaryCasesFromFiles(QList<QString> const&, RiaEnsembleImportTools::CreateConfig) at ResInsight/ApplicationLibCode/Application/Tools/Ensemble/RiaEnsembleImportTools.cpp:82
+  [20] RicImportSummaryCasesFeature::createAndAddSummaryCasesFromFiles(QList<QString> const&, bool) at ResInsight/ApplicationLibCode/Commands/RicImportSummaryCasesFeature.cpp:126
+  [21] RicImportGeneralDataFeature::openSummaryCaseFromFileNames(QList<QString> const&, bool) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:378
+  [22] RicImportGeneralDataFeature::openEclipseFilesFromFileNames(QList<QString> const&, bool, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:122
+  [23] RicImportGeneralDataFeature::openEclipseFilesFromFileNames(QList<QString> const&, bool, bool) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:55
+  [24] RiaApplication::openFile(QString const&) at ResInsight/ApplicationLibCode/Application/RiaApplication.cpp:421
+  [25] RiuRecentFileActionProvider::slotOpenRecentFile() at ResInsight/ApplicationLibCode/UserInterface/RiuRecentFileActionProvider.cpp:134
+  [26]  at :0
+  [27] QAction::triggered(bool) at :0
+  [28] QAction::activate(QAction::ActionEvent) at :0
+  [29]  at :0
+  [30]  at :0
+  [31] QWidget::event(QEvent*) at :0
+  [32] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [33] QApplication::notify(QObject*, QEvent*) at :0
+  [34] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [35] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [36] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [37]  at :0
+  [38]  at :0
+  [39] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [40] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [41] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [42] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [43] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [44]  at :0
+  [45] g_main_context_dispatch at :0
+  [46] g_main_context_iterate.isra.20 at :0
+  [47] g_main_context_iteration at :0
+  [48] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [49] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [50] QCoreApplication::exec() at :0
+  [51] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [52] __libc_start_main at :0
+  [53] _start at :0
+  [54]  at :0
+"
+2026-04-09T11:01:39.887Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] __cxa_call_terminate at :0
+  [10] __gxx_personality_v0 at :0
+  [11] _Unwind_RaiseException_Phase2 at :0
+  [12] _Unwind_Resume at :0
+  [13] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:121
+  [14] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+  [15] GOMP_parallel at :0
+  [16] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:561
+  [17] RimSummaryCaseMainCollection::loadSummaryCaseData(std::vector<RimSummaryCase*, std::allocator<RimSummaryCase*> > const&, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:457
+  [18] RimSummaryCaseMainCollection::createSummaryCasesFromFileInfos(std::vector<RifSummaryCaseFileResultInfo, std::allocator<RifSummaryCaseFileResultInfo> > const&, bool, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:712
+  [19] RiaEnsembleImportTools::createSummaryCasesFromFiles(QList<QString> const&, RiaEnsembleImportTools::CreateConfig) at ResInsight/ApplicationLibCode/Application/Tools/Ensemble/RiaEnsembleImportTools.cpp:82
+  [20] RicImportSummaryCasesFeature::createAndAddSummaryCasesFromFiles(QList<QString> const&, bool) at ResInsight/ApplicationLibCode/Commands/RicImportSummaryCasesFeature.cpp:126
+  [21] RicImportGeneralDataFeature::openSummaryCaseFromFileNames(QList<QString> const&, bool) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:378
+  [22] RicImportGeneralDataFeature::openEclipseFilesFromFileNames(QList<QString> const&, bool, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:122
+  [23] RicImportGeneralDataFeature::openEclipseFilesFromFileNames(QList<QString> const&, bool, bool) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:55
+  [24] RiaApplication::openFile(QString const&) at ResInsight/ApplicationLibCode/Application/RiaApplication.cpp:421
+  [25] RiuRecentFileActionProvider::slotOpenRecentFile() at ResInsight/ApplicationLibCode/UserInterface/RiuRecentFileActionProvider.cpp:134
+  [26]  at :0
+  [27] QAction::triggered(bool) at :0
+  [28] QAction::activate(QAction::ActionEvent) at :0
+  [29]  at :0
+  [30]  at :0
+  [31] QWidget::event(QEvent*) at :0
+  [32] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [33] QApplication::notify(QObject*, QEvent*) at :0
+  [34] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [35] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [36] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [37]  at :0
+  [38]  at :0
+  [39] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [40] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [41] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [42] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [43] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [44]  at :0
+  [45] g_main_context_dispatch at :0
+  [46] g_main_context_iterate.isra.20 at :0
+  [47] g_main_context_iteration at :0
+  [48] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [49] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [50] QCoreApplication::exec() at :0
+  [51] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [52] __libc_start_main at :0
+  [53] _start at :0
+  [54]  at :0
+"
+2026-04-09T11:01:21.542Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] __cxa_call_terminate at :0
+  [10] __gxx_personality_v0 at :0
+  [11] _Unwind_RaiseException_Phase2 at :0
+  [12] _Unwind_Resume at :0
+  [13] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:121
+  [14] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+  [15] gomp_thread_start at :0
+  [16] start_thread at :0
+  [17] clone at :0
+  [18]  at :0
+"
+2026-04-09T11:00:29.193Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] __cxa_call_terminate at :0
+  [10] __gxx_personality_v0 at :0
+  [11] _Unwind_RaiseException_Phase2 at :0
+  [12] _Unwind_Resume at :0
+  [13] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:121
+  [14] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+  [15] gomp_thread_start at :0
+  [16] start_thread at :0
+  [17] clone at :0
+  [18]  at :0
+"
+2026-04-09T11:00:28.928Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] __cxa_call_terminate at :0
+  [10] __gxx_personality_v0 at :0
+  [11] _Unwind_RaiseException_Phase2 at :0
+  [12] _Unwind_Resume at :0
+  [13] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:121
+  [14] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+  [15] gomp_thread_start at :0
+  [16] start_thread at :0
+  [17] clone at :0
+  [18]  at :0
+"
+2026-04-09T11:00:28.752Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] __cxa_call_terminate at :0
+  [10] __gxx_personality_v0 at :0
+  [11] _Unwind_RaiseException_Phase2 at :0
+  [12] _Unwind_Resume at :0
+  [13] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:121
+  [14] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+  [15] gomp_thread_start at :0
+  [16] start_thread at :0
+  [17] clone at :0
+  [18]  at :0
+"
+2026-04-09T11:00:28.7Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] __cxa_call_terminate at :0
+  [10] __gxx_personality_v0 at :0
+  [11] _Unwind_RaiseException_Phase2 at :0
+  [12] _Unwind_Resume at :0
+  [13] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:121
+  [14] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+  [15] gomp_thread_start at :0
+  [16] start_thread at :0
+  [17] clone at :0
+  [18]  at :0
+"
+2026-04-09T10:46:42.961Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] __cxa_call_terminate at :0
+  [10] __gxx_personality_v0 at :0
+  [11] _Unwind_RaiseException_Phase2 at :0
+  [12] _Unwind_Resume at :0
+  [13] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:121
+  [14] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+  [15] gomp_thread_start at :0
+  [16] start_thread at :0
+  [17] clone at :0
+  [18]  at :0
+"
+2026-04-09T10:46:42.894Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] __cxa_call_terminate at :0
+  [10] __gxx_personality_v0 at :0
+  [11] _Unwind_RaiseException_Phase2 at :0
+  [12] _Unwind_Resume at :0
+  [13] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:121
+  [14] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+  [15] GOMP_parallel at :0
+  [16] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:561
+  [17] RimSummaryCaseMainCollection::loadSummaryCaseData(std::vector<RimSummaryCase*, std::allocator<RimSummaryCase*> > const&, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:457
+  [18] RimSummaryCaseMainCollection::createSummaryCasesFromFileInfos(std::vector<RifSummaryCaseFileResultInfo, std::allocator<RifSummaryCaseFileResultInfo> > const&, bool, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:712
+  [19] RiaEnsembleImportTools::createSummaryCasesFromFiles(QList<QString> const&, RiaEnsembleImportTools::CreateConfig) at ResInsight/ApplicationLibCode/Application/Tools/Ensemble/RiaEnsembleImportTools.cpp:82
+  [20] RimSummaryFileSetEnsemble::createSummaryCasesFromEnsembleFileSet(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/Ensemble/RimSummaryFileSetEnsemble.cpp:168
+  [21] RimSummaryFileSetEnsemble::onLoadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/Ensemble/RimSummaryFileSetEnsemble.cpp:253
+  [22] RimEnsembleFileSetTools::createSummaryEnsemblesFromFileSets(std::vector<RimEnsembleFileSet*, std::allocator<RimEnsembleFileSet*> >) at ResInsight/ApplicationLibCode/ProjectDataModel/EnsembleFileSet/RimEnsembleFileSetTools.cpp:52
+  [23] RicImportEnsembleFeature::importSingleEnsembleFileSet(QList<QString> const&, bool, RiaDefines::EnsembleGroupingMode, RiaDefines::FileType, QString const&) at ResInsight/ApplicationLibCode/Commands/RicImportEnsembleFeature.cpp:185
+  [24] RicImportEnsembleFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/RicImportEnsembleFeature.cpp:108
+  [25] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+  [26]  at :0
+  [27] QAction::triggered(bool) at :0
+  [28] QAction::activate(QAction::ActionEvent) at :0
+  [29]  at :0
+  [30]  at :0
+  [31] QWidget::event(QEvent*) at :0
+  [32] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [33] QApplication::notify(QObject*, QEvent*) at :0
+  [34] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [35] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [36] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [37]  at :0
+  [38]  at :0
+  [39] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [40] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [41] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [42] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [43] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [44]  at :0
+  [45] g_main_context_dispatch at :0
+  [46] g_main_context_iterate.isra.20 at :0
+  [47] g_main_context_iteration at :0
+  [48] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [49] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [50] QCoreApplication::exec() at :0
+  [51] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [52] __libc_start_main at :0
+  [53] _start at :0
+  [54]  at :0
+"
+2026-04-09T10:46:42.775Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] __cxa_call_terminate at :0
+  [10] __gxx_personality_v0 at :0
+  [11] _Unwind_RaiseException_Phase2 at :0
+  [12] _Unwind_Resume at :0
+  [13] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:121
+  [14] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+  [15] gomp_thread_start at :0
+  [16] start_thread at :0
+  [17] clone at :0
+  [18]  at :0
+"
+2026-04-09T10:46:42.595Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] __cxa_call_terminate at :0
+  [10] __gxx_personality_v0 at :0
+  [11] _Unwind_RaiseException_Phase2 at :0
+  [12] _Unwind_Resume at :0
+  [13] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:121
+  [14] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+  [15] gomp_thread_start at :0
+  [16] start_thread at :0
+  [17] clone at :0
+  [18]  at :0
+"
+2026-04-09T10:46:42.401Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] __cxa_call_terminate at :0
+  [10] __gxx_personality_v0 at :0
+  [11] _Unwind_RaiseException_Phase2 at :0
+  [12] _Unwind_Resume at :0
+  [13] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:121
+  [14] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+  [15] gomp_thread_start at :0
+  [16] start_thread at :0
+  [17] clone at :0
+  [18]  at :0
+"
+2026-04-09T10:46:42.401Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] __cxa_call_terminate at :0
+  [10] __gxx_personality_v0 at :0
+  [11] _Unwind_RaiseException_Phase2 at :0
+  [12] _Unwind_Resume at :0
+  [13] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:121
+  [14] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+  [15] gomp_thread_start at :0
+  [16] start_thread at :0
+  [17] clone at :0
+  [18]  at :0
+"
+2026-04-09T10:43:18.121Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] __cxa_call_terminate at :0
+  [10] __gxx_personality_v0 at :0
+  [11] _Unwind_RaiseException_Phase2 at :0
+  [12] _Unwind_Resume at :0
+  [13] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:121
+  [14] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+  [15] GOMP_parallel at :0
+  [16] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:561
+  [17] RimSummaryCaseMainCollection::loadSummaryCaseData(std::vector<RimSummaryCase*, std::allocator<RimSummaryCase*> > const&, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:457
+  [18] RimSummaryCaseMainCollection::createSummaryCasesFromFileInfos(std::vector<RifSummaryCaseFileResultInfo, std::allocator<RifSummaryCaseFileResultInfo> > const&, bool, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:712
+  [19] RiaEnsembleImportTools::createSummaryCasesFromFiles(QList<QString> const&, RiaEnsembleImportTools::CreateConfig) at ResInsight/ApplicationLibCode/Application/Tools/Ensemble/RiaEnsembleImportTools.cpp:82
+  [20] RimSummaryFileSetEnsemble::createSummaryCasesFromEnsembleFileSet(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/Ensemble/RimSummaryFileSetEnsemble.cpp:168
+  [21] RimSummaryFileSetEnsemble::onLoadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/Ensemble/RimSummaryFileSetEnsemble.cpp:253
+  [22] RimEnsembleFileSetTools::createSummaryEnsemblesFromFileSets(std::vector<RimEnsembleFileSet*, std::allocator<RimEnsembleFileSet*> >) at ResInsight/ApplicationLibCode/ProjectDataModel/EnsembleFileSet/RimEnsembleFileSetTools.cpp:52
+  [23] RicImportEnsembleFeature::importSingleEnsembleFileSet(QList<QString> const&, bool, RiaDefines::EnsembleGroupingMode, RiaDefines::FileType, QString const&) at ResInsight/ApplicationLibCode/Commands/RicImportEnsembleFeature.cpp:185
+  [24] RicImportEnsembleFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/RicImportEnsembleFeature.cpp:108
+  [25] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+  [26]  at :0
+  [27] QAction::triggered(bool) at :0
+  [28] QAction::activate(QAction::ActionEvent) at :0
+  [29]  at :0
+  [30]  at :0
+  [31] QWidget::event(QEvent*) at :0
+  [32] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [33] QApplication::notify(QObject*, QEvent*) at :0
+  [34] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [35] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [36] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [37]  at :0
+  [38]  at :0
+  [39] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [40] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [41] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [42] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [43] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [44]  at :0
+  [45] g_main_context_dispatch at :0
+  [46] g_main_context_iterate.isra.20 at :0
+  [47] g_main_context_iteration at :0
+  [48] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [49] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [50]  at :0
+  [51] QMenu::exec(QPoint const&, QAction*) at :0
+  [52] RiuPlotMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp:1058
+  [53]  at :0
+  [54] QWidget::customContextMenuRequested(QPoint const&) at :0
+  [55] QWidget::event(QEvent*) at :0
+  [56] QFrame::event(QEvent*) at :0
+  [57] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [58] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [59] QApplication::notify(QObject*, QEvent*) at :0
+  [60] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [61] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [62]  at :0
+  [63]  at :0
+  [64] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [65] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [66] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [67] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [68] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [69]  at :0
+  [70] g_main_context_dispatch at :0
+  [71] g_main_context_iterate.isra.20 at :0
+  [72] g_main_context_iteration at :0
+  [73] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [74] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [75] QCoreApplication::exec() at :0
+  [76] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [77] __libc_start_main at :0
+  [78] _start at :0
+  [79]  at :0
+"
+2026-04-09T10:43:18.051Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] __cxa_call_terminate at :0
+  [10] __gxx_personality_v0 at :0
+  [11] _Unwind_RaiseException_Phase2 at :0
+  [12] _Unwind_Resume at :0
+  [13] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:121
+  [14] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+  [15] gomp_thread_start at :0
+  [16] start_thread at :0
+  [17] clone at :0
+  [18]  at :0
+"
+2026-04-09T10:43:17.75Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] __cxa_call_terminate at :0
+  [10] __gxx_personality_v0 at :0
+  [11] _Unwind_RaiseException_Phase2 at :0
+  [12] _Unwind_Resume at :0
+  [13] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:121
+  [14] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+  [15] gomp_thread_start at :0
+  [16] start_thread at :0
+  [17] clone at :0
+  [18]  at :0
+"
+2026-04-09T10:41:07.011Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] __cxa_call_terminate at :0
+  [10] __gxx_personality_v0 at :0
+  [11] _Unwind_RaiseException_Phase2 at :0
+  [12] _Unwind_Resume at :0
+  [13] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:121
+  [14] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+  [15] gomp_thread_start at :0
+  [16] start_thread at :0
+  [17] clone at :0
+  [18]  at :0
+"
+2026-04-09T10:41:06.845Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] __cxa_call_terminate at :0
+  [10] __gxx_personality_v0 at :0
+  [11] _Unwind_RaiseException_Phase2 at :0
+  [12] _Unwind_Resume at :0
+  [13] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:121
+  [14] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+  [15] gomp_thread_start at :0
+  [16] start_thread at :0
+  [17] clone at :0
+  [18]  at :0
+"
+2026-04-09T10:41:06.75Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] __cxa_call_terminate at :0
+  [10] __gxx_personality_v0 at :0
+  [11] _Unwind_RaiseException_Phase2 at :0
+  [12] _Unwind_Resume at :0
+  [13] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:121
+  [14] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+  [15] gomp_thread_start at :0
+  [16] start_thread at :0
+  [17] clone at :0
+  [18]  at :0
+"
+2026-04-09T10:40:03.962Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] __cxa_call_terminate at :0
+  [10] __gxx_personality_v0 at :0
+  [11] _Unwind_RaiseException_Phase2 at :0
+  [12] _Unwind_Resume at :0
+  [13] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:121
+  [14] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+  [15] gomp_thread_start at :0
+  [16] start_thread at :0
+  [17] clone at :0
+  [18]  at :0
+"
+2026-04-09T10:40:03.792Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] __cxa_call_terminate at :0
+  [10] __gxx_personality_v0 at :0
+  [11] _Unwind_RaiseException_Phase2 at :0
+  [12] _Unwind_Resume at :0
+  [13] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:121
+  [14] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+  [15] gomp_thread_start at :0
+  [16] start_thread at :0
+  [17] clone at :0
+  [18]  at :0
+"
+2026-04-09T10:40:03.62Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] __cxa_call_terminate at :0
+  [10] __gxx_personality_v0 at :0
+  [11] _Unwind_RaiseException_Phase2 at :0
+  [12] _Unwind_Resume at :0
+  [13] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:121
+  [14] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+  [15] gomp_thread_start at :0
+  [16] start_thread at :0
+  [17] clone at :0
+  [18]  at :0
+"
+2026-04-09T10:40:03.456Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] __cxa_call_terminate at :0
+  [10] __gxx_personality_v0 at :0
+  [11] _Unwind_RaiseException_Phase2 at :0
+  [12] _Unwind_Resume at :0
+  [13] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:121
+  [14] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+  [15] gomp_thread_start at :0
+  [16] start_thread at :0
+  [17] clone at :0
+  [18]  at :0
+"
+2026-04-09T10:40:03.281Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] __cxa_call_terminate at :0
+  [10] __gxx_personality_v0 at :0
+  [11] _Unwind_RaiseException_Phase2 at :0
+  [12] _Unwind_Resume at :0
+  [13] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:121
+  [14] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+  [15] gomp_thread_start at :0
+  [16] start_thread at :0
+  [17] clone at :0
+  [18]  at :0
+"
+2026-04-09T10:40:03.185Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] __cxa_call_terminate at :0
+  [10] __gxx_personality_v0 at :0
+  [11] _Unwind_RaiseException_Phase2 at :0
+  [12] _Unwind_Resume at :0
+  [13] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:121
+  [14] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+  [15] gomp_thread_start at :0
+  [16] start_thread at :0
+  [17] clone at :0
+  [18]  at :0
+"
+2026-04-09T10:38:58.888Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] __cxa_call_terminate at :0
+  [10] __gxx_personality_v0 at :0
+  [11] _Unwind_RaiseException_Phase2 at :0
+  [12] _Unwind_Resume at :0
+  [13] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:121
+  [14] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+  [15] gomp_thread_start at :0
+  [16] start_thread at :0
+  [17] clone at :0
+  [18]  at :0
+"
+2026-04-09T10:38:58.719Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] __cxa_call_terminate at :0
+  [10] __gxx_personality_v0 at :0
+  [11] _Unwind_RaiseException_Phase2 at :0
+  [12] _Unwind_Resume at :0
+  [13] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:121
+  [14] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+  [15] gomp_thread_start at :0
+  [16] start_thread at :0
+  [17] clone at :0
+  [18]  at :0
+"
+2026-04-09T10:38:58.551Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] __cxa_call_terminate at :0
+  [10] __gxx_personality_v0 at :0
+  [11] _Unwind_RaiseException_Phase2 at :0
+  [12] _Unwind_Resume at :0
+  [13] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:121
+  [14] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+  [15] gomp_thread_start at :0
+  [16] start_thread at :0
+  [17] clone at :0
+  [18]  at :0
+"
+2026-04-09T10:38:58.38Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] __cxa_call_terminate at :0
+  [10] __gxx_personality_v0 at :0
+  [11] _Unwind_RaiseException_Phase2 at :0
+  [12] _Unwind_Resume at :0
+  [13] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:121
+  [14] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+  [15] gomp_thread_start at :0
+  [16] start_thread at :0
+  [17] clone at :0
+  [18]  at :0
+"
+2026-04-09T10:38:58.207Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] __cxa_call_terminate at :0
+  [10] __gxx_personality_v0 at :0
+  [11] _Unwind_RaiseException_Phase2 at :0
+  [12] _Unwind_Resume at :0
+  [13] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:121
+  [14] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+  [15] gomp_thread_start at :0
+  [16] start_thread at :0
+  [17] clone at :0
+  [18]  at :0
+"
+2026-04-09T10:38:58.114Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] __cxa_call_terminate at :0
+  [10] __gxx_personality_v0 at :0
+  [11] _Unwind_RaiseException_Phase2 at :0
+  [12] _Unwind_Resume at :0
+  [13] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:121
+  [14] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+  [15] gomp_thread_start at :0
+  [16] start_thread at :0
+  [17] clone at :0
+  [18]  at :0
+"
+2026-04-09T10:37:57.767Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] __cxa_call_terminate at :0
+  [10] __gxx_personality_v0 at :0
+  [11] _Unwind_RaiseException_Phase2 at :0
+  [12] _Unwind_Resume at :0
+  [13] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:121
+  [14] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+  [15] GOMP_parallel at :0
+  [16] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:561
+  [17] RimSummaryCaseMainCollection::loadSummaryCaseData(std::vector<RimSummaryCase*, std::allocator<RimSummaryCase*> > const&, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:457
+  [18] RimSummaryCaseMainCollection::createSummaryCasesFromFileInfos(std::vector<RifSummaryCaseFileResultInfo, std::allocator<RifSummaryCaseFileResultInfo> > const&, bool, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:712
+  [19] RiaEnsembleImportTools::createSummaryCasesFromFiles(QList<QString> const&, RiaEnsembleImportTools::CreateConfig) at ResInsight/ApplicationLibCode/Application/Tools/Ensemble/RiaEnsembleImportTools.cpp:82
+  [20] RimSummaryFileSetEnsemble::createSummaryCasesFromEnsembleFileSet(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/Ensemble/RimSummaryFileSetEnsemble.cpp:168
+  [21] RimSummaryFileSetEnsemble::onFileSetChanged(caf::SignalEmitter const*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/Ensemble/RimSummaryFileSetEnsemble.cpp:134
+  [22] std::function<void (caf::SignalEmitter const*)>::operator()(caf::SignalEmitter const*) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:591
+  [23] RicReloadSummaryCaseFeature::reloadSelectedCasesAndUpdate() at ResInsight/ApplicationLibCode/Commands/RicReloadSummaryCaseFeature.cpp:142
+  [24] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+  [25]  at :0
+  [26] QAction::triggered(bool) at :0
+  [27] QAction::activate(QAction::ActionEvent) at :0
+  [28]  at :0
+  [29]  at :0
+  [30] QWidget::event(QEvent*) at :0
+  [31] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [32] QApplication::notify(QObject*, QEvent*) at :0
+  [33] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [34] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [35] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [36]  at :0
+  [37]  at :0
+  [38] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [39] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [40] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [41] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [42] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [43]  at :0
+  [44] g_main_context_dispatch at :0
+  [45] g_main_context_iterate.isra.20 at :0
+  [46] g_main_context_iteration at :0
+  [47] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [48] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [49]  at :0
+  [50] QMenu::exec(QPoint const&, QAction*) at :0
+  [51] RiuPlotMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp:1058
+  [52]  at :0
+  [53] QWidget::customContextMenuRequested(QPoint const&) at :0
+  [54] QWidget::event(QEvent*) at :0
+  [55] QFrame::event(QEvent*) at :0
+  [56] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [57] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [58] QApplication::notify(QObject*, QEvent*) at :0
+  [59] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [60] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [61]  at :0
+  [62]  at :0
+  [63] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [64] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [65] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [66] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [67] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [68]  at :0
+  [69] g_main_context_dispatch at :0
+  [70] g_main_context_iterate.isra.20 at :0
+  [71] g_main_context_iteration at :0
+  [72] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [73] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [74] QCoreApplication::exec() at :0
+  [75] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [76] __libc_start_main at :0
+  [77] _start at :0
+  [78]  at :0
+"
+2026-04-09T10:37:57.45Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] __cxa_call_terminate at :0
+  [10] __gxx_personality_v0 at :0
+  [11] _Unwind_RaiseException_Phase2 at :0
+  [12] _Unwind_Resume at :0
+  [13] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:121
+  [14] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+  [15] gomp_thread_start at :0
+  [16] start_thread at :0
+  [17] clone at :0
+  [18]  at :0
+"
+2026-04-09T10:37:57.066Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] __cxa_call_terminate at :0
+  [10] __gxx_personality_v0 at :0
+  [11] _Unwind_RaiseException_Phase2 at :0
+  [12] _Unwind_Resume at :0
+  [13] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:121
+  [14] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+  [15] gomp_thread_start at :0
+  [16] start_thread at :0
+  [17] clone at :0
+  [18]  at :0
+"
+2026-04-09T10:37:56.969Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] __cxa_call_terminate at :0
+  [10] __gxx_personality_v0 at :0
+  [11] _Unwind_RaiseException_Phase2 at :0
+  [12] _Unwind_Resume at :0
+  [13] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:121
+  [14] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+  [15] gomp_thread_start at :0
+  [16] start_thread at :0
+  [17] clone at :0
+  [18]  at :0
+"
+2026-04-09T10:37:56.909Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] __cxa_call_terminate at :0
+  [10] __gxx_personality_v0 at :0
+  [11] _Unwind_RaiseException_Phase2 at :0
+  [12] _Unwind_Resume at :0
+  [13] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:121
+  [14] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+  [15] gomp_thread_start at :0
+  [16] start_thread at :0
+  [17] clone at :0
+  [18]  at :0
+"
+2026-04-09T10:37:56.909Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] __cxa_call_terminate at :0
+  [10] __gxx_personality_v0 at :0
+  [11] _Unwind_RaiseException_Phase2 at :0
+  [12] _Unwind_Resume at :0
+  [13] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:121
+  [14] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+  [15] gomp_thread_start at :0
+  [16] start_thread at :0
+  [17] clone at :0
+  [18]  at :0
+"
+2026-04-09T10:29:18.564Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
+  [6] RimViewLinker::addDependentView(Rim3dView*) at ResInsight/ApplicationLibCode/ProjectDataModel/RimViewLinker.cpp:623
+  [7] RicSetMasterViewFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/ViewLink/RicSetMasterViewFeature.cpp:75
+  [8] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+  [9]  at :0
+  [10] QAction::triggered(bool) at :0
+  [11] QAction::activate(QAction::ActionEvent) at :0
+  [12]  at :0
+  [13]  at :0
+  [14] QWidget::event(QEvent*) at :0
+  [15] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [16] QApplication::notify(QObject*, QEvent*) at :0
+  [17] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [18] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [19] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [20]  at :0
+  [21]  at :0
+  [22] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [23] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [24] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [25] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [26] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [27]  at :0
+  [28] g_main_context_dispatch at :0
+  [29] g_main_context_iterate.isra.20 at :0
+  [30] g_main_context_iteration at :0
+  [31] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [32] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [33]  at :0
+  [34] QMenu::exec(QPoint const&, QAction*) at :0
+  [35] RiuMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:2056
+  [36]  at :0
+  [37] QWidget::customContextMenuRequested(QPoint const&) at :0
+  [38] QWidget::event(QEvent*) at :0
+  [39] QFrame::event(QEvent*) at :0
+  [40] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [41] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [42] QApplication::notify(QObject*, QEvent*) at :0
+  [43] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [44] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [45]  at :0
+  [46]  at :0
+  [47] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [48] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [49] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [50] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [51] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [52]  at :0
+  [53] g_main_context_dispatch at :0
+  [54] g_main_context_iterate.isra.20 at :0
+  [55] g_main_context_iteration at :0
+  [56] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [57] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [58] QCoreApplication::exec() at :0
+  [59] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [60] __libc_start_main at :0
+  [61] _start at :0
+  [62]  at :0
+"
+2026-04-09T10:07:57.999Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] RivSimWellPipesPartMgr::appendVirtualConnectionFactorGeo(RimEclipseView const*, unsigned long, unsigned long, caf::DisplayCoordTransform const*, double, RivSimWellPipesPartMgr::RivPipeBranchData&) at ResInsight/ApplicationLibCode/ModelVisualization/RivSimWellPipesPartMgr.cpp:311
+  [4] RivSimWellPipesPartMgr::buildWellPipeParts(caf::DisplayCoordTransform const*, bool, double, int, unsigned long) at ResInsight/ApplicationLibCode/ModelVisualization/RivSimWellPipesPartMgr.cpp:280
+  [5] RivSimWellPipesPartMgr::appendDynamicGeometryPartsToModel(cvf::ModelBasicList*, unsigned long, caf::DisplayCoordTransform const*) at ResInsight/ApplicationLibCode/ModelVisualization/RivSimWellPipesPartMgr.cpp:98
+  [6] RivReservoirSimWellsPartMgr::appendDynamicGeometryPartsToModel(cvf::ModelBasicList*, unsigned long) at ResInsight/ApplicationLibCode/ModelVisualization/RivReservoirSimWellsPartMgr.cpp:110
+  [7] RimEclipseView::appendWellsAndFracturesToModel() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp:1093
+  [8] RimEclipseContourMapView::updateGeometry() at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapView.cpp:302
+  [9] Rim3dView::updateDisplayModelForCurrentTimeStepAndRedraw() at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:673
+  [10] RiuViewer::setCurrentFrame(int) at ResInsight/ApplicationLibCode/UserInterface/RiuViewer.cpp:1008
+  [11] RimEclipseView::onCreateDisplayModel() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp:791
+  [12] RimEclipseContourMapView::onCreateDisplayModel() at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapView.cpp:205
+  [13] Rim3dView::createDisplayModelAndRedraw() at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:718
+  [14] RiaViewRedrawScheduler::updateAndRedrawScheduledViews() at ResInsight/ApplicationLibCode/Application/RiaViewRedrawScheduler.cpp:93
+  [15]  at :0
+  [16] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [17] QObject::event(QEvent*) at :0
+  [18] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [19] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [20] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [21] QTimerInfoList::activateTimers() at :0
+  [22]  at :0
+  [23] g_main_context_dispatch at :0
+  [24] g_main_context_iterate.isra.20 at :0
+  [25] g_main_context_iteration at :0
+  [26] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [27] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [28] QCoreApplication::exec() at :0
+  [29] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [30] __libc_start_main at :0
+  [31] _start at :0
+  [32]  at :0
+"
+2026-04-09T08:18:03.482Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] RigEclipseContourMapProjection::calculateColumnResult(RigCaseCellResultsData&, RigContourMapCalculator::ResultAggregationType, int, RigFloodingSettings&) at ResInsight/ApplicationLibCode/ReservoirDataModel/ContourMap/RigEclipseContourMapProjection.cpp:202
+  [4] RigEclipseContourMapProjection::generateResults(RigEclipseContourMapProjection const&, RigContourMapGrid const&, RigCaseCellResultsData&, RigEclipseResultAddress const&, RigContourMapCalculator::ResultAggregationType, int, RigFloodingSettings&) at ResInsight/ApplicationLibCode/ReservoirDataModel/ContourMap/RigEclipseContourMapProjection.cpp:126
+  [5] RigEclipseContourMapProjection::generateResults(RigEclipseResultAddress const&, RigContourMapCalculator::ResultAggregationType, int, RigFloodingSettings&) const at ResInsight/ApplicationLibCode/ReservoirDataModel/ContourMap/RigEclipseContourMapProjection.cpp:83
+  [6] RimEclipseContourMapProjection::generateResults(int) const at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapProjection.cpp:189
+  [7] RimEclipseContourMapProjection::computeMinMaxValuesAllTimeSteps() at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapProjection.cpp:376
+  [8] RimContourMapProjection::minmaxValuesAllTimeSteps() at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimContourMapProjection.cpp:478
+  [9] RimEclipseContourMapProjection::updateLegend() at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapProjection.cpp:117
+  [10] RimEclipseContourMapView::onUpdateLegends() at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapView.cpp:445
+  [11] RimEclipseContourMapView::updateGeometry() at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapView.cpp:284
+  [12] Rim3dView::updateDisplayModelForCurrentTimeStepAndRedraw() at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:673
+  [13] RiuViewer::setCurrentFrame(int) at ResInsight/ApplicationLibCode/UserInterface/RiuViewer.cpp:1008
+  [14] RimEclipseView::onCreateDisplayModel() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp:791
+  [15] RimEclipseContourMapView::onCreateDisplayModel() at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapView.cpp:205
+  [16] Rim3dView::createDisplayModelAndRedraw() at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:718
+  [17] RiaViewRedrawScheduler::updateAndRedrawScheduledViews() at ResInsight/ApplicationLibCode/Application/RiaViewRedrawScheduler.cpp:93
+  [18]  at :0
+  [19] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [20] QObject::event(QEvent*) at :0
+  [21] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [22] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [23] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [24] QTimerInfoList::activateTimers() at :0
+  [25]  at :0
+  [26] g_main_context_dispatch at :0
+  [27] g_main_context_iterate.isra.20 at :0
+  [28] g_main_context_iteration at :0
+  [29] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [30] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [31] QCoreApplication::exec() at :0
+  [32] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [33] __libc_start_main at :0
+  [34] _start at :0
+  [35]  at :0
+"
+2026-04-09T08:14:27.533Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] RigEclipseContourMapProjection::calculateColumnResult(RigCaseCellResultsData&, RigContourMapCalculator::ResultAggregationType, int, RigFloodingSettings&) at ResInsight/ApplicationLibCode/ReservoirDataModel/ContourMap/RigEclipseContourMapProjection.cpp:202
+  [4] RigEclipseContourMapProjection::generateResults(RigEclipseContourMapProjection const&, RigContourMapGrid const&, RigCaseCellResultsData&, RigEclipseResultAddress const&, RigContourMapCalculator::ResultAggregationType, int, RigFloodingSettings&) at ResInsight/ApplicationLibCode/ReservoirDataModel/ContourMap/RigEclipseContourMapProjection.cpp:126
+  [5] RigEclipseContourMapProjection::generateResults(RigEclipseResultAddress const&, RigContourMapCalculator::ResultAggregationType, int, RigFloodingSettings&) const at ResInsight/ApplicationLibCode/ReservoirDataModel/ContourMap/RigEclipseContourMapProjection.cpp:83
+  [6] RimEclipseContourMapProjection::generateResults(int) const at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapProjection.cpp:189
+  [7] RimEclipseContourMapProjection::computeMinMaxValuesAllTimeSteps() at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapProjection.cpp:376
+  [8] RimContourMapProjection::minmaxValuesAllTimeSteps() at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimContourMapProjection.cpp:478
+  [9] RimEclipseContourMapProjection::updateLegend() at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapProjection.cpp:117
+  [10] RimEclipseContourMapView::onUpdateLegends() at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapView.cpp:445
+  [11] RimEclipseContourMapView::updateGeometry() at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapView.cpp:284
+  [12] Rim3dView::updateDisplayModelForCurrentTimeStepAndRedraw() at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:673
+  [13] RiuViewer::setCurrentFrame(int) at ResInsight/ApplicationLibCode/UserInterface/RiuViewer.cpp:1008
+  [14] RimEclipseView::onCreateDisplayModel() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp:791
+  [15] RimEclipseContourMapView::onCreateDisplayModel() at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapView.cpp:205
+  [16] Rim3dView::createDisplayModelAndRedraw() at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:718
+  [17] RiaViewRedrawScheduler::updateAndRedrawScheduledViews() at ResInsight/ApplicationLibCode/Application/RiaViewRedrawScheduler.cpp:93
+  [18]  at :0
+  [19] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [20] QObject::event(QEvent*) at :0
+  [21] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [22] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [23] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [24] QTimerInfoList::activateTimers() at :0
+  [25]  at :0
+  [26] g_main_context_dispatch at :0
+  [27] g_main_context_iterate.isra.20 at :0
+  [28] g_main_context_iteration at :0
+  [29] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [30] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [31] QCoreApplication::exec() at :0
+  [32] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [33] __libc_start_main at :0
+  [34] _start at :0
+  [35]  at :0
+"
+2026-04-08T18:49:18.304Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] std::terminate() at :0
+  [10] __cxa_rethrow at :0
+  [11] main at ResInsight/ApplicationExeCode/RiaMain.cpp:232
+  [12] __libc_start_main at :0
+  [13] _start at :0
+  [14]  at :0
+"
+2026-04-08T13:00:08.832Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __libc_message at :0
+  [6] malloc_printerr at :0
+  [7] _int_free at :0
+  [8] __run_exit_handlers at :0
+  [9] __GI_exit at :0
+  [10] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:228
+  [11]  at :0
+  [12] __GI_raise at :0
+  [13] __GI_abort at :0
+  [14] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
+  [15] RiaWeightedHarmonicMeanCalculator::addValueAndWeight(double, double) at ResInsight/ApplicationLibCode/Application/Tools/RiaWeightedHarmonicMeanCalculator.cpp:39
+  [16] RigContourMapCalculator::calculateHarmonicMeanValue(RigContourMapProjection const&, std::vector<std::pair<unsigned long, double>, std::allocator<std::pair<unsigned long, double> > > const&, std::vector<double, std::allocator<double> > const&) at ResInsight/ApplicationLibCode/ReservoirDataModel/ContourMap/RigContourMapCalculator.cpp:184
+  [17] RigEclipseContourMapProjection::generateResults(RigEclipseContourMapProjection const&, RigContourMapGrid const&, RigCaseCellResultsData&, RigEclipseResultAddress const&, RigContourMapCalculator::ResultAggregationType, int, RigFloodingSettings&) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ReservoirDataModel/ContourMap/RigEclipseContourMapProjection.cpp:150
+  [18] gomp_thread_start at :0
+  [19] start_thread at :0
+  [20] clone at :0
+  [21]  at :0
+"
+2026-04-08T12:59:59.612Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
+  [6] RiaWeightedHarmonicMeanCalculator::addValueAndWeight(double, double) at ResInsight/ApplicationLibCode/Application/Tools/RiaWeightedHarmonicMeanCalculator.cpp:39
+  [7] RigContourMapCalculator::calculateHarmonicMeanValue(RigContourMapProjection const&, std::vector<std::pair<unsigned long, double>, std::allocator<std::pair<unsigned long, double> > > const&, std::vector<double, std::allocator<double> > const&) at ResInsight/ApplicationLibCode/ReservoirDataModel/ContourMap/RigContourMapCalculator.cpp:184
+  [8] RigEclipseContourMapProjection::generateResults(RigEclipseContourMapProjection const&, RigContourMapGrid const&, RigCaseCellResultsData&, RigEclipseResultAddress const&, RigContourMapCalculator::ResultAggregationType, int, RigFloodingSettings&) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ReservoirDataModel/ContourMap/RigEclipseContourMapProjection.cpp:150
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] clone at :0
+  [12]  at :0
+"
+2026-04-08T12:59:59.47Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
+  [6] RiaWeightedHarmonicMeanCalculator::addValueAndWeight(double, double) at ResInsight/ApplicationLibCode/Application/Tools/RiaWeightedHarmonicMeanCalculator.cpp:39
+  [7] RigContourMapCalculator::calculateHarmonicMeanValue(RigContourMapProjection const&, std::vector<std::pair<unsigned long, double>, std::allocator<std::pair<unsigned long, double> > > const&, std::vector<double, std::allocator<double> > const&) at ResInsight/ApplicationLibCode/ReservoirDataModel/ContourMap/RigContourMapCalculator.cpp:184
+  [8] RigEclipseContourMapProjection::generateResults(RigEclipseContourMapProjection const&, RigContourMapGrid const&, RigCaseCellResultsData&, RigEclipseResultAddress const&, RigContourMapCalculator::ResultAggregationType, int, RigFloodingSettings&) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ReservoirDataModel/ContourMap/RigEclipseContourMapProjection.cpp:150
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] clone at :0
+  [12]  at :0
+"
+2026-04-08T12:59:59.327Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
+  [6] RiaWeightedHarmonicMeanCalculator::addValueAndWeight(double, double) at ResInsight/ApplicationLibCode/Application/Tools/RiaWeightedHarmonicMeanCalculator.cpp:39
+  [7] RigContourMapCalculator::calculateHarmonicMeanValue(RigContourMapProjection const&, std::vector<std::pair<unsigned long, double>, std::allocator<std::pair<unsigned long, double> > > const&, std::vector<double, std::allocator<double> > const&) at ResInsight/ApplicationLibCode/ReservoirDataModel/ContourMap/RigContourMapCalculator.cpp:184
+  [8] RigEclipseContourMapProjection::generateResults(RigEclipseContourMapProjection const&, RigContourMapGrid const&, RigCaseCellResultsData&, RigEclipseResultAddress const&, RigContourMapCalculator::ResultAggregationType, int, RigFloodingSettings&) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ReservoirDataModel/ContourMap/RigEclipseContourMapProjection.cpp:150
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] clone at :0
+  [12]  at :0
+"
+2026-04-08T12:59:59.183Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
+  [6] RiaWeightedHarmonicMeanCalculator::addValueAndWeight(double, double) at ResInsight/ApplicationLibCode/Application/Tools/RiaWeightedHarmonicMeanCalculator.cpp:39
+  [7] RigContourMapCalculator::calculateHarmonicMeanValue(RigContourMapProjection const&, std::vector<std::pair<unsigned long, double>, std::allocator<std::pair<unsigned long, double> > > const&, std::vector<double, std::allocator<double> > const&) at ResInsight/ApplicationLibCode/ReservoirDataModel/ContourMap/RigContourMapCalculator.cpp:184
+  [8] RigEclipseContourMapProjection::generateResults(RigEclipseContourMapProjection const&, RigContourMapGrid const&, RigCaseCellResultsData&, RigEclipseResultAddress const&, RigContourMapCalculator::ResultAggregationType, int, RigFloodingSettings&) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ReservoirDataModel/ContourMap/RigEclipseContourMapProjection.cpp:150
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] clone at :0
+  [12]  at :0
+"
+2026-04-08T12:59:59.044Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
+  [6] RiaWeightedHarmonicMeanCalculator::addValueAndWeight(double, double) at ResInsight/ApplicationLibCode/Application/Tools/RiaWeightedHarmonicMeanCalculator.cpp:39
+  [7] RigContourMapCalculator::calculateHarmonicMeanValue(RigContourMapProjection const&, std::vector<std::pair<unsigned long, double>, std::allocator<std::pair<unsigned long, double> > > const&, std::vector<double, std::allocator<double> > const&) at ResInsight/ApplicationLibCode/ReservoirDataModel/ContourMap/RigContourMapCalculator.cpp:184
+  [8] RigEclipseContourMapProjection::generateResults(RigEclipseContourMapProjection const&, RigContourMapGrid const&, RigCaseCellResultsData&, RigEclipseResultAddress const&, RigContourMapCalculator::ResultAggregationType, int, RigFloodingSettings&) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ReservoirDataModel/ContourMap/RigEclipseContourMapProjection.cpp:150
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] clone at :0
+  [12]  at :0
+"
+2026-04-08T12:59:58.902Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
+  [6] RiaWeightedHarmonicMeanCalculator::addValueAndWeight(double, double) at ResInsight/ApplicationLibCode/Application/Tools/RiaWeightedHarmonicMeanCalculator.cpp:39
+  [7] RigContourMapCalculator::calculateHarmonicMeanValue(RigContourMapProjection const&, std::vector<std::pair<unsigned long, double>, std::allocator<std::pair<unsigned long, double> > > const&, std::vector<double, std::allocator<double> > const&) at ResInsight/ApplicationLibCode/ReservoirDataModel/ContourMap/RigContourMapCalculator.cpp:184
+  [8] RigEclipseContourMapProjection::generateResults(RigEclipseContourMapProjection const&, RigContourMapGrid const&, RigCaseCellResultsData&, RigEclipseResultAddress const&, RigContourMapCalculator::ResultAggregationType, int, RigFloodingSettings&) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ReservoirDataModel/ContourMap/RigEclipseContourMapProjection.cpp:150
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] clone at :0
+  [12]  at :0
+"
+2026-04-08T12:59:58.81Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
+  [6] RiaWeightedHarmonicMeanCalculator::addValueAndWeight(double, double) at ResInsight/ApplicationLibCode/Application/Tools/RiaWeightedHarmonicMeanCalculator.cpp:39
+  [7] RigContourMapCalculator::calculateHarmonicMeanValue(RigContourMapProjection const&, std::vector<std::pair<unsigned long, double>, std::allocator<std::pair<unsigned long, double> > > const&, std::vector<double, std::allocator<double> > const&) at ResInsight/ApplicationLibCode/ReservoirDataModel/ContourMap/RigContourMapCalculator.cpp:184
+  [8] RigEclipseContourMapProjection::generateResults(RigEclipseContourMapProjection const&, RigContourMapGrid const&, RigCaseCellResultsData&, RigEclipseResultAddress const&, RigContourMapCalculator::ResultAggregationType, int, RigFloodingSettings&) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ReservoirDataModel/ContourMap/RigEclipseContourMapProjection.cpp:150
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] clone at :0
+  [12]  at :0
+"
+2026-04-08T12:59:58.809Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
+  [6] RiaWeightedHarmonicMeanCalculator::addValueAndWeight(double, double) at ResInsight/ApplicationLibCode/Application/Tools/RiaWeightedHarmonicMeanCalculator.cpp:39
+  [7] RigContourMapCalculator::calculateHarmonicMeanValue(RigContourMapProjection const&, std::vector<std::pair<unsigned long, double>, std::allocator<std::pair<unsigned long, double> > > const&, std::vector<double, std::allocator<double> > const&) at ResInsight/ApplicationLibCode/ReservoirDataModel/ContourMap/RigContourMapCalculator.cpp:184
+  [8] RigEclipseContourMapProjection::generateResults(RigEclipseContourMapProjection const&, RigContourMapGrid const&, RigCaseCellResultsData&, RigEclipseResultAddress const&, RigContourMapCalculator::ResultAggregationType, int, RigFloodingSettings&) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ReservoirDataModel/ContourMap/RigEclipseContourMapProjection.cpp:150
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] clone at :0
+  [12]  at :0
+"
+2026-04-08T09:55:07.859Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
+  [6] RicWellPathExportCompletionDataFeatureImpl::wellPathUpperGridIntersectionIJ(gsl::not_null<RimEclipseCase const*>, gsl::not_null<RimWellPath const*>, QString const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportCompletionDataFeatureImpl.cpp:1294
+  [7] RicWellPathExportCompletionDataFeatureImpl::exportWelspecsToFile(RimEclipseCase*, std::shared_ptr<QFile>, std::vector<RigCompletionData, std::allocator<RigCompletionData> > const&, bool) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportCompletionDataFeatureImpl.cpp:699
+  [8] RicWellPathExportCompletionDataFeatureImpl::sortAndExportCompletionsToFile(RimEclipseCase*, QString const&, QString const&, std::vector<RigCompletionData, std::allocator<RigCompletionData> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> > const&, caf::AppEnum<RicExportCompletionDataSettingsUi::CompdatExport>, bool, bool) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportCompletionDataFeatureImpl.cpp:825
+  [9] RicWellPathExportCompletionDataFeatureImpl::exportCompletions(std::vector<RimWellPath*, std::allocator<RimWellPath*> > const&, RicExportCompletionDataSettingsUi const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportCompletionDataFeatureImpl.cpp:292
+  [10] RicWellPathExportCompletionDataFeature::prepareExportSettingsAndExportCompletions(QString const&, std::vector<RimWellPath*, std::allocator<RimWellPath*> > const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportCompletionDataFeature.cpp:177
+  [11] RicExportCompletionsForVisibleWellPathsFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportCompletionsForVisibleWellPathsFeature.cpp:75
+  [12] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+  [13]  at :0
+  [14] QAction::triggered(bool) at :0
+  [15] QAction::activate(QAction::ActionEvent) at :0
+  [16]  at :0
+  [17]  at :0
+  [18] QWidget::event(QEvent*) at :0
+  [19] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [20] QApplication::notify(QObject*, QEvent*) at :0
+  [21] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [22] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [23] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [24]  at :0
+  [25]  at :0
+  [26] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [27] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [28] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [29] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [30] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [31]  at :0
+  [32] g_main_context_dispatch at :0
+  [33] g_main_context_iterate.isra.20 at :0
+  [34] g_main_context_iteration at :0
+  [35] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [36] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [37]  at :0
+  [38] QMenu::exec(QPoint const&, QAction*) at :0
+  [39] RiuMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:2056
+  [40]  at :0
+  [41] QWidget::customContextMenuRequested(QPoint const&) at :0
+  [42] QWidget::event(QEvent*) at :0
+  [43] QFrame::event(QEvent*) at :0
+  [44] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [45] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [46] QApplication::notify(QObject*, QEvent*) at :0
+  [47] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [48] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [49]  at :0
+  [50]  at :0
+  [51] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [52] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [53] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [54] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [55] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [56]  at :0
+  [57] g_main_context_dispatch at :0
+  [58] g_main_context_iterate.isra.20 at :0
+  [59] g_main_context_iteration at :0
+  [60] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [61] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [62] QCoreApplication::exec() at :0
+  [63] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [64] __libc_start_main at :0
+  [65] _start at :0
+  [66]  at :0
+"
+2026-04-08T06:06:10.041Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] QwtPlotDict::PrivateData::ItemList::removeItem(QwtPlotItem*) at ResInsight/ThirdParty/qwt/src/qwt_plot_dict.cpp:32
+  [4] QwtPlot::attachItem(QwtPlotItem*, bool) at ResInsight/ThirdParty/qwt/src/qwt_plot.cpp:1133
+  [5] QwtPlotItem::attach(QwtPlot*) at ResInsight/ThirdParty/qwt/src/qwt_plot_item.cpp:104
+  [6] RimEnsembleWellLogCurveSet::~RimEnsembleWellLogCurveSet() at ResInsight/ApplicationLibCode/ProjectDataModel/WellLog/RimEnsembleWellLogCurveSet.cpp:180
+  [7] RimEnsembleWellLogCurveSet::~RimEnsembleWellLogCurveSet() at ResInsight/ApplicationLibCode/ProjectDataModel/WellLog/RimEnsembleWellLogCurveSet.cpp:182
+  [8] caf::PdmChildField<RimEnsembleWellLogCurveSet*>::~PdmChildField() at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmChildField.inl:80
+  [9] non-virtual thunk to RimWellLogTrack::~RimWellLogTrack() at ResInsight/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogTrack.h:92
+  [10] caf::PdmChildArrayField<RimWellLogTrack*>::deleteChildren() at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmChildArrayField.inl:181
+  [11] RimDepthTrackPlot::~RimDepthTrackPlot() at ResInsight/ApplicationLibCode/ProjectDataModel/RimDepthTrackPlot.cpp:189
+  [12] non-virtual thunk to RimWellLogPlot::~RimWellLogPlot() at ResInsight/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogPlot.h:38
+  [13] RicDeleteItemExec::redo() at ResInsight/ApplicationLibCode/Commands/RicDeleteItemExec.cpp:65
+  [14] RicDeleteItemFeature::deleteObject(caf::PdmObject*) at ResInsight/ApplicationLibCode/Commands/RicDeleteItemFeature.cpp:128
+  [15] RicDeleteItemFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/RicDeleteItemFeature.cpp:68
+  [16] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+  [17]  at :0
+  [18] QAction::triggered(bool) at :0
+  [19] QAction::activate(QAction::ActionEvent) at :0
+  [20]  at :0
+  [21]  at :0
+  [22] QWidget::event(QEvent*) at :0
+  [23] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [24] QApplication::notify(QObject*, QEvent*) at :0
+  [25] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [26] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [27] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [28]  at :0
+  [29]  at :0
+  [30] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [31] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [32] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [33] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [34] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [35]  at :0
+  [36] g_main_context_dispatch at :0
+  [37] g_main_context_iterate.isra.20 at :0
+  [38] g_main_context_iteration at :0
+  [39] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [40] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [41]  at :0
+  [42] QMenu::exec(QPoint const&, QAction*) at :0
+  [43] RiuPlotMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp:1058
+  [44]  at :0
+  [45] QWidget::customContextMenuRequested(QPoint const&) at :0
+  [46] QWidget::event(QEvent*) at :0
+  [47] QFrame::event(QEvent*) at :0
+  [48] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [49] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [50] QApplication::notify(QObject*, QEvent*) at :0
+  [51] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [52] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [53]  at :0
+  [54]  at :0
+  [55] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [56] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [57] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [58] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [59] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [60]  at :0
+  [61] g_main_context_dispatch at :0
+  [62] g_main_context_iterate.isra.20 at :0
+  [63] g_main_context_iteration at :0
+  [64] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [65] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [66] QCoreApplication::exec() at :0
+  [67] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [68] __libc_start_main at :0
+  [69] _start at :0
+  [70]  at :0
+"
+2026-03-30T04:08:38.358Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] raise at :0
+  [4]  at :0
+  [5] QAction::triggered(bool) at :0
+  [6] QAction::activate(QAction::ActionEvent) at :0
+  [7]  at :0
+  [8]  at :0
+  [9] QWidget::event(QEvent*) at :0
+  [10] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [11] QApplication::notify(QObject*, QEvent*) at :0
+  [12] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [13] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [14] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [15]  at :0
+  [16]  at :0
+  [17] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [18] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [19] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [20] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [21] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [22]  at :0
+  [23] g_main_context_dispatch at :0
+  [24] g_main_context_iterate.isra.20 at :0
+  [25] g_main_context_iteration at :0
+  [26] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [27] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [28] QCoreApplication::exec() at :0
+  [29] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [30] __libc_start_main at :0
+  [31] _start at :0
+  [32]  at :0
+"
+2026-03-30T03:33:28.48Z,"  [0] ResInsight+0x126638D at :0
+  [1] ResInsight+0x126630F at :0
+  [2] ucrtbase!raise+0x1D9 at :0
+  [3] Qt6Core!QObject::qt_static_metacall+0x1816 at :0
+  [4] Qt6Core!QMetaObject::activate+0x84 at :0
+  [5] Qt6Gui!QAction::activate+0x171 at :0
+  [6] Qt6Widgets!QMenu::actionGeometry+0x5D3 at :0
+  [7] Qt6Widgets!QMenu::actionGeometry+0x3B3 at :0
+  [8] Qt6Widgets!QMenu::mouseReleaseEvent+0x11A at :0
+  [9] Qt6Widgets!QWidget::event+0x164 at :0
+  [10] Qt6Widgets!QMenu::event+0x320 at :0
+  [11] Qt6Widgets!QApplicationPrivate::notify_helper+0x10E at :0
+  [12] Qt6Widgets!QApplication::notify+0x750 at :0
+  [13] ResInsight+0x13275B at :0
+  [14] Qt6Core!QCoreApplication::notifyInternal2+0x11F at :0
+  [15] Qt6Widgets!QApplicationPrivate::sendMouseEvent+0x3EF at :0
+  [16] Qt6Widgets!QWidgetRepaintManager::updateStaticContentsSize+0x2CF1 at :0
+  [17] Qt6Widgets!QWidgetRepaintManager::updateStaticContentsSize+0xCE2 at :0
+  [18] Qt6Widgets!QApplicationPrivate::notify_helper+0x10E at :0
+  [19] Qt6Widgets!QApplication::notify+0x18C1 at :0
+  [20] ResInsight+0x13275B at :0
+  [21] Qt6Core!QCoreApplication::notifyInternal2+0x11F at :0
+  [22] Qt6Gui!QGuiApplicationPrivate::processMouseEvent+0x77D at :0
+  [23] Qt6Gui!QWindowSystemInterface::sendWindowSystemEvents+0xEA at :0
+  [24] Qt6Core!QEventDispatcherWin32::processEvents+0x90 at :0
+  [25] Qt6Gui!QWindowsGuiEventDispatcher::processEvents+0x19 at :0
+  [26] Qt6Core!QEventLoop::exec+0x19F at :0
+  [27] Qt6Core!QCoreApplication::exec+0x15D at :0
+  [28] ResInsight+0x1265A01 at :0
+  [29] ResInsight!cJSON_malloc+0x45172D at :0
+  [30] ResInsight!cJSON_malloc+0x4503FA at :0
+  [31] KERNEL32!BaseThreadInitThunk+0x17 at :0
+  [32] ntdll!RtlUserThreadStart+0x2C at :0
+"
+2026-03-30T03:31:25.762Z,"  [0] ResInsight+0x126638D at :0
+  [1] ResInsight+0x126630F at :0
+  [2] ucrtbase!raise+0x1E1 at :0
+  [3] Qt6Core!QObject::qt_static_metacall+0x1816 at :0
+  [4] Qt6Core!QMetaObject::activate+0x84 at :0
+  [5] Qt6Gui!QAction::activate+0x171 at :0
+  [6] Qt6Widgets!QMenu::actionGeometry+0x5D3 at :0
+  [7] Qt6Widgets!QMenu::actionGeometry+0x3B3 at :0
+  [8] Qt6Widgets!QMenu::mouseReleaseEvent+0x11A at :0
+  [9] Qt6Widgets!QWidget::event+0x164 at :0
+  [10] Qt6Widgets!QMenu::event+0x320 at :0
+  [11] Qt6Widgets!QApplicationPrivate::notify_helper+0x10E at :0
+  [12] Qt6Widgets!QApplication::notify+0x750 at :0
+  [13] ResInsight+0x13275B at :0
+  [14] Qt6Core!QCoreApplication::notifyInternal2+0x11F at :0
+  [15] Qt6Widgets!QApplicationPrivate::sendMouseEvent+0x3EF at :0
+  [16] Qt6Widgets!QWidgetRepaintManager::updateStaticContentsSize+0x2CF1 at :0
+  [17] Qt6Widgets!QWidgetRepaintManager::updateStaticContentsSize+0xCE2 at :0
+  [18] Qt6Widgets!QApplicationPrivate::notify_helper+0x10E at :0
+  [19] Qt6Widgets!QApplication::notify+0x18C1 at :0
+  [20] ResInsight+0x13275B at :0
+  [21] Qt6Core!QCoreApplication::notifyInternal2+0x11F at :0
+  [22] Qt6Gui!QGuiApplicationPrivate::processMouseEvent+0x77D at :0
+  [23] Qt6Gui!QWindowSystemInterface::sendWindowSystemEvents+0xEA at :0
+  [24] Qt6Core!QEventDispatcherWin32::processEvents+0x90 at :0
+  [25] Qt6Gui!QWindowsGuiEventDispatcher::processEvents+0x19 at :0
+  [26] Qt6Core!QEventLoop::exec+0x19F at :0
+  [27] Qt6Core!QCoreApplication::exec+0x15D at :0
+  [28] ResInsight+0x1265A01 at :0
+  [29] ResInsight!cJSON_malloc+0x45172D at :0
+  [30] ResInsight!cJSON_malloc+0x4503FA at :0
+  [31] KERNEL32!BaseThreadInitThunk+0x14 at :0
+  [32] ntdll!RtlUserThreadStart+0x21 at :0
+"
+2026-03-30T03:30:29.282Z,"  [0] ResInsight+0x126638D at :0
+  [1] ResInsight+0x126630F at :0
+  [2] ucrtbase!raise+0x1E1 at :0
+  [3] Qt6Core!QObject::qt_static_metacall+0x1816 at :0
+  [4] Qt6Core!QMetaObject::activate+0x84 at :0
+  [5] Qt6Gui!QAction::activate+0x171 at :0
+  [6] Qt6Widgets!QMenu::actionGeometry+0x5D3 at :0
+  [7] Qt6Widgets!QMenu::actionGeometry+0x3B3 at :0
+  [8] Qt6Widgets!QMenu::mouseReleaseEvent+0x11A at :0
+  [9] Qt6Widgets!QWidget::event+0x164 at :0
+  [10] Qt6Widgets!QMenu::event+0x320 at :0
+  [11] Qt6Widgets!QApplicationPrivate::notify_helper+0x10E at :0
+  [12] Qt6Widgets!QApplication::notify+0x750 at :0
+  [13] ResInsight+0x13275B at :0
+  [14] Qt6Core!QCoreApplication::notifyInternal2+0x11F at :0
+  [15] Qt6Widgets!QApplicationPrivate::sendMouseEvent+0x3EF at :0
+  [16] Qt6Widgets!QWidgetRepaintManager::updateStaticContentsSize+0x2CF1 at :0
+  [17] Qt6Widgets!QWidgetRepaintManager::updateStaticContentsSize+0xCE2 at :0
+  [18] Qt6Widgets!QApplicationPrivate::notify_helper+0x10E at :0
+  [19] Qt6Widgets!QApplication::notify+0x18C1 at :0
+  [20] ResInsight+0x13275B at :0
+  [21] Qt6Core!QCoreApplication::notifyInternal2+0x11F at :0
+  [22] Qt6Gui!QGuiApplicationPrivate::processMouseEvent+0x77D at :0
+  [23] Qt6Gui!QWindowSystemInterface::sendWindowSystemEvents+0xEA at :0
+  [24] Qt6Core!QEventDispatcherWin32::processEvents+0x90 at :0
+  [25] Qt6Gui!QWindowsGuiEventDispatcher::processEvents+0x19 at :0
+  [26] Qt6Core!QEventLoop::exec+0x19F at :0
+  [27] Qt6Core!QCoreApplication::exec+0x15D at :0
+  [28] ResInsight+0x1265A01 at :0
+  [29] ResInsight!cJSON_malloc+0x45172D at :0
+  [30] ResInsight!cJSON_malloc+0x4503FA at :0
+  [31] KERNEL32!BaseThreadInitThunk+0x14 at :0
+  [32] ntdll!RtlUserThreadStart+0x21 at :0
+"
+2026-03-29T07:44:11.391Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] syscall at :0
+  [4] absl::lts_20240722::synchronization_internal::FutexWaiter::WaitUntil(std::atomic<int>*, int, absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [5] absl::lts_20240722::synchronization_internal::FutexWaiter::Wait(absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [6] AbslInternalPerThreadSemWait_lts_20240722 at :0
+  [7] absl::lts_20240722::CondVar::WaitCommon(absl::lts_20240722::Mutex*, absl::lts_20240722::synchronization_internal::KernelTimeout) [clone .cold] at :0
+  [8] gpr_cv_wait at :0
+  [9] grpc_core::Executor::ThreadMain(void*) at :0
+  [10] grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::{lambda(void*)#1}::_FUN(void*) at :0
+  [11] start_thread at :0
+  [12] clone at :0
+  [13]  at :0
+"
+2026-03-29T07:44:11.376Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] syscall at :0
+  [4] absl::lts_20240722::synchronization_internal::FutexWaiter::WaitUntil(std::atomic<int>*, int, absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [5] absl::lts_20240722::synchronization_internal::FutexWaiter::Wait(absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [6] AbslInternalPerThreadSemWait_lts_20240722 at :0
+  [7] absl::lts_20240722::CondVar::WaitCommon(absl::lts_20240722::Mutex*, absl::lts_20240722::synchronization_internal::KernelTimeout) [clone .cold] at :0
+  [8] grpc_event_engine::experimental::WorkStealingThreadPool::WorkSignal::WaitWithTimeout(grpc_core::Duration) at :0
+  [9] grpc_event_engine::experimental::WorkStealingThreadPool::ThreadState::Step() at :0
+  [10] grpc_event_engine::experimental::WorkStealingThreadPool::ThreadState::ThreadBody() at :0
+  [11] grpc_event_engine::experimental::WorkStealingThreadPool::WorkStealingThreadPoolImpl::StartThread()::{lambda(void*)#1}::_FUN(void*) at :0
+  [12] grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::{lambda(void*)#1}::_FUN(void*) at :0
+  [13] start_thread at :0
+  [14] clone at :0
+  [15]  at :0
+"
+2026-03-29T07:44:11.201Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] poll at :0
+  [4] g_main_context_iterate.isra.20 at :0
+  [5] g_main_context_iteration at :0
+  [6] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [7] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [8] QCoreApplication::exec() at :0
+  [9] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [10] __libc_start_main at :0
+  [11] _start at :0
+  [12]  at :0
+"
+2026-03-29T07:44:11.193Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] syscall at :0
+  [4] absl::lts_20240722::synchronization_internal::FutexWaiter::WaitUntil(std::atomic<int>*, int, absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [5] absl::lts_20240722::synchronization_internal::FutexWaiter::Wait(absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [6] AbslInternalPerThreadSemWait_lts_20240722 at :0
+  [7] absl::lts_20240722::CondVar::WaitCommon(absl::lts_20240722::Mutex*, absl::lts_20240722::synchronization_internal::KernelTimeout) [clone .cold] at :0
+  [8] grpc_event_engine::experimental::WorkStealingThreadPool::WorkSignal::WaitWithTimeout(grpc_core::Duration) at :0
+  [9] grpc_event_engine::experimental::WorkStealingThreadPool::ThreadState::Step() at :0
+  [10] grpc_event_engine::experimental::WorkStealingThreadPool::ThreadState::ThreadBody() at :0
+  [11] grpc_event_engine::experimental::WorkStealingThreadPool::WorkStealingThreadPoolImpl::StartThread()::{lambda(void*)#1}::_FUN(void*) at :0
+  [12] grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::{lambda(void*)#1}::_FUN(void*) at :0
+  [13] start_thread at :0
+  [14] clone at :0
+  [15]  at :0
+"
+2026-03-29T07:44:11.01Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] syscall at :0
+  [4] absl::lts_20240722::synchronization_internal::FutexWaiter::WaitUntil(std::atomic<int>*, int, absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [5] absl::lts_20240722::synchronization_internal::FutexWaiter::Wait(absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [6] AbslInternalPerThreadSemWait_lts_20240722 at :0
+  [7] absl::lts_20240722::CondVar::WaitCommon(absl::lts_20240722::Mutex*, absl::lts_20240722::synchronization_internal::KernelTimeout) [clone .cold] at :0
+  [8] gpr_cv_wait at :0
+  [9] timer_thread(void*) at :0
+  [10] grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::{lambda(void*)#1}::_FUN(void*) at :0
+  [11] start_thread at :0
+  [12] clone at :0
+  [13]  at :0
+"
+2026-03-29T07:44:11.003Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] poll at :0
+  [4] g_main_context_iterate.isra.20 at :0
+  [5] g_main_context_iteration at :0
+  [6] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [7] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [8] QCoreApplication::exec() at :0
+  [9] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [10] __libc_start_main at :0
+  [11] _start at :0
+  [12]  at :0
+"
+2026-03-29T07:44:10.809Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] epoll_wait at :0
+  [4] grpc_event_engine::experimental::Epoll1Poller::DoEpollWait(std::chrono::duration<long, std::ratio<1l, 1000000000l> >) at :0
+  [5] grpc_event_engine::experimental::Epoll1Poller::Work(std::chrono::duration<long, std::ratio<1l, 1000000000l> >, absl::lts_20240722::FunctionRef<void ()>) at :0
+  [6] grpc_event_engine::experimental::PosixEventEngine::PollerWorkInternal(std::shared_ptr<grpc_event_engine::experimental::PosixEnginePollerManager>) at :0
+  [7] void absl::lts_20240722::internal_any_invocable::LocalInvoker<false, void, grpc_event_engine::experimental::PosixEventEngine::PollerWorkInternal(std::shared_ptr<grpc_event_engine::experimental::PosixEnginePollerManager>)::{lambda()#1}::operator()() const::{lambda()#1}&>(absl::lts_20240722::internal_any_invocable::TypeErasedState*) at :0
+  [8] grpc_event_engine::experimental::SelfDeletingClosure::Run() at :0
+  [9] grpc_event_engine::experimental::WorkStealingThreadPool::ThreadState::Step() at :0
+  [10] grpc_event_engine::experimental::WorkStealingThreadPool::ThreadState::ThreadBody() at :0
+  [11] grpc_event_engine::experimental::WorkStealingThreadPool::WorkStealingThreadPoolImpl::StartThread()::{lambda(void*)#1}::_FUN(void*) at :0
+  [12] grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::{lambda(void*)#1}::_FUN(void*) at :0
+  [13] start_thread at :0
+  [14] clone at :0
+  [15]  at :0
+"
+2026-03-29T07:44:10.809Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] syscall at :0
+  [4] absl::lts_20240722::synchronization_internal::FutexWaiter::WaitUntil(std::atomic<int>*, int, absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [5] absl::lts_20240722::synchronization_internal::FutexWaiter::Wait(absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [6] AbslInternalPerThreadSemWait_lts_20240722 at :0
+  [7] absl::lts_20240722::CondVar::WaitCommon(absl::lts_20240722::Mutex*, absl::lts_20240722::synchronization_internal::KernelTimeout) [clone .cold] at :0
+  [8] gpr_cv_wait at :0
+  [9] grpc_core::Executor::ThreadMain(void*) at :0
+  [10] grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::{lambda(void*)#1}::_FUN(void*) at :0
+  [11] start_thread at :0
+  [12] clone at :0
+  [13]  at :0
+"
+2026-03-29T07:44:10.637Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] syscall at :0
+  [4] absl::lts_20240722::synchronization_internal::FutexWaiter::WaitUntil(std::atomic<int>*, int, absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [5] absl::lts_20240722::synchronization_internal::FutexWaiter::Wait(absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [6] AbslInternalPerThreadSemWait_lts_20240722 at :0
+  [7] absl::lts_20240722::CondVar::WaitCommon(absl::lts_20240722::Mutex*, absl::lts_20240722::synchronization_internal::KernelTimeout) [clone .cold] at :0
+  [8] grpc_event_engine::experimental::WorkStealingThreadPool::WorkSignal::WaitWithTimeout(grpc_core::Duration) at :0
+  [9] grpc_event_engine::experimental::WorkStealingThreadPool::ThreadState::Step() at :0
+  [10] grpc_event_engine::experimental::WorkStealingThreadPool::ThreadState::ThreadBody() at :0
+  [11] grpc_event_engine::experimental::WorkStealingThreadPool::WorkStealingThreadPoolImpl::StartThread()::{lambda(void*)#1}::_FUN(void*) at :0
+  [12] grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::{lambda(void*)#1}::_FUN(void*) at :0
+  [13] start_thread at :0
+  [14] clone at :0
+  [15]  at :0
+"
+2026-03-29T07:44:10.631Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] syscall at :0
+  [4] absl::lts_20240722::synchronization_internal::FutexWaiter::WaitUntil(std::atomic<int>*, int, absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [5] absl::lts_20240722::synchronization_internal::FutexWaiter::Wait(absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [6] AbslInternalPerThreadSemWait_lts_20240722 at :0
+  [7] absl::lts_20240722::CondVar::WaitCommon(absl::lts_20240722::Mutex*, absl::lts_20240722::synchronization_internal::KernelTimeout) [clone .cold] at :0
+  [8] gpr_cv_wait at :0
+  [9] timer_thread(void*) at :0
+  [10] grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::{lambda(void*)#1}::_FUN(void*) at :0
+  [11] start_thread at :0
+  [12] clone at :0
+  [13]  at :0
+"
+2026-03-29T07:44:10.472Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] epoll_wait at :0
+  [4] pollset_work(grpc_pollset*, grpc_pollset_worker**, grpc_core::Timestamp) at :0
+  [5] pollset_work(grpc_pollset*, grpc_pollset_worker**, grpc_core::Timestamp) at :0
+  [6] grpc_pollset_work(grpc_pollset*, grpc_pollset_worker**, grpc_core::Timestamp) at :0
+  [7] cq_next(grpc_completion_queue*, gpr_timespec, void*) at :0
+  [8] grpc::CompletionQueue::AsyncNextInternal(void**, bool*, gpr_timespec) at :0
+  [9] grpc::Server::ShutdownInternal(gpr_timespec) at :0
+  [10] grpc::ServerInterface::Shutdown() at ResInsight/cmakebuild/vcpkg_installed/x64-linux/include/grpcpp/server_interface.h:106
+  [11] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:109
+  [12] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:33
+  [13]  at :0
+  [14] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [15] QObject::event(QEvent*) at :0
+  [16] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [17] QTimerInfoList::activateTimers() at :0
+  [18]  at :0
+  [19] g_main_context_dispatch at :0
+  [20] g_main_context_iterate.isra.20 at :0
+  [21] g_main_context_iteration at :0
+  [22] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [23] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [24] QCoreApplication::exec() at :0
+  [25] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [26] __libc_start_main at :0
+  [27] _start at :0
+  [28]  at :0
+"
+2026-03-29T07:44:10.47Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] syscall at :0
+  [4] absl::lts_20240722::synchronization_internal::FutexWaiter::WaitUntil(std::atomic<int>*, int, absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [5] absl::lts_20240722::synchronization_internal::FutexWaiter::Wait(absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [6] AbslInternalPerThreadSemWait_lts_20240722 at :0
+  [7] absl::lts_20240722::CondVar::WaitCommon(absl::lts_20240722::Mutex*, absl::lts_20240722::synchronization_internal::KernelTimeout) [clone .cold] at :0
+  [8] grpc_event_engine::experimental::TimerManager::WaitUntil(grpc_core::Timestamp) at :0
+  [9] void absl::lts_20240722::internal_any_invocable::RemoteInvoker<false, void, grpc_event_engine::experimental::TimerManager::MainLoop()::{lambda()#1}&>(absl::lts_20240722::internal_any_invocable::TypeErasedState*) at :0
+  [10] grpc_event_engine::experimental::SelfDeletingClosure::Run() at :0
+  [11] grpc_event_engine::experimental::WorkStealingThreadPool::ThreadState::Step() at :0
+  [12] grpc_event_engine::experimental::WorkStealingThreadPool::ThreadState::ThreadBody() at :0
+  [13] grpc_event_engine::experimental::WorkStealingThreadPool::WorkStealingThreadPoolImpl::StartThread()::{lambda(void*)#1}::_FUN(void*) at :0
+  [14] grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::{lambda(void*)#1}::_FUN(void*) at :0
+  [15] start_thread at :0
+  [16] clone at :0
+  [17]  at :0
+"
+2026-03-29T07:44:10.465Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] syscall at :0
+  [4] absl::lts_20240722::synchronization_internal::FutexWaiter::WaitUntil(std::atomic<int>*, int, absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [5] absl::lts_20240722::synchronization_internal::FutexWaiter::Wait(absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [6] AbslInternalPerThreadSemWait_lts_20240722 at :0
+  [7] absl::lts_20240722::CondVar::WaitCommon(absl::lts_20240722::Mutex*, absl::lts_20240722::synchronization_internal::KernelTimeout) [clone .cold] at :0
+  [8] gpr_cv_wait at :0
+  [9] grpc_core::Executor::ThreadMain(void*) at :0
+  [10] grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::{lambda(void*)#1}::_FUN(void*) at :0
+  [11] start_thread at :0
+  [12] clone at :0
+  [13]  at :0
+"
+2026-03-29T07:44:10.318Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] syscall at :0
+  [4] absl::lts_20240722::synchronization_internal::FutexWaiter::WaitUntil(std::atomic<int>*, int, absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [5] absl::lts_20240722::synchronization_internal::FutexWaiter::Wait(absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [6] AbslInternalPerThreadSemWait_lts_20240722 at :0
+  [7] absl::lts_20240722::CondVar::WaitCommon(absl::lts_20240722::Mutex*, absl::lts_20240722::synchronization_internal::KernelTimeout) [clone .cold] at :0
+  [8] gpr_cv_wait at :0
+  [9] grpc_core::Executor::ThreadMain(void*) at :0
+  [10] grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::{lambda(void*)#1}::_FUN(void*) at :0
+  [11] start_thread at :0
+  [12] clone at :0
+  [13]  at :0
+"
+2026-03-29T07:44:10.318Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] syscall at :0
+  [4] absl::lts_20240722::synchronization_internal::FutexWaiter::WaitUntil(std::atomic<int>*, int, absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [5] absl::lts_20240722::synchronization_internal::FutexWaiter::Wait(absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [6] AbslInternalPerThreadSemWait_lts_20240722 at :0
+  [7] absl::lts_20240722::CondVar::WaitCommon(absl::lts_20240722::Mutex*, absl::lts_20240722::synchronization_internal::KernelTimeout) [clone .cold] at :0
+  [8] grpc_event_engine::experimental::WorkStealingThreadPool::WorkSignal::WaitWithTimeout(grpc_core::Duration) at :0
+  [9] grpc_event_engine::experimental::WorkStealingThreadPool::ThreadState::Step() at :0
+  [10] grpc_event_engine::experimental::WorkStealingThreadPool::ThreadState::ThreadBody() at :0
+  [11] grpc_event_engine::experimental::WorkStealingThreadPool::WorkStealingThreadPoolImpl::StartThread()::{lambda(void*)#1}::_FUN(void*) at :0
+  [12] grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::{lambda(void*)#1}::_FUN(void*) at :0
+  [13] start_thread at :0
+  [14] clone at :0
+  [15]  at :0
+"
+2026-03-29T07:44:10.317Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] syscall at :0
+  [4] absl::lts_20240722::synchronization_internal::FutexWaiter::WaitUntil(std::atomic<int>*, int, absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [5] absl::lts_20240722::synchronization_internal::FutexWaiter::Wait(absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [6] AbslInternalPerThreadSemWait_lts_20240722 at :0
+  [7] absl::lts_20240722::CondVar::WaitCommon(absl::lts_20240722::Mutex*, absl::lts_20240722::synchronization_internal::KernelTimeout) [clone .cold] at :0
+  [8] gpr_cv_wait at :0
+  [9] timer_thread(void*) at :0
+  [10] grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::{lambda(void*)#1}::_FUN(void*) at :0
+  [11] start_thread at :0
+  [12] clone at :0
+  [13]  at :0
+"
+2026-03-29T07:44:10.317Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] syscall at :0
+  [4] absl::lts_20240722::synchronization_internal::FutexWaiter::WaitUntil(std::atomic<int>*, int, absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [5] absl::lts_20240722::synchronization_internal::FutexWaiter::Wait(absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [6] AbslInternalPerThreadSemWait_lts_20240722 at :0
+  [7] absl::lts_20240722::CondVar::WaitCommon(absl::lts_20240722::Mutex*, absl::lts_20240722::synchronization_internal::KernelTimeout) [clone .cold] at :0
+  [8] grpc_event_engine::experimental::WorkStealingThreadPool::WorkSignal::WaitWithTimeout(grpc_core::Duration) at :0
+  [9] grpc_event_engine::experimental::WorkStealingThreadPool::ThreadState::Step() at :0
+  [10] grpc_event_engine::experimental::WorkStealingThreadPool::ThreadState::ThreadBody() at :0
+  [11] grpc_event_engine::experimental::WorkStealingThreadPool::WorkStealingThreadPoolImpl::StartThread()::{lambda(void*)#1}::_FUN(void*) at :0
+  [12] grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::{lambda(void*)#1}::_FUN(void*) at :0
+  [13] start_thread at :0
+  [14] clone at :0
+  [15]  at :0
+"
+2026-03-29T07:44:10.235Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] epoll_wait at :0
+  [4] pollset_work(grpc_pollset*, grpc_pollset_worker**, grpc_core::Timestamp) at :0
+  [5] pollset_work(grpc_pollset*, grpc_pollset_worker**, grpc_core::Timestamp) at :0
+  [6] grpc_pollset_work(grpc_pollset*, grpc_pollset_worker**, grpc_core::Timestamp) at :0
+  [7] cq_next(grpc_completion_queue*, gpr_timespec, void*) at :0
+  [8] grpc::CompletionQueue::AsyncNextInternal(void**, bool*, gpr_timespec) at :0
+  [9] grpc::Server::ShutdownInternal(gpr_timespec) at :0
+  [10] grpc::ServerInterface::Shutdown() at ResInsight/cmakebuild/vcpkg_installed/x64-linux/include/grpcpp/server_interface.h:106
+  [11] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:109
+  [12] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:33
+  [13]  at :0
+  [14] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [15] QObject::event(QEvent*) at :0
+  [16] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [17] QTimerInfoList::activateTimers() at :0
+  [18]  at :0
+  [19] g_main_context_dispatch at :0
+  [20] g_main_context_iterate.isra.20 at :0
+  [21] g_main_context_iteration at :0
+  [22] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [23] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [24] QCoreApplication::exec() at :0
+  [25] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [26] __libc_start_main at :0
+  [27] _start at :0
+  [28]  at :0
+"
+2026-03-29T07:44:10.206Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] syscall at :0
+  [4] absl::lts_20240722::synchronization_internal::FutexWaiter::WaitUntil(std::atomic<int>*, int, absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [5] absl::lts_20240722::synchronization_internal::FutexWaiter::Wait(absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [6] AbslInternalPerThreadSemWait_lts_20240722 at :0
+  [7] absl::lts_20240722::CondVar::WaitCommon(absl::lts_20240722::Mutex*, absl::lts_20240722::synchronization_internal::KernelTimeout) [clone .cold] at :0
+  [8] grpc_event_engine::experimental::TimerManager::WaitUntil(grpc_core::Timestamp) at :0
+  [9] void absl::lts_20240722::internal_any_invocable::RemoteInvoker<false, void, grpc_event_engine::experimental::TimerManager::MainLoop()::{lambda()#1}&>(absl::lts_20240722::internal_any_invocable::TypeErasedState*) at :0
+  [10] grpc_event_engine::experimental::SelfDeletingClosure::Run() at :0
+  [11] grpc_event_engine::experimental::WorkStealingThreadPool::ThreadState::Step() at :0
+  [12] grpc_event_engine::experimental::WorkStealingThreadPool::ThreadState::ThreadBody() at :0
+  [13] grpc_event_engine::experimental::WorkStealingThreadPool::WorkStealingThreadPoolImpl::StartThread()::{lambda(void*)#1}::_FUN(void*) at :0
+  [14] grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::{lambda(void*)#1}::_FUN(void*) at :0
+  [15] start_thread at :0
+  [16] clone at :0
+  [17]  at :0
+"
+2026-03-29T07:44:10.206Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] syscall at :0
+  [4] absl::lts_20240722::synchronization_internal::FutexWaiter::WaitUntil(std::atomic<int>*, int, absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [5] absl::lts_20240722::synchronization_internal::FutexWaiter::Wait(absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [6] AbslInternalPerThreadSemWait_lts_20240722 at :0
+  [7] absl::lts_20240722::CondVar::WaitCommon(absl::lts_20240722::Mutex*, absl::lts_20240722::synchronization_internal::KernelTimeout) [clone .cold] at :0
+  [8] grpc_event_engine::experimental::WorkStealingThreadPool::WorkSignal::WaitWithTimeout(grpc_core::Duration) at :0
+  [9] grpc_event_engine::experimental::WorkStealingThreadPool::ThreadState::Step() at :0
+  [10] grpc_event_engine::experimental::WorkStealingThreadPool::ThreadState::ThreadBody() at :0
+  [11] grpc_event_engine::experimental::WorkStealingThreadPool::WorkStealingThreadPoolImpl::StartThread()::{lambda(void*)#1}::_FUN(void*) at :0
+  [12] grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::{lambda(void*)#1}::_FUN(void*) at :0
+  [13] start_thread at :0
+  [14] clone at :0
+  [15]  at :0
+"
+2026-03-29T07:44:10.205Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] syscall at :0
+  [4] absl::lts_20240722::synchronization_internal::FutexWaiter::WaitUntil(std::atomic<int>*, int, absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [5] absl::lts_20240722::synchronization_internal::FutexWaiter::Wait(absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [6] AbslInternalPerThreadSemWait_lts_20240722 at :0
+  [7] absl::lts_20240722::CondVar::WaitCommon(absl::lts_20240722::Mutex*, absl::lts_20240722::synchronization_internal::KernelTimeout) [clone .cold] at :0
+  [8] gpr_cv_wait at :0
+  [9] grpc_core::Executor::ThreadMain(void*) at :0
+  [10] grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::{lambda(void*)#1}::_FUN(void*) at :0
+  [11] start_thread at :0
+  [12] clone at :0
+  [13]  at :0
+"
+2026-03-25T12:55:49.978Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] RigWellPathGeometryExporter::computeWellPathDataForExport(RigWellPath const&, double, double, std::vector<double, std::allocator<double> >&, std::vector<double, std::allocator<double> >&, std::vector<double, std::allocator<double> >&, std::vector<double, std::allocator<double> >&) at ResInsight/ApplicationLibCode/ReservoirDataModel/Well/RigWellPathGeometryExporter.cpp:80
+  [4] RimcWellPath_extractWellPathPropertiesInternal::execute() at ResInsight/ApplicationLibCode/ProjectDataModelCommands/RimcWellPath.cpp:351
+  [5] RiaGrpcPdmObjectService::CallPdmObjectMethod(grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*) at ResInsight/GrpcInterface/RiaGrpcPdmObjectService.cpp:578
+  [6] grpc::Status std::__invoke_impl<grpc::Status, grpc::Status (RiaGrpcPdmObjectService::*&)(grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*), RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*>(std::__invoke_memfun_ref, grpc::Status (RiaGrpcPdmObjectService::*&)(grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*), RiaGrpcPdmObjectService&, grpc::ServerContext*&&, rips::PdmObjectMethodRequest const*&&, rips::PdmObject*&&) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/invoke.h:67
+  [7] std::function<grpc::Status (RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*)>::operator()(RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:591
+  [8] RiaGrpcServerImpl::processAllQueuedRequests() at ResInsight/GrpcInterface/RiaGrpcServer.cpp:197
+  [9] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:115
+  [10] RiaGrpcGuiApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcGuiApplication.cpp:60
+  [11]  at :0
+  [12] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [13] QObject::event(QEvent*) at :0
+  [14] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [15] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1826
+  [16] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [17] QTimerInfoList::activateTimers() at :0
+  [18]  at :0
+  [19] g_main_context_dispatch at :0
+  [20] g_main_context_iterate.isra.20 at :0
+  [21] g_main_context_iteration at :0
+  [22] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [23] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [24] QCoreApplication::exec() at :0
+  [25] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [26] __libc_start_main at :0
+  [27] _start at :0
+  [28]  at :0
+"
+2026-03-25T12:54:55.433Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] RigWellPathGeometryExporter::computeWellPathDataForExport(RigWellPath const&, double, double, std::vector<double, std::allocator<double> >&, std::vector<double, std::allocator<double> >&, std::vector<double, std::allocator<double> >&, std::vector<double, std::allocator<double> >&) at ResInsight/ApplicationLibCode/ReservoirDataModel/Well/RigWellPathGeometryExporter.cpp:80
+  [4] RimcWellPath_extractWellPathPropertiesInternal::execute() at ResInsight/ApplicationLibCode/ProjectDataModelCommands/RimcWellPath.cpp:351
+  [5] RiaGrpcPdmObjectService::CallPdmObjectMethod(grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*) at ResInsight/GrpcInterface/RiaGrpcPdmObjectService.cpp:578
+  [6] grpc::Status std::__invoke_impl<grpc::Status, grpc::Status (RiaGrpcPdmObjectService::*&)(grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*), RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*>(std::__invoke_memfun_ref, grpc::Status (RiaGrpcPdmObjectService::*&)(grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*), RiaGrpcPdmObjectService&, grpc::ServerContext*&&, rips::PdmObjectMethodRequest const*&&, rips::PdmObject*&&) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/invoke.h:67
+  [7] std::function<grpc::Status (RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*)>::operator()(RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:591
+  [8] RiaGrpcServerImpl::processAllQueuedRequests() at ResInsight/GrpcInterface/RiaGrpcServer.cpp:197
+  [9] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:115
+  [10] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:33
+  [11]  at :0
+  [12] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [13] QObject::event(QEvent*) at :0
+  [14] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [15] QTimerInfoList::activateTimers() at :0
+  [16]  at :0
+  [17] g_main_context_dispatch at :0
+  [18] g_main_context_iterate.isra.20 at :0
+  [19] g_main_context_iteration at :0
+  [20] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [21] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [22] QCoreApplication::exec() at :0
+  [23] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [24] __libc_start_main at :0
+  [25] _start at :0
+  [26]  at :0
+"
+2026-03-25T12:47:56.632Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] RigWellPathGeometryExporter::computeWellPathDataForExport(RigWellPath const&, double, double, std::vector<double, std::allocator<double> >&, std::vector<double, std::allocator<double> >&, std::vector<double, std::allocator<double> >&, std::vector<double, std::allocator<double> >&) at ResInsight/ApplicationLibCode/ReservoirDataModel/Well/RigWellPathGeometryExporter.cpp:80
+  [4] RimcWellPath_extractWellPathPropertiesInternal::execute() at ResInsight/ApplicationLibCode/ProjectDataModelCommands/RimcWellPath.cpp:351
+  [5] RiaGrpcPdmObjectService::CallPdmObjectMethod(grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*) at ResInsight/GrpcInterface/RiaGrpcPdmObjectService.cpp:578
+  [6] grpc::Status std::__invoke_impl<grpc::Status, grpc::Status (RiaGrpcPdmObjectService::*&)(grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*), RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*>(std::__invoke_memfun_ref, grpc::Status (RiaGrpcPdmObjectService::*&)(grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*), RiaGrpcPdmObjectService&, grpc::ServerContext*&&, rips::PdmObjectMethodRequest const*&&, rips::PdmObject*&&) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/invoke.h:67
+  [7] std::function<grpc::Status (RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*)>::operator()(RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:591
+  [8] RiaGrpcServerImpl::processAllQueuedRequests() at ResInsight/GrpcInterface/RiaGrpcServer.cpp:197
+  [9] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:115
+  [10] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:33
+  [11]  at :0
+  [12] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [13] QObject::event(QEvent*) at :0
+  [14] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [15] QTimerInfoList::activateTimers() at :0
+  [16]  at :0
+  [17] g_main_context_dispatch at :0
+  [18] g_main_context_iterate.isra.20 at :0
+  [19] g_main_context_iteration at :0
+  [20] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [21] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [22] QCoreApplication::exec() at :0
+  [23] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [24] __libc_start_main at :0
+  [25] _start at :0
+  [26]  at :0
+"
+2026-03-25T10:10:23.922Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] RigWellPathGeometryExporter::computeWellPathDataForExport(RigWellPath const&, double, double, std::vector<double, std::allocator<double> >&, std::vector<double, std::allocator<double> >&, std::vector<double, std::allocator<double> >&, std::vector<double, std::allocator<double> >&) at ResInsight/ApplicationLibCode/ReservoirDataModel/Well/RigWellPathGeometryExporter.cpp:80
+  [4] RimcWellPath_extractWellPathPropertiesInternal::execute() at ResInsight/ApplicationLibCode/ProjectDataModelCommands/RimcWellPath.cpp:351
+  [5] RiaGrpcPdmObjectService::CallPdmObjectMethod(grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*) at ResInsight/GrpcInterface/RiaGrpcPdmObjectService.cpp:578
+  [6] grpc::Status std::__invoke_impl<grpc::Status, grpc::Status (RiaGrpcPdmObjectService::*&)(grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*), RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*>(std::__invoke_memfun_ref, grpc::Status (RiaGrpcPdmObjectService::*&)(grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*), RiaGrpcPdmObjectService&, grpc::ServerContext*&&, rips::PdmObjectMethodRequest const*&&, rips::PdmObject*&&) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/invoke.h:67
+  [7] std::function<grpc::Status (RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*)>::operator()(RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:591
+  [8] RiaGrpcServerImpl::processAllQueuedRequests() at ResInsight/GrpcInterface/RiaGrpcServer.cpp:197
+  [9] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:115
+  [10] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:33
+  [11]  at :0
+  [12] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [13] QObject::event(QEvent*) at :0
+  [14] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [15] QTimerInfoList::activateTimers() at :0
+  [16]  at :0
+  [17] g_main_context_dispatch at :0
+  [18] g_main_context_iterate.isra.20 at :0
+  [19] g_main_context_iteration at :0
+  [20] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [21] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [22] QCoreApplication::exec() at :0
+  [23] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [24] __libc_start_main at :0
+  [25] _start at :0
+  [26]  at :0
+"
+2026-03-25T10:06:48.53Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] RigWellPathGeometryExporter::computeWellPathDataForExport(RigWellPath const&, double, double, std::vector<double, std::allocator<double> >&, std::vector<double, std::allocator<double> >&, std::vector<double, std::allocator<double> >&, std::vector<double, std::allocator<double> >&) at ResInsight/ApplicationLibCode/ReservoirDataModel/Well/RigWellPathGeometryExporter.cpp:80
+  [4] RimcWellPath_extractWellPathPropertiesInternal::execute() at ResInsight/ApplicationLibCode/ProjectDataModelCommands/RimcWellPath.cpp:351
+  [5] RiaGrpcPdmObjectService::CallPdmObjectMethod(grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*) at ResInsight/GrpcInterface/RiaGrpcPdmObjectService.cpp:578
+  [6] grpc::Status std::__invoke_impl<grpc::Status, grpc::Status (RiaGrpcPdmObjectService::*&)(grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*), RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*>(std::__invoke_memfun_ref, grpc::Status (RiaGrpcPdmObjectService::*&)(grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*), RiaGrpcPdmObjectService&, grpc::ServerContext*&&, rips::PdmObjectMethodRequest const*&&, rips::PdmObject*&&) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/invoke.h:67
+  [7] std::function<grpc::Status (RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*)>::operator()(RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:591
+  [8] RiaGrpcServerImpl::processAllQueuedRequests() at ResInsight/GrpcInterface/RiaGrpcServer.cpp:197
+  [9] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:115
+  [10] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:33
+  [11]  at :0
+  [12] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [13] QObject::event(QEvent*) at :0
+  [14] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [15] QTimerInfoList::activateTimers() at :0
+  [16]  at :0
+  [17] g_main_context_dispatch at :0
+  [18] g_main_context_iterate.isra.20 at :0
+  [19] g_main_context_iteration at :0
+  [20] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [21] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [22] QCoreApplication::exec() at :0
+  [23] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [24] __libc_start_main at :0
+  [25] _start at :0
+  [26]  at :0
+"
+2026-03-24T21:10:48.891Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] syscall at :0
+  [4] absl::lts_20240722::synchronization_internal::FutexWaiter::WaitUntil(std::atomic<int>*, int, absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [5] absl::lts_20240722::synchronization_internal::FutexWaiter::Wait(absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [6] AbslInternalPerThreadSemWait_lts_20240722 at :0
+  [7] absl::lts_20240722::CondVar::WaitCommon(absl::lts_20240722::Mutex*, absl::lts_20240722::synchronization_internal::KernelTimeout) [clone .cold] at :0
+  [8] gpr_cv_wait at :0
+  [9] grpc_core::Executor::ThreadMain(void*) at :0
+  [10] grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::{lambda(void*)#1}::_FUN(void*) at :0
+  [11] start_thread at :0
+  [12] clone at :0
+  [13]  at :0
+"
+2026-03-24T21:10:48.872Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] syscall at :0
+  [4] absl::lts_20240722::synchronization_internal::FutexWaiter::WaitUntil(std::atomic<int>*, int, absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [5] absl::lts_20240722::synchronization_internal::FutexWaiter::Wait(absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [6] AbslInternalPerThreadSemWait_lts_20240722 at :0
+  [7] absl::lts_20240722::CondVar::WaitCommon(absl::lts_20240722::Mutex*, absl::lts_20240722::synchronization_internal::KernelTimeout) [clone .cold] at :0
+  [8] gpr_cv_wait at :0
+  [9] grpc_core::Executor::ThreadMain(void*) at :0
+  [10] grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::{lambda(void*)#1}::_FUN(void*) at :0
+  [11] start_thread at :0
+  [12] clone at :0
+  [13]  at :0
+"
+2026-03-24T21:10:48.872Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] poll at :0
+  [4] g_main_context_iterate.isra.20 at :0
+  [5] g_main_context_iteration at :0
+  [6] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [7] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [8] QCoreApplication::exec() at :0
+  [9] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [10] __libc_start_main at :0
+  [11] _start at :0
+  [12]  at :0
+"
+2026-03-24T21:10:48.865Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] poll at :0
+  [4] g_main_context_iterate.isra.20 at :0
+  [5] g_main_context_iteration at :0
+  [6] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [7] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [8] QCoreApplication::exec() at :0
+  [9] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [10] __libc_start_main at :0
+  [11] _start at :0
+  [12]  at :0
+"
+2026-03-24T21:10:48.859Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] syscall at :0
+  [4] absl::lts_20240722::synchronization_internal::FutexWaiter::WaitUntil(std::atomic<int>*, int, absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [5] absl::lts_20240722::synchronization_internal::FutexWaiter::Wait(absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [6] AbslInternalPerThreadSemWait_lts_20240722 at :0
+  [7] absl::lts_20240722::CondVar::WaitCommon(absl::lts_20240722::Mutex*, absl::lts_20240722::synchronization_internal::KernelTimeout) [clone .cold] at :0
+  [8] gpr_cv_wait at :0
+  [9] grpc_core::Executor::ThreadMain(void*) at :0
+  [10] grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::{lambda(void*)#1}::_FUN(void*) at :0
+  [11] start_thread at :0
+  [12] clone at :0
+  [13]  at :0
+"
+2026-03-24T21:10:48.856Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] epoll_wait at :0
+  [4] pollset_work(grpc_pollset*, grpc_pollset_worker**, grpc_core::Timestamp) at :0
+  [5] pollset_work(grpc_pollset*, grpc_pollset_worker**, grpc_core::Timestamp) at :0
+  [6] grpc_pollset_work(grpc_pollset*, grpc_pollset_worker**, grpc_core::Timestamp) at :0
+  [7] cq_next(grpc_completion_queue*, gpr_timespec, void*) at :0
+  [8] grpc::CompletionQueue::AsyncNextInternal(void**, bool*, gpr_timespec) at :0
+  [9] grpc::Server::ShutdownInternal(gpr_timespec) at :0
+  [10] grpc::ServerInterface::Shutdown() at ResInsight/cmakebuild/vcpkg_installed/x64-linux/include/grpcpp/server_interface.h:106
+  [11] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:109
+  [12] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:33
+  [13]  at :0
+  [14] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [15] QObject::event(QEvent*) at :0
+  [16] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [17] QTimerInfoList::activateTimers() at :0
+  [18]  at :0
+  [19] g_main_context_dispatch at :0
+  [20] g_main_context_iterate.isra.20 at :0
+  [21] g_main_context_iteration at :0
+  [22] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [23] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [24] QCoreApplication::exec() at :0
+  [25] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [26] __libc_start_main at :0
+  [27] _start at :0
+  [28]  at :0
+"
+2026-03-24T21:10:48.856Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] syscall at :0
+  [4] absl::lts_20240722::synchronization_internal::FutexWaiter::WaitUntil(std::atomic<int>*, int, absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [5] absl::lts_20240722::synchronization_internal::FutexWaiter::Wait(absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [6] AbslInternalPerThreadSemWait_lts_20240722 at :0
+  [7] absl::lts_20240722::CondVar::WaitCommon(absl::lts_20240722::Mutex*, absl::lts_20240722::synchronization_internal::KernelTimeout) [clone .cold] at :0
+  [8] gpr_cv_wait at :0
+  [9] grpc_core::Executor::ThreadMain(void*) at :0
+  [10] grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::{lambda(void*)#1}::_FUN(void*) at :0
+  [11] start_thread at :0
+  [12] clone at :0
+  [13]  at :0
+"
+2026-03-24T21:10:48.853Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] poll at :0
+  [4] g_main_context_iterate.isra.20 at :0
+  [5] g_main_context_iteration at :0
+  [6] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [7] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [8] QCoreApplication::exec() at :0
+  [9] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [10] __libc_start_main at :0
+  [11] _start at :0
+  [12]  at :0
+"
+2026-03-24T21:10:48.853Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] syscall at :0
+  [4] absl::lts_20240722::synchronization_internal::FutexWaiter::WaitUntil(std::atomic<int>*, int, absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [5] absl::lts_20240722::synchronization_internal::FutexWaiter::Wait(absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [6] AbslInternalPerThreadSemWait_lts_20240722 at :0
+  [7] absl::lts_20240722::CondVar::WaitCommon(absl::lts_20240722::Mutex*, absl::lts_20240722::synchronization_internal::KernelTimeout) [clone .cold] at :0
+  [8] gpr_cv_wait at :0
+  [9] grpc_core::Executor::ThreadMain(void*) at :0
+  [10] grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::{lambda(void*)#1}::_FUN(void*) at :0
+  [11] start_thread at :0
+  [12] clone at :0
+  [13]  at :0
+"
+2026-03-24T21:10:48.771Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] epoll_wait at :0
+  [4] pollset_work(grpc_pollset*, grpc_pollset_worker**, grpc_core::Timestamp) at :0
+  [5] pollset_work(grpc_pollset*, grpc_pollset_worker**, grpc_core::Timestamp) at :0
+  [6] grpc_pollset_work(grpc_pollset*, grpc_pollset_worker**, grpc_core::Timestamp) at :0
+  [7] cq_next(grpc_completion_queue*, gpr_timespec, void*) at :0
+  [8] grpc::CompletionQueue::AsyncNextInternal(void**, bool*, gpr_timespec) at :0
+  [9] grpc::Server::ShutdownInternal(gpr_timespec) at :0
+  [10] grpc::ServerInterface::Shutdown() at ResInsight/cmakebuild/vcpkg_installed/x64-linux/include/grpcpp/server_interface.h:106
+  [11] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:109
+  [12] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:33
+  [13]  at :0
+  [14] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [15] QObject::event(QEvent*) at :0
+  [16] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [17] QTimerInfoList::activateTimers() at :0
+  [18]  at :0
+  [19] g_main_context_dispatch at :0
+  [20] g_main_context_iterate.isra.20 at :0
+  [21] g_main_context_iteration at :0
+  [22] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [23] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [24] QCoreApplication::exec() at :0
+  [25] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [26] __libc_start_main at :0
+  [27] _start at :0
+  [28]  at :0
+"
+2026-03-24T21:10:48.77Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] syscall at :0
+  [4] absl::lts_20240722::synchronization_internal::FutexWaiter::WaitUntil(std::atomic<int>*, int, absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [5] absl::lts_20240722::synchronization_internal::FutexWaiter::Wait(absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [6] AbslInternalPerThreadSemWait_lts_20240722 at :0
+  [7] absl::lts_20240722::CondVar::WaitCommon(absl::lts_20240722::Mutex*, absl::lts_20240722::synchronization_internal::KernelTimeout) [clone .cold] at :0
+  [8] gpr_cv_wait at :0
+  [9] pollset_work(grpc_pollset*, grpc_pollset_worker**, grpc_core::Timestamp) at :0
+  [10] pollset_work(grpc_pollset*, grpc_pollset_worker**, grpc_core::Timestamp) at :0
+  [11] grpc_pollset_work(grpc_pollset*, grpc_pollset_worker**, grpc_core::Timestamp) at :0
+  [12] cq_next(grpc_completion_queue*, gpr_timespec, void*) at :0
+  [13] grpc::CompletionQueue::AsyncNextInternal(void**, bool*, gpr_timespec) at :0
+  [14] grpc::Server::ShutdownInternal(gpr_timespec) at :0
+  [15] grpc::ServerInterface::Shutdown() at ResInsight/cmakebuild/vcpkg_installed/x64-linux/include/grpcpp/server_interface.h:106
+  [16] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:109
+  [17] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:33
+  [18]  at :0
+  [19] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [20] QObject::event(QEvent*) at :0
+  [21] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [22] QTimerInfoList::activateTimers() at :0
+  [23]  at :0
+  [24] g_main_context_dispatch at :0
+  [25] g_main_context_iterate.isra.20 at :0
+  [26] g_main_context_iteration at :0
+  [27] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [28] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [29] QCoreApplication::exec() at :0
+  [30] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [31] __libc_start_main at :0
+  [32] _start at :0
+  [33]  at :0
+"
+2026-03-24T21:10:48.77Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] epoll_wait at :0
+  [4] pollset_work(grpc_pollset*, grpc_pollset_worker**, grpc_core::Timestamp) at :0
+  [5] pollset_work(grpc_pollset*, grpc_pollset_worker**, grpc_core::Timestamp) at :0
+  [6] grpc_pollset_work(grpc_pollset*, grpc_pollset_worker**, grpc_core::Timestamp) at :0
+  [7] cq_next(grpc_completion_queue*, gpr_timespec, void*) at :0
+  [8] grpc::CompletionQueue::AsyncNextInternal(void**, bool*, gpr_timespec) at :0
+  [9] grpc::Server::ShutdownInternal(gpr_timespec) at :0
+  [10] grpc::ServerInterface::Shutdown() at ResInsight/cmakebuild/vcpkg_installed/x64-linux/include/grpcpp/server_interface.h:106
+  [11] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:109
+  [12] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:33
+  [13]  at :0
+  [14] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [15] QObject::event(QEvent*) at :0
+  [16] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [17] QTimerInfoList::activateTimers() at :0
+  [18]  at :0
+  [19] g_main_context_dispatch at :0
+  [20] g_main_context_iterate.isra.20 at :0
+  [21] g_main_context_iteration at :0
+  [22] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [23] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [24] QCoreApplication::exec() at :0
+  [25] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [26] __libc_start_main at :0
+  [27] _start at :0
+  [28]  at :0
+"
+2026-03-24T21:10:48.738Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] syscall at :0
+  [4] absl::lts_20240722::synchronization_internal::FutexWaiter::WaitUntil(std::atomic<int>*, int, absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [5] absl::lts_20240722::synchronization_internal::FutexWaiter::Wait(absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [6] AbslInternalPerThreadSemWait_lts_20240722 at :0
+  [7] absl::lts_20240722::CondVar::WaitCommon(absl::lts_20240722::Mutex*, absl::lts_20240722::synchronization_internal::KernelTimeout) [clone .cold] at :0
+  [8] gpr_cv_wait at :0
+  [9] grpc_core::Executor::ThreadMain(void*) at :0
+  [10] grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::{lambda(void*)#1}::_FUN(void*) at :0
+  [11] start_thread at :0
+  [12] clone at :0
+  [13]  at :0
+"
+2026-03-24T21:10:48.737Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] syscall at :0
+  [4] absl::lts_20240722::synchronization_internal::FutexWaiter::WaitUntil(std::atomic<int>*, int, absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [5] absl::lts_20240722::synchronization_internal::FutexWaiter::Wait(absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [6] AbslInternalPerThreadSemWait_lts_20240722 at :0
+  [7] absl::lts_20240722::CondVar::WaitCommon(absl::lts_20240722::Mutex*, absl::lts_20240722::synchronization_internal::KernelTimeout) [clone .cold] at :0
+  [8] gpr_cv_wait at :0
+  [9] grpc_core::Executor::ThreadMain(void*) at :0
+  [10] grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::{lambda(void*)#1}::_FUN(void*) at :0
+  [11] start_thread at :0
+  [12] clone at :0
+  [13]  at :0
+"
+2026-03-24T21:10:48.736Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] syscall at :0
+  [4] absl::lts_20240722::synchronization_internal::FutexWaiter::WaitUntil(std::atomic<int>*, int, absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [5] absl::lts_20240722::synchronization_internal::FutexWaiter::Wait(absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [6] AbslInternalPerThreadSemWait_lts_20240722 at :0
+  [7] absl::lts_20240722::CondVar::WaitCommon(absl::lts_20240722::Mutex*, absl::lts_20240722::synchronization_internal::KernelTimeout) [clone .cold] at :0
+  [8] gpr_cv_wait at :0
+  [9] grpc_core::Executor::ThreadMain(void*) at :0
+  [10] grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::{lambda(void*)#1}::_FUN(void*) at :0
+  [11] start_thread at :0
+  [12] clone at :0
+  [13]  at :0
+"
+2026-03-24T21:10:48.736Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] syscall at :0
+  [4] absl::lts_20240722::synchronization_internal::FutexWaiter::WaitUntil(std::atomic<int>*, int, absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [5] absl::lts_20240722::synchronization_internal::FutexWaiter::Wait(absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [6] AbslInternalPerThreadSemWait_lts_20240722 at :0
+  [7] absl::lts_20240722::CondVar::WaitCommon(absl::lts_20240722::Mutex*, absl::lts_20240722::synchronization_internal::KernelTimeout) [clone .cold] at :0
+  [8] gpr_cv_wait at :0
+  [9] grpc_core::Executor::ThreadMain(void*) at :0
+  [10] grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::{lambda(void*)#1}::_FUN(void*) at :0
+  [11] start_thread at :0
+  [12] clone at :0
+  [13]  at :0
+"
+2026-03-24T21:10:48.731Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] poll at :0
+  [4] g_main_context_iterate.isra.20 at :0
+  [5] g_main_context_iteration at :0
+  [6] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [7] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [8] QCoreApplication::exec() at :0
+  [9] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [10] __libc_start_main at :0
+  [11] _start at :0
+  [12]  at :0
+"
+2026-03-24T21:10:48.729Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] poll at :0
+  [4] g_main_context_iterate.isra.20 at :0
+  [5] g_main_context_iteration at :0
+  [6] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [7] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [8] QCoreApplication::exec() at :0
+  [9] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [10] __libc_start_main at :0
+  [11] _start at :0
+  [12]  at :0
+"
+2026-03-24T08:14:19.702Z,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] ecl_grid_get_cell_nnc_info1 at ResInsight/ThirdParty/Ert/lib/ecl/ecl_grid.cpp:5245
+  [4] ecl_nnc_geometry_add_pairs at ResInsight/ThirdParty/Ert/lib/ecl/ecl_nnc_geometry.cpp:58
+  [5] ecl_nnc_geometry_alloc at ResInsight/ThirdParty/Ert/lib/ecl/ecl_nnc_geometry.cpp:105
+  [6] RifEclipseOutputFileTools::transferNncFluxData(ecl_grid_struct const*, ecl_file_view_struct const*, std::vector<double, std::allocator<double> >*, std::vector<double, std::allocator<double> >*, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseOutputFileTools.cpp:591
+  [7] RifEclipseUnifiedRestartFileAccess::dynamicNNCResults(ecl_grid_struct const*, unsigned long, std::vector<double, std::allocator<double> >*, std::vector<double, std::allocator<double> >*, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseUnifiedRestartFileAccess.cpp:280
+  [8] RifReaderEclipseOutput::transferDynamicNNCData(ecl_grid_struct const*, RigMainGrid*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp:774
+  [9] RifReaderEclipseOutput::open(QString const&, RigEclipseCaseData*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp:494
+  [10] RimEclipseResultCase::importGridAndResultMetaData(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultCase.cpp:261
+  [11] RimReservoirGridEnsemble::loadGridsInSharedMode() at ResInsight/ApplicationLibCode/ProjectDataModel/RimReservoirGridEnsemble.cpp:906
+  [12] RimReservoirGridEnsemble::loadGridDataFromFiles() at ResInsight/ApplicationLibCode/ProjectDataModel/RimReservoirGridEnsemble.cpp:856
+  [13] RimEnsembleFileSetTools::createGridEnsemblesFromFileSets(std::vector<RimEnsembleFileSet*, std::allocator<RimEnsembleFileSet*> >) at ResInsight/ApplicationLibCode/ProjectDataModel/EnsembleFileSet/RimEnsembleFileSetTools.cpp:107
+  [14] doImport at ResInsight/ApplicationLibCode/Commands/RicImportGridAndSummaryEnsembleFeature.cpp:130
+  [15] RicImportGridAndSummaryEnsembleFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/RicImportGridAndSummaryEnsembleFeature.cpp:224
+  [16] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+  [17]  at :0
+  [18] QAction::triggered(bool) at :0
+  [19] QAction::activate(QAction::ActionEvent) at :0
+  [20]  at :0
+  [21] QAbstractButton::mouseReleaseEvent(QMouseEvent*) at :0
+  [22] QToolButton::mouseReleaseEvent(QMouseEvent*) at :0
+  [23] QWidget::event(QEvent*) at :0
+  [24] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [25] QApplication::notify(QObject*, QEvent*) at :0
+  [26] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1826
+  [27] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [28] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [29]  at :0
+  [30]  at :0
+  [31] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [32] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1826
+  [33] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [34] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [35] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [36]  at :0
+  [37] g_main_context_dispatch at :0
+  [38] g_main_context_iterate.isra.20 at :0
+  [39] g_main_context_iteration at :0
+  [40] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [41] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [42] QCoreApplication::exec() at :0
+  [43] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [44] __libc_start_main at :0
+  [45] _start at :0
+  [46]  at :0
+"
+2026-03-23T14:37:58.284Z,"  [0] manageSegFailure(int) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:86
+  [1]  at :0
+  [2] Rim3dView::scaleZ() const at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:1241
+  [3] RimViewLinker::updateDependentViews() at ResInsight/ApplicationLibCode/ProjectDataModel/RimViewLinker.cpp:325
+  [4] RicLinkVisibleViewsFeature::linkViews(std::vector<Rim3dView*, std::allocator<Rim3dView*> >&) at ResInsight/ApplicationLibCode/Commands/ViewLink/RicLinkVisibleViewsFeature.cpp:122
+  [5] RicLinkVisibleViewsFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/ViewLink/RicLinkVisibleViewsFeature.cpp:68
+  [6] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+  [7]  at :0
+  [8] QAction::triggered(bool) at :0
+  [9] QAction::activate(QAction::ActionEvent) at :0
+  [10]  at :0
+  [11] QAbstractButton::mouseReleaseEvent(QMouseEvent*) at :0
+  [12] QToolButton::mouseReleaseEvent(QMouseEvent*) at :0
+  [13] QWidget::event(QEvent*) at :0
+  [14] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [15] QApplication::notify(QObject*, QEvent*) at :0
+  [16] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1826
+  [17] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [18] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [19]  at :0
+  [20]  at :0
+  [21] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [22] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1826
+  [23] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [24] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [25] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [26]  at :0
+  [27] g_main_context_dispatch at :0
+  [28] g_main_context_iterate.isra.20 at :0
+  [29] g_main_context_iteration at :0
+  [30] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [31] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [32] QCoreApplication::exec() at :0
+  [33] main at ResInsight/ApplicationExeCode/RiaMain.cpp:209
+  [34] __libc_start_main at :0
+  [35] _start at :0
+  [36]  at :0
+"
+2026-03-23T13:56:09.34Z,"  [0] manageSegFailure(int) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:86
+  [1]  at :0
+  [2] syscall at :0
+  [3] absl::lts_20240722::synchronization_internal::FutexWaiter::WaitUntil(std::atomic<int>*, int, absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [4] absl::lts_20240722::synchronization_internal::FutexWaiter::Wait(absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [5] AbslInternalPerThreadSemWait_lts_20240722 at :0
+  [6] absl::lts_20240722::CondVar::WaitCommon(absl::lts_20240722::Mutex*, absl::lts_20240722::synchronization_internal::KernelTimeout) [clone .cold] at :0
+  [7] gpr_cv_wait at :0
+  [8] grpc_core::Executor::ThreadMain(void*) at :0
+  [9] grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::{lambda(void*)#1}::_FUN(void*) at :0
+  [10] start_thread at :0
+  [11] clone at :0
+  [12]  at :0
+"
+2026-03-23T13:56:09.34Z,"  [0] manageSegFailure(int) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:86
+  [1]  at :0
+  [2] syscall at :0
+  [3] absl::lts_20240722::synchronization_internal::FutexWaiter::WaitUntil(std::atomic<int>*, int, absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [4] absl::lts_20240722::synchronization_internal::FutexWaiter::Wait(absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [5] AbslInternalPerThreadSemWait_lts_20240722 at :0
+  [6] absl::lts_20240722::CondVar::WaitCommon(absl::lts_20240722::Mutex*, absl::lts_20240722::synchronization_internal::KernelTimeout) [clone .cold] at :0
+  [7] gpr_cv_wait at :0
+  [8] grpc_core::Executor::ThreadMain(void*) at :0
+  [9] grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::{lambda(void*)#1}::_FUN(void*) at :0
+  [10] start_thread at :0
+  [11] clone at :0
+  [12]  at :0
+"
+2026-03-23T13:56:09.34Z,"  [0] manageSegFailure(int) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:86
+  [1]  at :0
+  [2] syscall at :0
+  [3] absl::lts_20240722::synchronization_internal::FutexWaiter::WaitUntil(std::atomic<int>*, int, absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [4] absl::lts_20240722::synchronization_internal::FutexWaiter::Wait(absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [5] AbslInternalPerThreadSemWait_lts_20240722 at :0
+  [6] absl::lts_20240722::CondVar::WaitCommon(absl::lts_20240722::Mutex*, absl::lts_20240722::synchronization_internal::KernelTimeout) [clone .cold] at :0
+  [7] gpr_cv_wait at :0
+  [8] grpc_core::Executor::ThreadMain(void*) at :0
+  [9] grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::{lambda(void*)#1}::_FUN(void*) at :0
+  [10] start_thread at :0
+  [11] clone at :0
+  [12]  at :0
+"
+2026-03-23T13:56:09.34Z,"  [0] manageSegFailure(int) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:86
+  [1]  at :0
+  [2] syscall at :0
+  [3] absl::lts_20240722::synchronization_internal::FutexWaiter::WaitUntil(std::atomic<int>*, int, absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [4] absl::lts_20240722::synchronization_internal::FutexWaiter::Wait(absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [5] AbslInternalPerThreadSemWait_lts_20240722 at :0
+  [6] absl::lts_20240722::CondVar::WaitCommon(absl::lts_20240722::Mutex*, absl::lts_20240722::synchronization_internal::KernelTimeout) [clone .cold] at :0
+  [7] gpr_cv_wait at :0
+  [8] grpc_core::Executor::ThreadMain(void*) at :0
+  [9] grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::{lambda(void*)#1}::_FUN(void*) at :0
+  [10] start_thread at :0
+  [11] clone at :0
+  [12]  at :0
+"
+2026-03-23T13:56:09.34Z,"  [0] manageSegFailure(int) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:86
+  [1]  at :0
+  [2] syscall at :0
+  [3] absl::lts_20240722::synchronization_internal::FutexWaiter::WaitUntil(std::atomic<int>*, int, absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [4] absl::lts_20240722::synchronization_internal::FutexWaiter::Wait(absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [5] AbslInternalPerThreadSemWait_lts_20240722 at :0
+  [6] absl::lts_20240722::CondVar::WaitCommon(absl::lts_20240722::Mutex*, absl::lts_20240722::synchronization_internal::KernelTimeout) [clone .cold] at :0
+  [7] gpr_cv_wait at :0
+  [8] grpc_core::Executor::ThreadMain(void*) at :0
+  [9] grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::{lambda(void*)#1}::_FUN(void*) at :0
+  [10] start_thread at :0
+  [11] clone at :0
+  [12]  at :0
+"
+2026-03-23T13:56:09.226Z,"  [0] manageSegFailure(int) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:86
+  [1]  at :0
+  [2] syscall at :0
+  [3] absl::lts_20240722::synchronization_internal::FutexWaiter::WaitUntil(std::atomic<int>*, int, absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [4] absl::lts_20240722::synchronization_internal::FutexWaiter::Wait(absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [5] AbslInternalPerThreadSemWait_lts_20240722 at :0
+  [6] absl::lts_20240722::CondVar::WaitCommon(absl::lts_20240722::Mutex*, absl::lts_20240722::synchronization_internal::KernelTimeout) [clone .cold] at :0
+  [7] gpr_cv_wait at :0
+  [8] grpc_core::Executor::ThreadMain(void*) at :0
+  [9] grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::{lambda(void*)#1}::_FUN(void*) at :0
+  [10] start_thread at :0
+  [11] clone at :0
+  [12]  at :0
+"
+2026-03-23T13:56:09.216Z,"  [0] manageSegFailure(int) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:86
+  [1]  at :0
+  [2] poll at :0
+  [3] g_main_context_iterate.isra.20 at :0
+  [4] g_main_context_iteration at :0
+  [5] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [6] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [7] QCoreApplication::exec() at :0
+  [8] main at ResInsight/ApplicationExeCode/RiaMain.cpp:209
+  [9] __libc_start_main at :0
+  [10] _start at :0
+  [11]  at :0
+"
+2026-03-23T13:56:09.207Z,"  [0] manageSegFailure(int) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:86
+  [1]  at :0
+  [2] poll at :0
+  [3] g_main_context_iterate.isra.20 at :0
+  [4] g_main_context_iteration at :0
+  [5] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [6] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [7] QCoreApplication::exec() at :0
+  [8] main at ResInsight/ApplicationExeCode/RiaMain.cpp:209
+  [9] __libc_start_main at :0
+  [10] _start at :0
+  [11]  at :0
+"
+2026-03-23T13:56:09.206Z,"  [0] manageSegFailure(int) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:86
+  [1]  at :0
+  [2] syscall at :0
+  [3] absl::lts_20240722::synchronization_internal::FutexWaiter::WaitUntil(std::atomic<int>*, int, absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [4] absl::lts_20240722::synchronization_internal::FutexWaiter::Wait(absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [5] AbslInternalPerThreadSemWait_lts_20240722 at :0
+  [6] absl::lts_20240722::CondVar::WaitCommon(absl::lts_20240722::Mutex*, absl::lts_20240722::synchronization_internal::KernelTimeout) [clone .cold] at :0
+  [7] gpr_cv_wait at :0
+  [8] grpc_core::Executor::ThreadMain(void*) at :0
+  [9] grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::{lambda(void*)#1}::_FUN(void*) at :0
+  [10] start_thread at :0
+  [11] clone at :0
+  [12]  at :0
+"
+2026-03-23T13:56:09.203Z,"  [0] manageSegFailure(int) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:86
+  [1]  at :0
+  [2] poll at :0
+  [3] g_main_context_iterate.isra.20 at :0
+  [4] g_main_context_iteration at :0
+  [5] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [6] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [7] QCoreApplication::exec() at :0
+  [8] main at ResInsight/ApplicationExeCode/RiaMain.cpp:209
+  [9] __libc_start_main at :0
+  [10] _start at :0
+  [11]  at :0
+"
+2026-03-23T13:56:09.095Z,"  [0] manageSegFailure(int) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:86
+  [1]  at :0
+  [2] syscall at :0
+  [3] absl::lts_20240722::synchronization_internal::FutexWaiter::WaitUntil(std::atomic<int>*, int, absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [4] absl::lts_20240722::synchronization_internal::FutexWaiter::Wait(absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [5] AbslInternalPerThreadSemWait_lts_20240722 at :0
+  [6] absl::lts_20240722::CondVar::WaitCommon(absl::lts_20240722::Mutex*, absl::lts_20240722::synchronization_internal::KernelTimeout) [clone .cold] at :0
+  [7] gpr_cv_wait at :0
+  [8] grpc_core::Executor::ThreadMain(void*) at :0
+  [9] grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::{lambda(void*)#1}::_FUN(void*) at :0
+  [10] start_thread at :0
+  [11] clone at :0
+  [12]  at :0
+"
+2026-03-23T13:56:09.091Z,"  [0] manageSegFailure(int) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:86
+  [1]  at :0
+  [2] syscall at :0
+  [3] absl::lts_20240722::synchronization_internal::FutexWaiter::WaitUntil(std::atomic<int>*, int, absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [4] absl::lts_20240722::synchronization_internal::FutexWaiter::Wait(absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [5] AbslInternalPerThreadSemWait_lts_20240722 at :0
+  [6] absl::lts_20240722::CondVar::WaitCommon(absl::lts_20240722::Mutex*, absl::lts_20240722::synchronization_internal::KernelTimeout) [clone .cold] at :0
+  [7] gpr_cv_wait at :0
+  [8] grpc_core::Executor::ThreadMain(void*) at :0
+  [9] grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::{lambda(void*)#1}::_FUN(void*) at :0
+  [10] start_thread at :0
+  [11] clone at :0
+  [12]  at :0
+"
+2026-03-23T13:56:09.091Z,"  [0] manageSegFailure(int) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:86
+  [1]  at :0
+  [2] syscall at :0
+  [3] absl::lts_20240722::synchronization_internal::FutexWaiter::WaitUntil(std::atomic<int>*, int, absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [4] absl::lts_20240722::synchronization_internal::FutexWaiter::Wait(absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [5] AbslInternalPerThreadSemWait_lts_20240722 at :0
+  [6] absl::lts_20240722::CondVar::WaitCommon(absl::lts_20240722::Mutex*, absl::lts_20240722::synchronization_internal::KernelTimeout) [clone .cold] at :0
+  [7] gpr_cv_wait at :0
+  [8] grpc_core::Executor::ThreadMain(void*) at :0
+  [9] grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::{lambda(void*)#1}::_FUN(void*) at :0
+  [10] start_thread at :0
+  [11] clone at :0
+  [12]  at :0
+"
+2026-03-23T13:56:09.083Z,"  [0] manageSegFailure(int) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:86
+  [1]  at :0
+  [2] poll at :0
+  [3] g_main_context_iterate.isra.20 at :0
+  [4] g_main_context_iteration at :0
+  [5] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [6] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [7] QCoreApplication::exec() at :0
+  [8] main at ResInsight/ApplicationExeCode/RiaMain.cpp:209
+  [9] __libc_start_main at :0
+  [10] _start at :0
+  [11]  at :0
+"
+2026-03-23T13:56:09.083Z,"  [0] manageSegFailure(int) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:86
+  [1]  at :0
+  [2] poll at :0
+  [3] g_main_context_iterate.isra.20 at :0
+  [4] g_main_context_iteration at :0
+  [5] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [6] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [7] QCoreApplication::exec() at :0
+  [8] main at ResInsight/ApplicationExeCode/RiaMain.cpp:209
+  [9] __libc_start_main at :0
+  [10] _start at :0
+  [11]  at :0
+"
+2026-03-23T13:56:06.842Z,"  [0]  at :0
+  [1]  at :0
+  [2]  at :0
+  [3]  at :0
+  [4]  at :0
+  [5]  at :0
+  [6]  at :0
+  [7]  at :0
+  [8]  at :0
+  [9]  at :0
+  [10]  at :0
+  [11]  at :0
+"
+2026-03-23T13:56:06.842Z,"  [0]  at :0
+  [1]  at :0
+  [2]  at :0
+  [3]  at :0
+  [4]  at :0
+  [5]  at :0
+  [6]  at :0
+  [7]  at :0
+  [8]  at :0
+  [9]  at :0
+  [10]  at :0
+  [11]  at :0
+"
+2026-03-23T13:56:06.841Z,"  [0]  at :0
+  [1]  at :0
+  [2]  at :0
+  [3]  at :0
+  [4]  at :0
+  [5]  at :0
+  [6]  at :0
+  [7]  at :0
+  [8]  at :0
+  [9]  at :0
+  [10]  at :0
+  [11]  at :0
+"
+2026-03-23T13:56:06.841Z,"  [0]  at :0
+  [1]  at :0
+  [2]  at :0
+  [3]  at :0
+  [4]  at :0
+  [5]  at :0
+  [6]  at :0
+  [7]  at :0
+  [8]  at :0
+  [9]  at :0
+  [10]  at :0
+  [11]  at :0
+"
+2026-03-22T18:37:47.816Z,"  [0] manageSegFailure(int) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:86
+  [1]  at :0
+  [2] syscall at :0
+  [3] absl::lts_20240722::synchronization_internal::FutexWaiter::WaitUntil(std::atomic<int>*, int, absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [4] absl::lts_20240722::synchronization_internal::FutexWaiter::Wait(absl::lts_20240722::synchronization_internal::KernelTimeout) at :0
+  [5] AbslInternalPerThreadSemWait_lts_20240722 at :0
+  [6] absl::lts_20240722::CondVar::WaitCommon(absl::lts_20240722::Mutex*, absl::lts_20240722::synchronization_internal::KernelTimeout) [clone .cold] at :0
+  [7] gpr_cv_wait at :0
+  [8] grpc_core::Executor::ThreadMain(void*) at :0
+  [9] grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::{lambda(void*)#1}::_FUN(void*) at :0
+  [10] start_thread at :0
+  [11] clone at :0
+  [12]  at :0
+"
+2026-03-22T18:37:47.764Z,"  [0] manageSegFailure(int) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:86
+  [1]  at :0
+  [2] poll at :0
+  [3] g_main_context_iterate.isra.20 at :0
+  [4] g_main_context_iteration at :0
+  [5] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [6] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [7] QCoreApplication::exec() at :0
+  [8] main at ResInsight/ApplicationExeCode/RiaMain.cpp:209
+  [9] __libc_start_main at :0
+  [10] _start at :0
+  [11]  at :0
+"
+2026-03-22T08:13:41.54Z,"  [0] manageSegFailure(int) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:86
+  [1]  at :0
+  [2] poll at :0
+  [3] g_main_context_iterate.isra.20 at :0
+  [4] g_main_context_iteration at :0
+  [5] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [6] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [7] QCoreApplication::exec() at :0
+  [8] main at ResInsight/ApplicationExeCode/RiaMain.cpp:209
+  [9] __libc_start_main at :0
+  [10] _start at :0
+  [11]  at :0
+"
+2026-03-22T08:13:41.539Z,"  [0] manageSegFailure(int) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:86
+  [1]  at :0
+  [2] poll at :0
+  [3] g_main_context_iterate.isra.20 at :0
+  [4] g_main_context_iteration at :0
+  [5] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [6] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [7] QCoreApplication::exec() at :0
+  [8] main at ResInsight/ApplicationExeCode/RiaMain.cpp:209
+  [9] __libc_start_main at :0
+  [10] _start at :0
+  [11]  at :0
+"
+2026-03-22T08:11:57.24Z,"  [0] manageSegFailure(int) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:86
+  [1]  at :0
+  [2] poll at :0
+  [3] g_main_context_iterate.isra.20 at :0
+  [4] g_main_context_iteration at :0
+  [5] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [6] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [7] QCoreApplication::exec() at :0
+  [8] main at ResInsight/ApplicationExeCode/RiaMain.cpp:209
+  [9] __libc_start_main at :0
+  [10] _start at :0
+  [11]  at :0
+"
+2026-03-22T08:11:28.913Z,"  [0] manageSegFailure(int) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:86
+  [1]  at :0
+  [2] poll at :0
+  [3] g_main_context_iterate.isra.20 at :0
+  [4] g_main_context_iteration at :0
+  [5] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [6] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [7] QCoreApplication::exec() at :0
+  [8] main at ResInsight/ApplicationExeCode/RiaMain.cpp:209
+  [9] __libc_start_main at :0
+  [10] _start at :0
+  [11]  at :0
+"
+2026-03-22T08:11:28.907Z,"  [0] manageSegFailure(int) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:86
+  [1]  at :0
+  [2] poll at :0
+  [3] g_main_context_iterate.isra.20 at :0
+  [4] g_main_context_iteration at :0
+  [5] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [6] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [7] QCoreApplication::exec() at :0
+  [8] main at ResInsight/ApplicationExeCode/RiaMain.cpp:209
+  [9] __libc_start_main at :0
+  [10] _start at :0
+  [11]  at :0
+"
+2026-03-22T08:10:46.492Z,"  [0] manageSegFailure(int) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:86
+  [1]  at :0
+  [2] poll at :0
+  [3] g_main_context_iterate.isra.20 at :0
+  [4] g_main_context_iteration at :0
+  [5] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [6] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [7] QCoreApplication::exec() at :0
+  [8] main at ResInsight/ApplicationExeCode/RiaMain.cpp:209
+  [9] __libc_start_main at :0
+  [10] _start at :0
+  [11]  at :0
+"
+2026-03-22T08:10:29.679Z,"  [0] manageSegFailure(int) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:86
+  [1]  at :0
+  [2] poll at :0
+  [3] g_main_context_iterate.isra.20 at :0
+  [4] g_main_context_iteration at :0
+  [5] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [6] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [7] QCoreApplication::exec() at :0
+  [8] main at ResInsight/ApplicationExeCode/RiaMain.cpp:209
+  [9] __libc_start_main at :0
+  [10] _start at :0
+  [11]  at :0
+"
+2026-03-22T08:10:29.678Z,"  [0] manageSegFailure(int) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:86
+  [1]  at :0
+  [2] poll at :0
+  [3] g_main_context_iterate.isra.20 at :0
+  [4] g_main_context_iteration at :0
+  [5] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [6] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [7] QCoreApplication::exec() at :0
+  [8] main at ResInsight/ApplicationExeCode/RiaMain.cpp:209
+  [9] __libc_start_main at :0
+  [10] _start at :0
+  [11]  at :0
+"
+2026-03-22T08:10:29.678Z,"  [0] manageSegFailure(int) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:86
+  [1]  at :0
+  [2] poll at :0
+  [3] g_main_context_iterate.isra.20 at :0
+  [4] g_main_context_iteration at :0
+  [5] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [6] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [7] QCoreApplication::exec() at :0
+  [8] main at ResInsight/ApplicationExeCode/RiaMain.cpp:209
+  [9] __libc_start_main at :0
+  [10] _start at :0
+  [11]  at :0
+"
+2026-03-22T08:08:37.201Z,"  [0] manageSegFailure(int) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:86
+  [1]  at :0
+  [2] poll at :0
+  [3] g_main_context_iterate.isra.20 at :0
+  [4] g_main_context_iteration at :0
+  [5] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [6] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [7] QCoreApplication::exec() at :0
+  [8] main at ResInsight/ApplicationExeCode/RiaMain.cpp:209
+  [9] __libc_start_main at :0
+  [10] _start at :0
+  [11]  at :0
+"
+2026-03-22T08:08:37.201Z,"  [0] manageSegFailure(int) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:86
+  [1]  at :0
+  [2] poll at :0
+  [3] g_main_context_iterate.isra.20 at :0
+  [4] g_main_context_iteration at :0
+  [5] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [6] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [7] QCoreApplication::exec() at :0
+  [8] main at ResInsight/ApplicationExeCode/RiaMain.cpp:209
+  [9] __libc_start_main at :0
+  [10] _start at :0
+  [11]  at :0
+"
+2026-03-22T08:08:37.2Z,"  [0] manageSegFailure(int) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:86
+  [1]  at :0
+  [2] poll at :0
+  [3] g_main_context_iterate.isra.20 at :0
+  [4] g_main_context_iteration at :0
+  [5] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [6] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [7] QCoreApplication::exec() at :0
+  [8] main at ResInsight/ApplicationExeCode/RiaMain.cpp:209
+  [9] __libc_start_main at :0
+  [10] _start at :0
+  [11]  at :0
+"
+2026-03-22T08:08:37.2Z,"  [0] manageSegFailure(int) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:86
+  [1]  at :0
+  [2] poll at :0
+  [3] g_main_context_iterate.isra.20 at :0
+  [4] g_main_context_iteration at :0
+  [5] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [6] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [7] QCoreApplication::exec() at :0
+  [8] main at ResInsight/ApplicationExeCode/RiaMain.cpp:209
+  [9] __libc_start_main at :0
+  [10] _start at :0
+  [11]  at :0
+"
+2026-03-22T08:08:37.2Z,"  [0] manageSegFailure(int) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:86
+  [1]  at :0
+  [2] poll at :0
+  [3] g_main_context_iterate.isra.20 at :0
+  [4] g_main_context_iteration at :0
+  [5] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [6] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [7] QCoreApplication::exec() at :0
+  [8] main at ResInsight/ApplicationExeCode/RiaMain.cpp:209
+  [9] __libc_start_main at :0
+  [10] _start at :0
+  [11]  at :0
+"
+2026-03-22T08:08:37.2Z,"  [0] manageSegFailure(int) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:86
+  [1]  at :0
+  [2] poll at :0
+  [3] g_main_context_iterate.isra.20 at :0
+  [4] g_main_context_iteration at :0
+  [5] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [6] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [7] QCoreApplication::exec() at :0
+  [8] main at ResInsight/ApplicationExeCode/RiaMain.cpp:209
+  [9] __libc_start_main at :0
+  [10] _start at :0
+  [11]  at :0
+"
+2026-03-22T08:08:37.2Z,"  [0] manageSegFailure(int) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:86
+  [1]  at :0
+  [2] poll at :0
+  [3] g_main_context_iterate.isra.20 at :0
+  [4] g_main_context_iteration at :0
+  [5] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [6] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [7] QCoreApplication::exec() at :0
+  [8] main at ResInsight/ApplicationExeCode/RiaMain.cpp:209
+  [9] __libc_start_main at :0
+  [10] _start at :0
+  [11]  at :0
+"
+2026-03-22T08:08:37.2Z,"  [0] manageSegFailure(int) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:86
+  [1]  at :0
+  [2] poll at :0
+  [3] g_main_context_iterate.isra.20 at :0
+  [4] g_main_context_iteration at :0
+  [5] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [6] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [7] QCoreApplication::exec() at :0
+  [8] main at ResInsight/ApplicationExeCode/RiaMain.cpp:209
+  [9] __libc_start_main at :0
+  [10] _start at :0
+  [11]  at :0
+"
+2026-03-22T08:08:37.2Z,"  [0] manageSegFailure(int) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:86
+  [1]  at :0
+  [2] poll at :0
+  [3] g_main_context_iterate.isra.20 at :0
+  [4] g_main_context_iteration at :0
+  [5] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [6] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [7] QCoreApplication::exec() at :0
+  [8] main at ResInsight/ApplicationExeCode/RiaMain.cpp:209
+  [9] __libc_start_main at :0
+  [10] _start at :0
+  [11]  at :0
+"
+2026-03-22T08:08:37.2Z,"  [0] manageSegFailure(int) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:86
+  [1]  at :0
+  [2] poll at :0
+  [3] g_main_context_iterate.isra.20 at :0
+  [4] g_main_context_iteration at :0
+  [5] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [6] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [7] QCoreApplication::exec() at :0
+  [8] main at ResInsight/ApplicationExeCode/RiaMain.cpp:209
+  [9] __libc_start_main at :0
+  [10] _start at :0
+  [11]  at :0
+"
+2026-03-22T08:08:37.2Z,"  [0] manageSegFailure(int) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:86
+  [1]  at :0
+  [2] poll at :0
+  [3] g_main_context_iterate.isra.20 at :0
+  [4] g_main_context_iteration at :0
+  [5] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [6] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [7] QCoreApplication::exec() at :0
+  [8] main at ResInsight/ApplicationExeCode/RiaMain.cpp:209
+  [9] __libc_start_main at :0
+  [10] _start at :0
+  [11]  at :0
+"
+2026-03-18T12:14:34.205Z,"  [0] ResInsight+0xED6DCD at :0
+  [1] Qt6Core!QObject::qt_static_metacall+0x1816 at :0
+  [2] Qt6Core!QMetaObject::activate+0x84 at :0
+  [3] Qt6Gui!QAction::activate+0x171 at :0
+  [4] Qt6Widgets!QMenu::actionGeometry+0x5D3 at :0
+  [5] Qt6Widgets!QMenu::actionGeometry+0x3B3 at :0
+  [6] Qt6Widgets!QMenu::mouseReleaseEvent+0x11A at :0
+  [7] Qt6Widgets!QWidget::event+0x164 at :0
+  [8] Qt6Widgets!QMenu::event+0x320 at :0
+  [9] Qt6Widgets!QApplicationPrivate::notify_helper+0x10E at :0
+  [10] Qt6Widgets!QApplication::notify+0x750 at :0
+  [11] ResInsight+0x1331F7 at :0
+  [12] Qt6Core!QCoreApplication::notifyInternal2+0x11F at :0
+  [13] Qt6Widgets!QApplicationPrivate::sendMouseEvent+0x3EF at :0
+  [14] Qt6Widgets!QWidgetRepaintManager::updateStaticContentsSize+0x2CF1 at :0
+  [15] Qt6Widgets!QWidgetRepaintManager::updateStaticContentsSize+0xCE2 at :0
+  [16] Qt6Widgets!QApplicationPrivate::notify_helper+0x10E at :0
+  [17] Qt6Widgets!QApplication::notify+0x18C1 at :0
+  [18] ResInsight+0x1331F7 at :0
+  [19] Qt6Core!QCoreApplication::notifyInternal2+0x11F at :0
+  [20] Qt6Gui!QGuiApplicationPrivate::processMouseEvent+0x77D at :0
+  [21] Qt6Gui!QWindowSystemInterface::sendWindowSystemEvents+0xEA at :0
+  [22] Qt6Core!QEventDispatcherWin32::processEvents+0x90 at :0
+  [23] Qt6Gui!QWindowsGuiEventDispatcher::processEvents+0x19 at :0
+  [24] Qt6Core!QEventLoop::exec+0x19F at :0
+  [25] Qt6Core!QCoreApplication::exec+0x15D at :0
+  [26] ResInsight+0x1266711 at :0
+  [27] ResInsight!cJSON_malloc+0x47131D at :0
+  [28] ResInsight!cJSON_malloc+0x47004A at :0
+  [29] KERNEL32!BaseThreadInitThunk+0x17 at :0
+  [30] ntdll!RtlUserThreadStart+0x2C at :0
+"
+2026-03-17T07:32:21.759Z,"  [0] manageSegFailure(int) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:86
+  [1]  at :0
+  [2] __GI___poll at :0
+  [3] g_main_context_iterate.isra.20 at :0
+  [4] g_main_context_iteration at :0
+  [5] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [6] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [7] QCoreApplication::exec() at :0
+  [8] main at ResInsight/ApplicationExeCode/RiaMain.cpp:209
+  [9] __libc_start_main at :0
+  [10] _start at :0
+  [11]  at :0
+"
+2026-03-16T11:29:14.634Z,"  [0] manageSegFailure(int) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:86
+  [1]  at :0
+  [2] __read at :0
+  [3] std::__basic_file<char>::xsgetn(char*, long) at :0
+  [4] std::basic_filebuf<char, std::char_traits<char> >::underflow() at :0
+  [5] std::basic_streambuf<char, std::char_traits<char> >::xsgetn(char*, long) at :0
+  [6] std::basic_filebuf<char, std::char_traits<char> >::xsgetn(char*, long) at :0
+  [7] std::istream::read(char*, long) at :0
+  [8] Opm::EclIO::ESmry::loadData(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&) const at ResInsight/ThirdParty/custom-opm-common/opm-common/opm/io/eclipse/ESmry.cpp:806
+  [9] Opm::EclIO::ESmry::get(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const at ResInsight/ThirdParty/custom-opm-common/opm-common/opm/io/eclipse/ESmry.cpp:1381
+  [10] RifOpmCommonEclipseSummary::values(RifEclipseSummaryAddress const&) const at ResInsight/ApplicationLibCode/FileInterface/RifOpmCommonSummary.cpp:210
+  [11] RifReaderEclipseSummary::values(RifEclipseSummaryAddress const&) const at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseSummary.cpp:216
+  [12] RifMultipleSummaryReaders::values(RifEclipseSummaryAddress const&) const at ResInsight/ApplicationLibCode/FileInterface/RifMultipleSummaryReaders.cpp:105
+  [13] RimEnsembleStatisticsCase::calculate(std::vector<RimSummaryCase*, std::allocator<RimSummaryCase*> > const&, RifEclipseSummaryAddress const&, bool, std::vector<int, std::allocator<int> > const&) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimEnsembleStatisticsCase.cpp:219
+  [14] RimEnsembleCurveSet::updateStatisticsCurves(std::vector<RimSummaryCase*, std::allocator<RimSummaryCase*> > const&) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimEnsembleCurveSet.cpp:2259
+  [15] RimEnsembleCurveSet::updateStatisticsCurves() at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimEnsembleCurveSet.cpp:2421
+  [16] RimEnsembleCurveSet::computeRealizationColor() at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimEnsembleCurveSet.cpp:1370
+  [17] caf::PdmXmlObjectHandle::initAfterReadRecursively(caf::PdmObjectHandle*) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmXml/cafPdmXmlObjectHandle.cpp:407
+  [18] caf::PdmXmlObjectHandle::initAfterReadRecursively(caf::PdmObjectHandle*) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmXml/cafPdmXmlObjectHandle.cpp:401
+  [19] caf::PdmXmlObjectHandle::initAfterReadRecursively(caf::PdmObjectHandle*) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmXml/cafPdmXmlObjectHandle.cpp:401
+  [20] caf::PdmXmlObjectHandle::initAfterReadRecursively(caf::PdmObjectHandle*) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmXml/cafPdmXmlObjectHandle.cpp:401
+  [21] caf::PdmXmlObjectHandle::initAfterReadRecursively(caf::PdmObjectHandle*) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmXml/cafPdmXmlObjectHandle.cpp:401
+  [22] caf::PdmXmlObjectHandle::initAfterReadRecursively(caf::PdmObjectHandle*) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmXml/cafPdmXmlObjectHandle.cpp:401
+  [23] caf::PdmXmlObjectHandle::initAfterReadRecursively(caf::PdmObjectHandle*) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmXml/cafPdmXmlObjectHandle.cpp:401
+  [24] RiaApplication::loadProject(QString const&, RiaApplication::ProjectLoadAction, RiaProjectModifier*) at ResInsight/ApplicationLibCode/Application/RiaApplication.cpp:578
+  [25] RiaGuiApplication::handleArguments(gsl::not_null<cvf::ProgramOptions*>) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:801
+  [26] main at ResInsight/ApplicationExeCode/RiaMain.cpp:153
+  [27] __libc_start_main at :0
+  [28] _start at :0
+  [29]  at :0
+"
+2026-03-16T06:26:43.342Z,"  [0] ResInsight+0xED6DCD at :0
+  [1] Qt6Core!QObject::qt_static_metacall+0x1816 at :0
+  [2] Qt6Core!QMetaObject::activate+0x84 at :0
+  [3] Qt6Gui!QAction::activate+0x171 at :0
+  [4] Qt6Widgets!QMenu::actionGeometry+0x5D3 at :0
+  [5] Qt6Widgets!QMenu::actionGeometry+0x3B3 at :0
+  [6] Qt6Widgets!QMenu::mouseReleaseEvent+0x11A at :0
+  [7] Qt6Widgets!QWidget::event+0x164 at :0
+  [8] Qt6Widgets!QMenu::event+0x320 at :0
+  [9] Qt6Widgets!QApplicationPrivate::notify_helper+0x10E at :0
+  [10] Qt6Widgets!QApplication::notify+0x750 at :0
+  [11] ResInsight+0x1331F7 at :0
+  [12] Qt6Core!QCoreApplication::notifyInternal2+0x11F at :0
+  [13] Qt6Widgets!QApplicationPrivate::sendMouseEvent+0x3EF at :0
+  [14] Qt6Widgets!QWidgetRepaintManager::updateStaticContentsSize+0x2CF1 at :0
+  [15] Qt6Widgets!QWidgetRepaintManager::updateStaticContentsSize+0xCE2 at :0
+  [16] Qt6Widgets!QApplicationPrivate::notify_helper+0x10E at :0
+  [17] Qt6Widgets!QApplication::notify+0x18C1 at :0
+  [18] ResInsight+0x1331F7 at :0
+  [19] Qt6Core!QCoreApplication::notifyInternal2+0x11F at :0
+  [20] Qt6Gui!QGuiApplicationPrivate::processMouseEvent+0x77D at :0
+  [21] Qt6Gui!QWindowSystemInterface::sendWindowSystemEvents+0xEA at :0
+  [22] Qt6Core!QEventDispatcherWin32::processEvents+0x90 at :0
+  [23] Qt6Gui!QWindowsGuiEventDispatcher::processEvents+0x19 at :0
+  [24] Qt6Core!QEventLoop::exec+0x19F at :0
+  [25] Qt6Core!QCoreApplication::exec+0x15D at :0
+  [26] ResInsight+0x1266711 at :0
+  [27] ResInsight!cJSON_malloc+0x47131D at :0
+  [28] ResInsight!cJSON_malloc+0x47004A at :0
+  [29] KERNEL32!BaseThreadInitThunk+0x14 at :0
+  [30] ntdll!RtlUserThreadStart+0x21 at :0
+"

--- a/stacktrace-reports/incoming-csvs.md
+++ b/stacktrace-reports/incoming-csvs.md
@@ -1,0 +1,13 @@
+---
+title: Incoming CSVs
+permalink: /stacktrace-reports/incoming-csvs/
+layout: default
+---
+
+# Incoming CSVs
+
+Every raw weekly crash-report CSV received from the telemetry pipeline. Each row links to the committed CSV and to the per-week stacktrace report generated from it.
+
+| Date       | CSV                                                   | Total rows | Unique stacks | Report                                |
+|------------|-------------------------------------------------------|-----------:|--------------:|---------------------------------------|
+| 2026-04-14 | [2026-04-14-query_data.csv](./csv/2026-04-14-query_data.csv) |        163 |            34 | [2026-04-14](./reports/2026-04-14.md) |

--- a/stacktrace-reports/index.md
+++ b/stacktrace-reports/index.md
@@ -1,0 +1,13 @@
+---
+title: Weekly Stacktrace Reports
+permalink: /stacktrace-reports/index/
+layout: default
+---
+
+# Weekly Stacktrace Reports
+
+Per-week deduplicated stacktrace analyses, newest first. Each report lists unique ResInsight call stacks with occurrence counts and a link to the matching issue on [OPM/ResInsight](https://github.com/OPM/ResInsight/issues) when one is known.
+
+| Week       | Report                                | Total rows | Unique stacks |
+|------------|---------------------------------------|-----------:|--------------:|
+| 2026-04-14 | [2026-04-14](./reports/2026-04-14.md) |        163 |            34 |

--- a/stacktrace-reports/reports/2026-04-14.md
+++ b/stacktrace-reports/reports/2026-04-14.md
@@ -1,0 +1,696 @@
+---
+title: Stacktrace report 2026-04-14
+permalink: /stacktrace-reports/reports/2026-04-14/
+layout: default
+---
+
+# Stacktrace report 2026-04-14
+
+- **Source CSV:** [2026-04-14-query_data.csv](../csv/2026-04-14-query_data.csv)
+- **Total crash reports:** 163
+- **Unique call stacks:** 34
+
+## Stack #1 — count 33
+
+First seen: `2026-04-13T08:14:54.227Z`
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[13] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:121
+[14] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+```
+
+**OPM issue:** none found
+
+## Stack #2 — count 27
+
+First seen: `2026-03-23T13:56:09.216Z`
+
+```
+[0] manageSegFailure(int) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:86
+[8] main at ResInsight/ApplicationExeCode/RiaMain.cpp:209
+[9] __libc_start_main at :0
+```
+
+**OPM issue:** none found
+
+## Stack #3 — count 26
+
+First seen: `2026-03-29T07:44:11.391Z`
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+```
+
+**OPM issue:** none found
+
+## Stack #4 — count 11
+
+First seen: `2026-03-23T13:56:09.34Z`
+
+```
+[0] manageSegFailure(int) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:86
+```
+
+**OPM issue:** none found
+
+## Stack #5 — count 9
+
+First seen: `2026-03-30T03:33:28.48Z`
+
+```
+```
+
+**OPM issue:** none found
+
+## Stack #6 — count 8
+
+First seen: `2026-04-10T05:51:17.438Z`
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[9] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[10] __libc_start_main at :0
+```
+
+**OPM issue:** none found
+
+## Stack #7 — count 8
+
+First seen: `2026-04-08T12:59:59.612Z`
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[6] RiaWeightedHarmonicMeanCalculator::addValueAndWeight(double, double) at ResInsight/ApplicationLibCode/Application/Tools/RiaWeightedHarmonicMeanCalculator.cpp:39
+[7] RigContourMapCalculator::calculateHarmonicMeanValue(RigContourMapProjection const&, std::vector<std::pair<unsigned long, double>, std::allocator<std::pair<unsigned long, double> > > const&, std::vector<double, std::allocator<double> > const&) at ResInsight/ApplicationLibCode/ReservoirDataModel/ContourMap/RigContourMapCalculator.cpp:184
+[8] RigEclipseContourMapProjection::generateResults(RigEclipseContourMapProjection const&, RigContourMapGrid const&, RigCaseCellResultsData&, RigEclipseResultAddress const&, RigContourMapCalculator::ResultAggregationType, int, RigFloodingSettings&) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ReservoirDataModel/ContourMap/RigEclipseContourMapProjection.cpp:150
+```
+
+**OPM issue:** none found
+
+## Stack #8 — count 5
+
+First seen: `2026-03-29T07:44:10.472Z`
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[11] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:109
+[12] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:33
+[25] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[26] __libc_start_main at :0
+```
+
+**OPM issue:** none found
+
+## Stack #9 — count 4
+
+First seen: `2026-03-25T12:54:55.433Z`
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[3] RigWellPathGeometryExporter::computeWellPathDataForExport(RigWellPath const&, double, double, std::vector<double, std::allocator<double> >&, std::vector<double, std::allocator<double> >&, std::vector<double, std::allocator<double> >&, std::vector<double, std::allocator<double> >&) at ResInsight/ApplicationLibCode/ReservoirDataModel/Well/RigWellPathGeometryExporter.cpp:80
+[4] RimcWellPath_extractWellPathPropertiesInternal::execute() at ResInsight/ApplicationLibCode/ProjectDataModelCommands/RimcWellPath.cpp:351
+[5] RiaGrpcPdmObjectService::CallPdmObjectMethod(grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*) at ResInsight/GrpcInterface/RiaGrpcPdmObjectService.cpp:578
+[6] grpc::Status std::__invoke_impl<grpc::Status, grpc::Status (RiaGrpcPdmObjectService::*&)(grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*), RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*>(std::__invoke_memfun_ref, grpc::Status (RiaGrpcPdmObjectService::*&)(grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*), RiaGrpcPdmObjectService&, grpc::ServerContext*&&, rips::PdmObjectMethodRequest const*&&, rips::PdmObject*&&) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/invoke.h:67
+[7] std::function<grpc::Status (RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*)>::operator()(RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:591
+[8] RiaGrpcServerImpl::processAllQueuedRequests() at ResInsight/GrpcInterface/RiaGrpcServer.cpp:197
+[9] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:115
+[10] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:33
+[23] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[24] __libc_start_main at :0
+```
+
+**OPM issue:** none found
+
+## Stack #10 — count 3
+
+First seen: `2026-04-09T12:23:12.993Z`
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[3] RifHdf5Exporter::RifHdf5Exporter(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) at ResInsight/ApplicationLibCode/FileInterface/RifHdf5Exporter.cpp:34
+[4] RifHdf5SummaryExporter::ensureHdf5FileIsCreated(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool, unsigned long&) at ResInsight/ApplicationLibCode/FileInterface/RifHdf5SummaryExporter.cpp:139
+[5] RifReaderEclipseSummary::open(QString const&, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseSummary.cpp:107
+[6] RimFileSummaryCase::findRelatedFilesAndCreateReader(QString const&, bool, RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:238
+[7] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:110
+[8] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+```
+
+**OPM issue:** none found
+
+## Stack #11 — count 2
+
+First seen: `2026-04-13T08:14:54.995Z`
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[13] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:121
+[14] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+[16] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:561
+[17] RimSummaryCaseMainCollection::loadSummaryCaseData(std::vector<RimSummaryCase*, std::allocator<RimSummaryCase*> > const&, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:457
+[18] RimSummaryCaseMainCollection::createSummaryCasesFromFileInfos(std::vector<RifSummaryCaseFileResultInfo, std::allocator<RifSummaryCaseFileResultInfo> > const&, bool, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:712
+[19] RiaEnsembleImportTools::createSummaryCasesFromFiles(QList<QString> const&, RiaEnsembleImportTools::CreateConfig) at ResInsight/ApplicationLibCode/Application/Tools/Ensemble/RiaEnsembleImportTools.cpp:82
+[20] RimSummaryFileSetEnsemble::createSummaryCasesFromEnsembleFileSet(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/Ensemble/RimSummaryFileSetEnsemble.cpp:168
+[21] RimSummaryFileSetEnsemble::onLoadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/Ensemble/RimSummaryFileSetEnsemble.cpp:253
+[22] RimEnsembleFileSetTools::createSummaryEnsemblesFromFileSets(std::vector<RimEnsembleFileSet*, std::allocator<RimEnsembleFileSet*> >) at ResInsight/ApplicationLibCode/ProjectDataModel/EnsembleFileSet/RimEnsembleFileSetTools.cpp:52
+[23] RicImportEnsembleFeature::importSingleEnsembleFileSet(QList<QString> const&, bool, RiaDefines::EnsembleGroupingMode, RiaDefines::FileType, QString const&) at ResInsight/ApplicationLibCode/Commands/RicImportEnsembleFeature.cpp:185
+[24] RicImportEnsembleFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/RicImportEnsembleFeature.cpp:108
+[34] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[40] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[52] RiuPlotMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp:1058
+[60] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[65] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[76] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[77] __libc_start_main at :0
+```
+
+**OPM issue:** none found
+
+## Stack #12 — count 2
+
+First seen: `2026-04-09T16:57:31.451Z`
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[11] main at ResInsight/ApplicationExeCode/RiaMain.cpp:232
+[12] __libc_start_main at :0
+```
+
+**OPM issue:** none found
+
+## Stack #13 — count 2
+
+First seen: `2026-04-09T12:10:24.492Z`
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[3] RifHdf5Exporter::RifHdf5Exporter(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) at ResInsight/ApplicationLibCode/FileInterface/RifHdf5Exporter.cpp:34
+[4] RifHdf5SummaryExporter::ensureHdf5FileIsCreated(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool, unsigned long&) at ResInsight/ApplicationLibCode/FileInterface/RifHdf5SummaryExporter.cpp:139
+[5] RifReaderEclipseSummary::open(QString const&, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseSummary.cpp:107
+[6] RimFileSummaryCase::findRelatedFilesAndCreateReader(QString const&, bool, RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:238
+[7] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:110
+[8] RimFileSummaryCase::createSummaryReaderInterface() at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:129
+[9] RiaSummaryTools::reloadSummaryCaseAndUpdateConnectedPlots(RimSummaryCase*) at ResInsight/ApplicationLibCode/Application/Tools/Summary/RiaSummaryTools.cpp:409
+[10] RimReloadCaseTools::reloadEclipseData(RimEclipseCase*, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimReloadCaseTools.cpp:102
+[11] RicReloadCaseFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/RicReloadCaseFeature.cpp:62
+[21] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[27] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[39] RiuMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:2056
+[47] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[52] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[63] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[64] __libc_start_main at :0
+```
+
+**OPM issue:** none found
+
+## Stack #14 — count 2
+
+First seen: `2026-04-09T11:05:37.642Z`
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[13] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:121
+[14] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+[16] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:561
+[17] RimSummaryCaseMainCollection::loadSummaryCaseData(std::vector<RimSummaryCase*, std::allocator<RimSummaryCase*> > const&, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:457
+[18] RimSummaryCaseMainCollection::createSummaryCasesFromFileInfos(std::vector<RifSummaryCaseFileResultInfo, std::allocator<RifSummaryCaseFileResultInfo> > const&, bool, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:712
+[19] RiaEnsembleImportTools::createSummaryCasesFromFiles(QList<QString> const&, RiaEnsembleImportTools::CreateConfig) at ResInsight/ApplicationLibCode/Application/Tools/Ensemble/RiaEnsembleImportTools.cpp:82
+[20] RicImportSummaryCasesFeature::createAndAddSummaryCasesFromFiles(QList<QString> const&, bool) at ResInsight/ApplicationLibCode/Commands/RicImportSummaryCasesFeature.cpp:126
+[21] RicImportGeneralDataFeature::openSummaryCaseFromFileNames(QList<QString> const&, bool) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:378
+[22] RicImportGeneralDataFeature::openEclipseFilesFromFileNames(QList<QString> const&, bool, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:122
+[23] RicImportGeneralDataFeature::openEclipseFilesFromFileNames(QList<QString> const&, bool, bool) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:55
+[24] RiaApplication::openFile(QString const&) at ResInsight/ApplicationLibCode/Application/RiaApplication.cpp:421
+[25] RiuRecentFileActionProvider::slotOpenRecentFile() at ResInsight/ApplicationLibCode/UserInterface/RiuRecentFileActionProvider.cpp:134
+[34] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[40] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[51] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[52] __libc_start_main at :0
+```
+
+**OPM issue:** none found
+
+## Stack #15 — count 2
+
+First seen: `2026-04-09T08:18:03.482Z`
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[3] RigEclipseContourMapProjection::calculateColumnResult(RigCaseCellResultsData&, RigContourMapCalculator::ResultAggregationType, int, RigFloodingSettings&) at ResInsight/ApplicationLibCode/ReservoirDataModel/ContourMap/RigEclipseContourMapProjection.cpp:202
+[4] RigEclipseContourMapProjection::generateResults(RigEclipseContourMapProjection const&, RigContourMapGrid const&, RigCaseCellResultsData&, RigEclipseResultAddress const&, RigContourMapCalculator::ResultAggregationType, int, RigFloodingSettings&) at ResInsight/ApplicationLibCode/ReservoirDataModel/ContourMap/RigEclipseContourMapProjection.cpp:126
+[5] RigEclipseContourMapProjection::generateResults(RigEclipseResultAddress const&, RigContourMapCalculator::ResultAggregationType, int, RigFloodingSettings&) const at ResInsight/ApplicationLibCode/ReservoirDataModel/ContourMap/RigEclipseContourMapProjection.cpp:83
+[6] RimEclipseContourMapProjection::generateResults(int) const at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapProjection.cpp:189
+[7] RimEclipseContourMapProjection::computeMinMaxValuesAllTimeSteps() at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapProjection.cpp:376
+[8] RimContourMapProjection::minmaxValuesAllTimeSteps() at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimContourMapProjection.cpp:478
+[9] RimEclipseContourMapProjection::updateLegend() at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapProjection.cpp:117
+[10] RimEclipseContourMapView::onUpdateLegends() at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapView.cpp:445
+[11] RimEclipseContourMapView::updateGeometry() at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapView.cpp:284
+[12] Rim3dView::updateDisplayModelForCurrentTimeStepAndRedraw() at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:673
+[13] RiuViewer::setCurrentFrame(int) at ResInsight/ApplicationLibCode/UserInterface/RiuViewer.cpp:1008
+[14] RimEclipseView::onCreateDisplayModel() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp:791
+[15] RimEclipseContourMapView::onCreateDisplayModel() at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapView.cpp:205
+[16] Rim3dView::createDisplayModelAndRedraw() at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:718
+[17] RiaViewRedrawScheduler::updateAndRedrawScheduledViews() at ResInsight/ApplicationLibCode/Application/RiaViewRedrawScheduler.cpp:93
+[22] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[32] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[33] __libc_start_main at :0
+```
+
+**OPM issue:** none found
+
+## Stack #16 — count 1
+
+First seen: `2026-04-13T07:26:09.516Z`
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[13] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:121
+[14] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+[16] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:561
+[17] RimSummaryCaseMainCollection::loadSummaryCaseData(std::vector<RimSummaryCase*, std::allocator<RimSummaryCase*> > const&, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:457
+[18] RimSummaryCaseMainCollection::createSummaryCasesFromFileInfos(std::vector<RifSummaryCaseFileResultInfo, std::allocator<RifSummaryCaseFileResultInfo> > const&, bool, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:712
+[19] RiaEnsembleImportTools::createSummaryCasesFromFiles(QList<QString> const&, RiaEnsembleImportTools::CreateConfig) at ResInsight/ApplicationLibCode/Application/Tools/Ensemble/RiaEnsembleImportTools.cpp:82
+[20] RicImportSummaryCasesFeature::createAndAddSummaryCasesFromFiles(QList<QString> const&, bool) at ResInsight/ApplicationLibCode/Commands/RicImportSummaryCasesFeature.cpp:126
+[21] RicImportGeneralDataFeature::openSummaryCaseFromFileNames(QList<QString> const&, bool) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:378
+[22] RicImportGeneralDataFeature::openEclipseFilesFromFileNames(QList<QString> const&, bool, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:122
+[23] RicImportGeneralDataFeature::openEclipseFilesFromFileNames(QList<QString> const&, bool, bool) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:55
+[24] RicImportGeneralDataFeature::openFileDialog(RiaDefines::ImportFileType) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:339
+[34] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[40] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[51] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[52] __libc_start_main at :0
+```
+
+**OPM issue:** none found
+
+## Stack #17 — count 1
+
+First seen: `2026-04-10T13:26:29.41Z`
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[4] RimCorrelationMatrixPlot::createMatrix() at ResInsight/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationMatrixPlot.cpp:555
+[5] RimCorrelationMatrixPlot::onLoadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationMatrixPlot.cpp:377
+[6] RimViewWindow::loadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimViewWindow.cpp:88
+[7] RimCorrelationMatrixPlot::fieldChangedByUi(caf::PdmFieldHandle const*, QVariant const&, QVariant const&) at ResInsight/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationMatrixPlot.cpp:272
+[23] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[29] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[40] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[41] __libc_start_main at :0
+```
+
+**OPM issue:** none found
+
+## Stack #18 — count 1
+
+First seen: `2026-04-10T13:22:59.604Z`
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[6] RifElementPropertyReader::readAllElementPropertiesInFileContainingField(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) at ResInsight/ApplicationLibCode/FileInterface/RifElementPropertyReader.cpp:103
+[7] RigFemPartResultsCollection::findOrLoadScalarResult(int, RigFemResultAddress const&) at ResInsight/ApplicationLibCode/GeoMech/GeoMechDataModel/RigFemPartResultsCollection.cpp:451
+[8] RigFemPartResultsCollection::assertResultsLoaded(RigFemResultAddress const&) at ResInsight/ApplicationLibCode/GeoMech/GeoMechDataModel/RigFemPartResultsCollection.cpp:1014
+[9] RimGeoMechResultDefinition::hasResult() at ResInsight/ApplicationLibCode/ProjectDataModel/GeoMech/RimGeoMechResultDefinition.cpp:722
+[10] RimGeoMechView::isTimeStepDependentDataVisible() const at ResInsight/ApplicationLibCode/ProjectDataModel/GeoMech/RimGeoMechView.cpp:838
+[11] Rim3dView::isTimeStepDependentDataVisibleInThisOrComparisonView() const at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:603
+[12] RiuMainWindow::refreshAnimationActions() at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:1035
+[13] RiuMainWindow::selectedObjectsChanged() at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:1571
+[29] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[35] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[46] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[47] __libc_start_main at :0
+```
+
+**OPM issue:** none found
+
+## Stack #19 — count 1
+
+First seen: `2026-04-10T10:39:06.081Z`
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[6] RifElementPropertyReader::readAllElementPropertiesInFileContainingField(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) at ResInsight/ApplicationLibCode/FileInterface/RifElementPropertyReader.cpp:103
+[7] RigFemPartResultsCollection::findOrLoadScalarResult(int, RigFemResultAddress const&) at ResInsight/ApplicationLibCode/GeoMech/GeoMechDataModel/RigFemPartResultsCollection.cpp:451
+[8] RigFemPartResultsCollection::assertResultsLoaded(RigFemResultAddress const&) at ResInsight/ApplicationLibCode/GeoMech/GeoMechDataModel/RigFemPartResultsCollection.cpp:1014
+[9] RimGeoMechResultDefinition::hasResult() at ResInsight/ApplicationLibCode/ProjectDataModel/GeoMech/RimGeoMechResultDefinition.cpp:722
+[10] RimGeoMechView::isTimeStepDependentDataVisible() const at ResInsight/ApplicationLibCode/ProjectDataModel/GeoMech/RimGeoMechView.cpp:838
+[11] Rim3dView::isTimeStepDependentDataVisibleInThisOrComparisonView() const at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:603
+[12] RiuMainWindow::refreshAnimationActions() at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:1035
+[13] RiuMainWindow::selectedObjectsChanged() at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:1571
+[24] RiuMainWindowBase::selectAsCurrentItem(caf::PdmObject const*, bool) at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindowBase.cpp:273
+[25] RiuViewerCommands::handlePickAction(int, int, QFlags<Qt::KeyboardModifier>) at ResInsight/ApplicationLibCode/UserInterface/RiuViewerCommands.cpp:807
+[29] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[35] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[45] RiaOpenTelemetryManager::reportCrash(int, std::basic_stacktrace<std::allocator<std::stacktrace_entry> > const&, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > const&) at ResInsight/ApplicationLibCode/Application/Tools/Telemetry/RiaOpenTelemetryManager.cpp:415
+[46] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:174
+[47] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[52] RifElementPropertyReader::readAllElementPropertiesInFileContainingField(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) at ResInsight/ApplicationLibCode/FileInterface/RifElementPropertyReader.cpp:103
+[53] RigFemPartResultsCollection::findOrLoadScalarResult(int, RigFemResultAddress const&) at ResInsight/ApplicationLibCode/GeoMech/GeoMechDataModel/RigFemPartResultsCollection.cpp:451
+[54] RigFemPartResultsCollection::assertResultsLoaded(RigFemResultAddress const&) at ResInsight/ApplicationLibCode/GeoMech/GeoMechDataModel/RigFemPartResultsCollection.cpp:1014
+[55] RimGeoMechResultDefinition::hasResult() at ResInsight/ApplicationLibCode/ProjectDataModel/GeoMech/RimGeoMechResultDefinition.cpp:722
+[56] RiuSelectionChangedHandler::addResultCurveFromSelectionItem(RiuGeoMechSelectionItem const*) const at ResInsight/ApplicationLibCode/UserInterface/RiuSelectionChangedHandler.cpp:208
+[57] RiuSelectionChangedHandler::handleItemAppended(RiuSelectionItem const*) const at ResInsight/ApplicationLibCode/UserInterface/RiuSelectionChangedHandler.cpp:119
+[58] RiuCellAndNncPickEventHandler::handle3dPickEvent(Ric3dPickEvent const&) at ResInsight/ApplicationLibCode/UserInterface/RiuCellAndNncPickEventHandler.cpp:459
+[59] RiuViewerCommands::handlePickAction(int, int, QFlags<Qt::KeyboardModifier>) at ResInsight/ApplicationLibCode/UserInterface/RiuViewerCommands.cpp:702
+[63] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[69] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[80] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[81] __libc_start_main at :0
+```
+
+**OPM issue:** none found
+
+## Stack #20 — count 1
+
+First seen: `2026-04-10T10:39:05.787Z`
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[6] RifElementPropertyReader::readAllElementPropertiesInFileContainingField(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) at ResInsight/ApplicationLibCode/FileInterface/RifElementPropertyReader.cpp:103
+[7] RigFemPartResultsCollection::findOrLoadScalarResult(int, RigFemResultAddress const&) at ResInsight/ApplicationLibCode/GeoMech/GeoMechDataModel/RigFemPartResultsCollection.cpp:451
+[8] RigFemPartResultsCollection::assertResultsLoaded(RigFemResultAddress const&) at ResInsight/ApplicationLibCode/GeoMech/GeoMechDataModel/RigFemPartResultsCollection.cpp:1014
+[9] RimGeoMechResultDefinition::hasResult() at ResInsight/ApplicationLibCode/ProjectDataModel/GeoMech/RimGeoMechResultDefinition.cpp:722
+[10] RiuSelectionChangedHandler::addResultCurveFromSelectionItem(RiuGeoMechSelectionItem const*) const at ResInsight/ApplicationLibCode/UserInterface/RiuSelectionChangedHandler.cpp:208
+[11] RiuSelectionChangedHandler::handleItemAppended(RiuSelectionItem const*) const at ResInsight/ApplicationLibCode/UserInterface/RiuSelectionChangedHandler.cpp:119
+[12] RiuCellAndNncPickEventHandler::handle3dPickEvent(Ric3dPickEvent const&) at ResInsight/ApplicationLibCode/UserInterface/RiuCellAndNncPickEventHandler.cpp:459
+[13] RiuViewerCommands::handlePickAction(int, int, QFlags<Qt::KeyboardModifier>) at ResInsight/ApplicationLibCode/UserInterface/RiuViewerCommands.cpp:702
+[17] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[23] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[34] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[35] __libc_start_main at :0
+```
+
+**OPM issue:** none found
+
+## Stack #21 — count 1
+
+First seen: `2026-04-10T09:34:08.705Z`
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[44] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[54] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[55] __libc_start_main at :0
+```
+
+**OPM issue:** none found
+
+## Stack #22 — count 1
+
+First seen: `2026-04-09T10:46:42.894Z`
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[13] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:121
+[14] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+[16] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:561
+[17] RimSummaryCaseMainCollection::loadSummaryCaseData(std::vector<RimSummaryCase*, std::allocator<RimSummaryCase*> > const&, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:457
+[18] RimSummaryCaseMainCollection::createSummaryCasesFromFileInfos(std::vector<RifSummaryCaseFileResultInfo, std::allocator<RifSummaryCaseFileResultInfo> > const&, bool, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:712
+[19] RiaEnsembleImportTools::createSummaryCasesFromFiles(QList<QString> const&, RiaEnsembleImportTools::CreateConfig) at ResInsight/ApplicationLibCode/Application/Tools/Ensemble/RiaEnsembleImportTools.cpp:82
+[20] RimSummaryFileSetEnsemble::createSummaryCasesFromEnsembleFileSet(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/Ensemble/RimSummaryFileSetEnsemble.cpp:168
+[21] RimSummaryFileSetEnsemble::onLoadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/Ensemble/RimSummaryFileSetEnsemble.cpp:253
+[22] RimEnsembleFileSetTools::createSummaryEnsemblesFromFileSets(std::vector<RimEnsembleFileSet*, std::allocator<RimEnsembleFileSet*> >) at ResInsight/ApplicationLibCode/ProjectDataModel/EnsembleFileSet/RimEnsembleFileSetTools.cpp:52
+[23] RicImportEnsembleFeature::importSingleEnsembleFileSet(QList<QString> const&, bool, RiaDefines::EnsembleGroupingMode, RiaDefines::FileType, QString const&) at ResInsight/ApplicationLibCode/Commands/RicImportEnsembleFeature.cpp:185
+[24] RicImportEnsembleFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/RicImportEnsembleFeature.cpp:108
+[34] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[40] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[51] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[52] __libc_start_main at :0
+```
+
+**OPM issue:** none found
+
+## Stack #23 — count 1
+
+First seen: `2026-04-09T10:37:57.767Z`
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[13] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:121
+[14] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+[16] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:561
+[17] RimSummaryCaseMainCollection::loadSummaryCaseData(std::vector<RimSummaryCase*, std::allocator<RimSummaryCase*> > const&, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:457
+[18] RimSummaryCaseMainCollection::createSummaryCasesFromFileInfos(std::vector<RifSummaryCaseFileResultInfo, std::allocator<RifSummaryCaseFileResultInfo> > const&, bool, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:712
+[19] RiaEnsembleImportTools::createSummaryCasesFromFiles(QList<QString> const&, RiaEnsembleImportTools::CreateConfig) at ResInsight/ApplicationLibCode/Application/Tools/Ensemble/RiaEnsembleImportTools.cpp:82
+[20] RimSummaryFileSetEnsemble::createSummaryCasesFromEnsembleFileSet(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/Ensemble/RimSummaryFileSetEnsemble.cpp:168
+[21] RimSummaryFileSetEnsemble::onFileSetChanged(caf::SignalEmitter const*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/Ensemble/RimSummaryFileSetEnsemble.cpp:134
+[23] RicReloadSummaryCaseFeature::reloadSelectedCasesAndUpdate() at ResInsight/ApplicationLibCode/Commands/RicReloadSummaryCaseFeature.cpp:142
+[33] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[39] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[51] RiuPlotMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp:1058
+[59] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[64] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[75] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[76] __libc_start_main at :0
+```
+
+**OPM issue:** none found
+
+## Stack #24 — count 1
+
+First seen: `2026-04-09T10:29:18.564Z`
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[6] RimViewLinker::addDependentView(Rim3dView*) at ResInsight/ApplicationLibCode/ProjectDataModel/RimViewLinker.cpp:623
+[7] RicSetMasterViewFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/ViewLink/RicSetMasterViewFeature.cpp:75
+[17] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[23] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[35] RiuMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:2056
+[43] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[48] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[59] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[60] __libc_start_main at :0
+```
+
+**OPM issue:** none found
+
+## Stack #25 — count 1
+
+First seen: `2026-04-09T10:07:57.999Z`
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[3] RivSimWellPipesPartMgr::appendVirtualConnectionFactorGeo(RimEclipseView const*, unsigned long, unsigned long, caf::DisplayCoordTransform const*, double, RivSimWellPipesPartMgr::RivPipeBranchData&) at ResInsight/ApplicationLibCode/ModelVisualization/RivSimWellPipesPartMgr.cpp:311
+[4] RivSimWellPipesPartMgr::buildWellPipeParts(caf::DisplayCoordTransform const*, bool, double, int, unsigned long) at ResInsight/ApplicationLibCode/ModelVisualization/RivSimWellPipesPartMgr.cpp:280
+[5] RivSimWellPipesPartMgr::appendDynamicGeometryPartsToModel(cvf::ModelBasicList*, unsigned long, caf::DisplayCoordTransform const*) at ResInsight/ApplicationLibCode/ModelVisualization/RivSimWellPipesPartMgr.cpp:98
+[6] RivReservoirSimWellsPartMgr::appendDynamicGeometryPartsToModel(cvf::ModelBasicList*, unsigned long) at ResInsight/ApplicationLibCode/ModelVisualization/RivReservoirSimWellsPartMgr.cpp:110
+[7] RimEclipseView::appendWellsAndFracturesToModel() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp:1093
+[8] RimEclipseContourMapView::updateGeometry() at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapView.cpp:302
+[9] Rim3dView::updateDisplayModelForCurrentTimeStepAndRedraw() at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:673
+[10] RiuViewer::setCurrentFrame(int) at ResInsight/ApplicationLibCode/UserInterface/RiuViewer.cpp:1008
+[11] RimEclipseView::onCreateDisplayModel() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp:791
+[12] RimEclipseContourMapView::onCreateDisplayModel() at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapView.cpp:205
+[13] Rim3dView::createDisplayModelAndRedraw() at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:718
+[14] RiaViewRedrawScheduler::updateAndRedrawScheduledViews() at ResInsight/ApplicationLibCode/Application/RiaViewRedrawScheduler.cpp:93
+[19] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[29] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[30] __libc_start_main at :0
+```
+
+**OPM issue:** none found
+
+## Stack #26 — count 1
+
+First seen: `2026-04-08T13:00:08.832Z`
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[10] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:228
+[15] RiaWeightedHarmonicMeanCalculator::addValueAndWeight(double, double) at ResInsight/ApplicationLibCode/Application/Tools/RiaWeightedHarmonicMeanCalculator.cpp:39
+[16] RigContourMapCalculator::calculateHarmonicMeanValue(RigContourMapProjection const&, std::vector<std::pair<unsigned long, double>, std::allocator<std::pair<unsigned long, double> > > const&, std::vector<double, std::allocator<double> > const&) at ResInsight/ApplicationLibCode/ReservoirDataModel/ContourMap/RigContourMapCalculator.cpp:184
+[17] RigEclipseContourMapProjection::generateResults(RigEclipseContourMapProjection const&, RigContourMapGrid const&, RigCaseCellResultsData&, RigEclipseResultAddress const&, RigContourMapCalculator::ResultAggregationType, int, RigFloodingSettings&) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ReservoirDataModel/ContourMap/RigEclipseContourMapProjection.cpp:150
+```
+
+**OPM issue:** none found
+
+## Stack #27 — count 1
+
+First seen: `2026-04-08T09:55:07.859Z`
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[6] RicWellPathExportCompletionDataFeatureImpl::wellPathUpperGridIntersectionIJ(gsl::not_null<RimEclipseCase const*>, gsl::not_null<RimWellPath const*>, QString const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportCompletionDataFeatureImpl.cpp:1294
+[7] RicWellPathExportCompletionDataFeatureImpl::exportWelspecsToFile(RimEclipseCase*, std::shared_ptr<QFile>, std::vector<RigCompletionData, std::allocator<RigCompletionData> > const&, bool) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportCompletionDataFeatureImpl.cpp:699
+[8] RicWellPathExportCompletionDataFeatureImpl::sortAndExportCompletionsToFile(RimEclipseCase*, QString const&, QString const&, std::vector<RigCompletionData, std::allocator<RigCompletionData> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> > const&, caf::AppEnum<RicExportCompletionDataSettingsUi::CompdatExport>, bool, bool) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportCompletionDataFeatureImpl.cpp:825
+[9] RicWellPathExportCompletionDataFeatureImpl::exportCompletions(std::vector<RimWellPath*, std::allocator<RimWellPath*> > const&, RicExportCompletionDataSettingsUi const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportCompletionDataFeatureImpl.cpp:292
+[10] RicWellPathExportCompletionDataFeature::prepareExportSettingsAndExportCompletions(QString const&, std::vector<RimWellPath*, std::allocator<RimWellPath*> > const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportCompletionDataFeature.cpp:177
+[11] RicExportCompletionsForVisibleWellPathsFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportCompletionsForVisibleWellPathsFeature.cpp:75
+[21] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[27] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[39] RiuMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:2056
+[47] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[52] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[63] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[64] __libc_start_main at :0
+```
+
+**OPM issue:** none found
+
+## Stack #28 — count 1
+
+First seen: `2026-04-08T06:06:10.041Z`
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[6] RimEnsembleWellLogCurveSet::~RimEnsembleWellLogCurveSet() at ResInsight/ApplicationLibCode/ProjectDataModel/WellLog/RimEnsembleWellLogCurveSet.cpp:180
+[7] RimEnsembleWellLogCurveSet::~RimEnsembleWellLogCurveSet() at ResInsight/ApplicationLibCode/ProjectDataModel/WellLog/RimEnsembleWellLogCurveSet.cpp:182
+[8] caf::PdmChildField<RimEnsembleWellLogCurveSet*>::~PdmChildField() at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmChildField.inl:80
+[9] non-virtual thunk to RimWellLogTrack::~RimWellLogTrack() at ResInsight/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogTrack.h:92
+[10] caf::PdmChildArrayField<RimWellLogTrack*>::deleteChildren() at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmChildArrayField.inl:181
+[11] RimDepthTrackPlot::~RimDepthTrackPlot() at ResInsight/ApplicationLibCode/ProjectDataModel/RimDepthTrackPlot.cpp:189
+[12] non-virtual thunk to RimWellLogPlot::~RimWellLogPlot() at ResInsight/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogPlot.h:38
+[13] RicDeleteItemExec::redo() at ResInsight/ApplicationLibCode/Commands/RicDeleteItemExec.cpp:65
+[14] RicDeleteItemFeature::deleteObject(caf::PdmObject*) at ResInsight/ApplicationLibCode/Commands/RicDeleteItemFeature.cpp:128
+[15] RicDeleteItemFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/RicDeleteItemFeature.cpp:68
+[25] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[31] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[43] RiuPlotMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp:1058
+[51] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[56] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[67] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[68] __libc_start_main at :0
+```
+
+**OPM issue:** none found
+
+## Stack #29 — count 1
+
+First seen: `2026-03-30T04:08:38.358Z`
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[12] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[18] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[29] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[30] __libc_start_main at :0
+```
+
+**OPM issue:** none found
+
+## Stack #30 — count 1
+
+First seen: `2026-03-25T12:55:49.978Z`
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[3] RigWellPathGeometryExporter::computeWellPathDataForExport(RigWellPath const&, double, double, std::vector<double, std::allocator<double> >&, std::vector<double, std::allocator<double> >&, std::vector<double, std::allocator<double> >&, std::vector<double, std::allocator<double> >&) at ResInsight/ApplicationLibCode/ReservoirDataModel/Well/RigWellPathGeometryExporter.cpp:80
+[4] RimcWellPath_extractWellPathPropertiesInternal::execute() at ResInsight/ApplicationLibCode/ProjectDataModelCommands/RimcWellPath.cpp:351
+[5] RiaGrpcPdmObjectService::CallPdmObjectMethod(grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*) at ResInsight/GrpcInterface/RiaGrpcPdmObjectService.cpp:578
+[6] grpc::Status std::__invoke_impl<grpc::Status, grpc::Status (RiaGrpcPdmObjectService::*&)(grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*), RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*>(std::__invoke_memfun_ref, grpc::Status (RiaGrpcPdmObjectService::*&)(grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*), RiaGrpcPdmObjectService&, grpc::ServerContext*&&, rips::PdmObjectMethodRequest const*&&, rips::PdmObject*&&) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/invoke.h:67
+[7] std::function<grpc::Status (RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*)>::operator()(RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:591
+[8] RiaGrpcServerImpl::processAllQueuedRequests() at ResInsight/GrpcInterface/RiaGrpcServer.cpp:197
+[9] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:115
+[10] RiaGrpcGuiApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcGuiApplication.cpp:60
+[15] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1826
+[25] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[26] __libc_start_main at :0
+```
+
+**OPM issue:** none found
+
+## Stack #31 — count 1
+
+First seen: `2026-03-24T21:10:48.77Z`
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[16] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:109
+[17] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:33
+[30] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[31] __libc_start_main at :0
+```
+
+**OPM issue:** none found
+
+## Stack #32 — count 1
+
+First seen: `2026-03-24T08:14:19.702Z`
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[6] RifEclipseOutputFileTools::transferNncFluxData(ecl_grid_struct const*, ecl_file_view_struct const*, std::vector<double, std::allocator<double> >*, std::vector<double, std::allocator<double> >*, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseOutputFileTools.cpp:591
+[7] RifEclipseUnifiedRestartFileAccess::dynamicNNCResults(ecl_grid_struct const*, unsigned long, std::vector<double, std::allocator<double> >*, std::vector<double, std::allocator<double> >*, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseUnifiedRestartFileAccess.cpp:280
+[8] RifReaderEclipseOutput::transferDynamicNNCData(ecl_grid_struct const*, RigMainGrid*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp:774
+[9] RifReaderEclipseOutput::open(QString const&, RigEclipseCaseData*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp:494
+[10] RimEclipseResultCase::importGridAndResultMetaData(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultCase.cpp:261
+[11] RimReservoirGridEnsemble::loadGridsInSharedMode() at ResInsight/ApplicationLibCode/ProjectDataModel/RimReservoirGridEnsemble.cpp:906
+[12] RimReservoirGridEnsemble::loadGridDataFromFiles() at ResInsight/ApplicationLibCode/ProjectDataModel/RimReservoirGridEnsemble.cpp:856
+[13] RimEnsembleFileSetTools::createGridEnsemblesFromFileSets(std::vector<RimEnsembleFileSet*, std::allocator<RimEnsembleFileSet*> >) at ResInsight/ApplicationLibCode/ProjectDataModel/EnsembleFileSet/RimEnsembleFileSetTools.cpp:107
+[14] doImport at ResInsight/ApplicationLibCode/Commands/RicImportGridAndSummaryEnsembleFeature.cpp:130
+[15] RicImportGridAndSummaryEnsembleFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/RicImportGridAndSummaryEnsembleFeature.cpp:224
+[26] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1826
+[32] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1826
+[43] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[44] __libc_start_main at :0
+```
+
+**OPM issue:** none found
+
+## Stack #33 — count 1
+
+First seen: `2026-03-23T14:37:58.284Z`
+
+```
+[0] manageSegFailure(int) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:86
+[2] Rim3dView::scaleZ() const at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:1241
+[3] RimViewLinker::updateDependentViews() at ResInsight/ApplicationLibCode/ProjectDataModel/RimViewLinker.cpp:325
+[4] RicLinkVisibleViewsFeature::linkViews(std::vector<Rim3dView*, std::allocator<Rim3dView*> >&) at ResInsight/ApplicationLibCode/Commands/ViewLink/RicLinkVisibleViewsFeature.cpp:122
+[5] RicLinkVisibleViewsFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/ViewLink/RicLinkVisibleViewsFeature.cpp:68
+[16] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1826
+[22] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1826
+[33] main at ResInsight/ApplicationExeCode/RiaMain.cpp:209
+[34] __libc_start_main at :0
+```
+
+**OPM issue:** none found
+
+## Stack #34 — count 1
+
+First seen: `2026-03-16T11:29:14.634Z`
+
+```
+[0] manageSegFailure(int) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:86
+[10] RifOpmCommonEclipseSummary::values(RifEclipseSummaryAddress const&) const at ResInsight/ApplicationLibCode/FileInterface/RifOpmCommonSummary.cpp:210
+[11] RifReaderEclipseSummary::values(RifEclipseSummaryAddress const&) const at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseSummary.cpp:216
+[12] RifMultipleSummaryReaders::values(RifEclipseSummaryAddress const&) const at ResInsight/ApplicationLibCode/FileInterface/RifMultipleSummaryReaders.cpp:105
+[13] RimEnsembleStatisticsCase::calculate(std::vector<RimSummaryCase*, std::allocator<RimSummaryCase*> > const&, RifEclipseSummaryAddress const&, bool, std::vector<int, std::allocator<int> > const&) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimEnsembleStatisticsCase.cpp:219
+[14] RimEnsembleCurveSet::updateStatisticsCurves(std::vector<RimSummaryCase*, std::allocator<RimSummaryCase*> > const&) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimEnsembleCurveSet.cpp:2259
+[15] RimEnsembleCurveSet::updateStatisticsCurves() at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimEnsembleCurveSet.cpp:2421
+[16] RimEnsembleCurveSet::computeRealizationColor() at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimEnsembleCurveSet.cpp:1370
+[24] RiaApplication::loadProject(QString const&, RiaApplication::ProjectLoadAction, RiaProjectModifier*) at ResInsight/ApplicationLibCode/Application/RiaApplication.cpp:578
+[25] RiaGuiApplication::handleArguments(gsl::not_null<cvf::ProgramOptions*>) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:801
+[26] main at ResInsight/ApplicationExeCode/RiaMain.cpp:153
+[27] __libc_start_main at :0
+```
+
+**OPM issue:** none found

--- a/stacktrace-reports/reports/2026-04-14.md
+++ b/stacktrace-reports/reports/2026-04-14.md
@@ -12,7 +12,8 @@ layout: default
 
 ## Stack #1 — count 33
 
-First seen: `2026-04-13T08:14:54.227Z`
+First seen: `2026-04-09T10:37:56.909Z`  
+Last seen: `2026-04-13T08:14:54.227Z`
 
 ```
 [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
@@ -21,11 +22,12 @@ First seen: `2026-04-13T08:14:54.227Z`
 [14] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
 ```
 
-**OPM issue:** [#13883](https://github.com/OPM/ResInsight/issues/13883)
+**OPM issue:** [#13883](https://github.com/OPM/ResInsight/issues/13883) — CLOSED
 
 ## Stack #2 — count 27
 
-First seen: `2026-03-23T13:56:09.216Z`
+First seen: `2026-03-17T07:32:21.759Z`  
+Last seen: `2026-03-23T13:56:09.216Z`
 
 ```
 [0] manageSegFailure(int) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:86
@@ -37,7 +39,8 @@ First seen: `2026-03-23T13:56:09.216Z`
 
 ## Stack #3 — count 26
 
-First seen: `2026-03-29T07:44:11.391Z`
+First seen: `2026-03-24T21:10:48.736Z`  
+Last seen: `2026-03-29T07:44:11.391Z`
 
 ```
 [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
@@ -48,7 +51,8 @@ First seen: `2026-03-29T07:44:11.391Z`
 
 ## Stack #4 — count 11
 
-First seen: `2026-03-23T13:56:09.34Z`
+First seen: `2026-03-22T18:37:47.816Z`  
+Last seen: `2026-03-23T13:56:09.34Z`
 
 ```
 [0] manageSegFailure(int) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:86
@@ -58,7 +62,8 @@ First seen: `2026-03-23T13:56:09.34Z`
 
 ## Stack #5 — count 9
 
-First seen: `2026-03-30T03:33:28.48Z`
+First seen: `2026-03-16T06:26:43.342Z`  
+Last seen: `2026-03-30T03:33:28.48Z`
 
 ```
 ```
@@ -67,7 +72,8 @@ First seen: `2026-03-30T03:33:28.48Z`
 
 ## Stack #6 — count 8
 
-First seen: `2026-04-10T05:51:17.438Z`
+First seen: `2026-03-24T21:10:48.729Z`  
+Last seen: `2026-04-10T05:51:17.438Z`
 
 ```
 [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
@@ -80,7 +86,8 @@ First seen: `2026-04-10T05:51:17.438Z`
 
 ## Stack #7 — count 8
 
-First seen: `2026-04-08T12:59:59.612Z`
+First seen: `2026-04-08T12:59:58.809Z`  
+Last seen: `2026-04-08T12:59:59.612Z`
 
 ```
 [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
@@ -94,7 +101,8 @@ First seen: `2026-04-08T12:59:59.612Z`
 
 ## Stack #8 — count 5
 
-First seen: `2026-03-29T07:44:10.472Z`
+First seen: `2026-03-24T21:10:48.771Z`  
+Last seen: `2026-03-29T07:44:10.472Z`
 
 ```
 [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
@@ -105,11 +113,12 @@ First seen: `2026-03-29T07:44:10.472Z`
 [26] __libc_start_main at :0
 ```
 
-**OPM issue:** [#13881](https://github.com/OPM/ResInsight/issues/13881)
+**OPM issue:** [#13881](https://github.com/OPM/ResInsight/issues/13881) — CLOSED
 
 ## Stack #9 — count 4
 
-First seen: `2026-03-25T12:54:55.433Z`
+First seen: `2026-03-25T10:06:48.53Z`  
+Last seen: `2026-03-25T12:54:55.433Z`
 
 ```
 [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
@@ -126,11 +135,12 @@ First seen: `2026-03-25T12:54:55.433Z`
 [24] __libc_start_main at :0
 ```
 
-**OPM issue:** [#13876](https://github.com/OPM/ResInsight/issues/13876)
+**OPM issue:** [#13876](https://github.com/OPM/ResInsight/issues/13876) — CLOSED
 
 ## Stack #10 — count 3
 
-First seen: `2026-04-09T12:23:12.993Z`
+First seen: `2026-04-09T12:06:55.492Z`  
+Last seen: `2026-04-09T12:23:12.993Z`
 
 ```
 [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
@@ -147,7 +157,8 @@ First seen: `2026-04-09T12:23:12.993Z`
 
 ## Stack #11 — count 2
 
-First seen: `2026-04-13T08:14:54.995Z`
+First seen: `2026-04-09T10:43:18.121Z`  
+Last seen: `2026-04-13T08:14:54.995Z`
 
 ```
 [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
@@ -172,11 +183,12 @@ First seen: `2026-04-13T08:14:54.995Z`
 [77] __libc_start_main at :0
 ```
 
-**OPM issue:** [#13883](https://github.com/OPM/ResInsight/issues/13883)
+**OPM issue:** [#13883](https://github.com/OPM/ResInsight/issues/13883) — CLOSED
 
 ## Stack #12 — count 2
 
-First seen: `2026-04-09T16:57:31.451Z`
+First seen: `2026-04-08T18:49:18.304Z`  
+Last seen: `2026-04-09T16:57:31.451Z`
 
 ```
 [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
@@ -189,7 +201,8 @@ First seen: `2026-04-09T16:57:31.451Z`
 
 ## Stack #13 — count 2
 
-First seen: `2026-04-09T12:10:24.492Z`
+First seen: `2026-04-09T12:06:09.707Z`  
+Last seen: `2026-04-09T12:10:24.492Z`
 
 ```
 [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
@@ -216,7 +229,8 @@ First seen: `2026-04-09T12:10:24.492Z`
 
 ## Stack #14 — count 2
 
-First seen: `2026-04-09T11:05:37.642Z`
+First seen: `2026-04-09T11:01:39.887Z`  
+Last seen: `2026-04-09T11:05:37.642Z`
 
 ```
 [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
@@ -239,11 +253,12 @@ First seen: `2026-04-09T11:05:37.642Z`
 [52] __libc_start_main at :0
 ```
 
-**OPM issue:** [#13883](https://github.com/OPM/ResInsight/issues/13883)
+**OPM issue:** [#13883](https://github.com/OPM/ResInsight/issues/13883) — CLOSED
 
 ## Stack #15 — count 2
 
-First seen: `2026-04-09T08:18:03.482Z`
+First seen: `2026-04-09T08:14:27.533Z`  
+Last seen: `2026-04-09T08:18:03.482Z`
 
 ```
 [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
@@ -268,11 +283,12 @@ First seen: `2026-04-09T08:18:03.482Z`
 [33] __libc_start_main at :0
 ```
 
-**OPM issue:** [#13877](https://github.com/OPM/ResInsight/issues/13877)
+**OPM issue:** [#13877](https://github.com/OPM/ResInsight/issues/13877) — CLOSED
 
 ## Stack #16 — count 1
 
-First seen: `2026-04-13T07:26:09.516Z`
+First seen: `2026-04-13T07:26:09.516Z`  
+Last seen: `2026-04-13T07:26:09.516Z`
 
 ```
 [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
@@ -294,11 +310,12 @@ First seen: `2026-04-13T07:26:09.516Z`
 [52] __libc_start_main at :0
 ```
 
-**OPM issue:** [#13883](https://github.com/OPM/ResInsight/issues/13883)
+**OPM issue:** [#13883](https://github.com/OPM/ResInsight/issues/13883) — CLOSED
 
 ## Stack #17 — count 1
 
-First seen: `2026-04-10T13:26:29.41Z`
+First seen: `2026-04-10T13:26:29.41Z`  
+Last seen: `2026-04-10T13:26:29.41Z`
 
 ```
 [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
@@ -313,11 +330,12 @@ First seen: `2026-04-10T13:26:29.41Z`
 [41] __libc_start_main at :0
 ```
 
-**OPM issue:** [#13874](https://github.com/OPM/ResInsight/issues/13874)
+**OPM issue:** [#13874](https://github.com/OPM/ResInsight/issues/13874) — CLOSED
 
 ## Stack #18 — count 1
 
-First seen: `2026-04-10T13:22:59.604Z`
+First seen: `2026-04-10T13:22:59.604Z`  
+Last seen: `2026-04-10T13:22:59.604Z`
 
 ```
 [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
@@ -336,11 +354,12 @@ First seen: `2026-04-10T13:22:59.604Z`
 [47] __libc_start_main at :0
 ```
 
-**OPM issue:** [#13875](https://github.com/OPM/ResInsight/issues/13875)
+**OPM issue:** [#13875](https://github.com/OPM/ResInsight/issues/13875) — CLOSED
 
 ## Stack #19 — count 1
 
-First seen: `2026-04-10T10:39:06.081Z`
+First seen: `2026-04-10T10:39:06.081Z`  
+Last seen: `2026-04-10T10:39:06.081Z`
 
 ```
 [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
@@ -374,11 +393,12 @@ First seen: `2026-04-10T10:39:06.081Z`
 [81] __libc_start_main at :0
 ```
 
-**OPM issue:** [#13875](https://github.com/OPM/ResInsight/issues/13875)
+**OPM issue:** [#13875](https://github.com/OPM/ResInsight/issues/13875) — CLOSED
 
 ## Stack #20 — count 1
 
-First seen: `2026-04-10T10:39:05.787Z`
+First seen: `2026-04-10T10:39:05.787Z`  
+Last seen: `2026-04-10T10:39:05.787Z`
 
 ```
 [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
@@ -397,11 +417,12 @@ First seen: `2026-04-10T10:39:05.787Z`
 [35] __libc_start_main at :0
 ```
 
-**OPM issue:** [#13875](https://github.com/OPM/ResInsight/issues/13875)
+**OPM issue:** [#13875](https://github.com/OPM/ResInsight/issues/13875) — CLOSED
 
 ## Stack #21 — count 1
 
-First seen: `2026-04-10T09:34:08.705Z`
+First seen: `2026-04-10T09:34:08.705Z`  
+Last seen: `2026-04-10T09:34:08.705Z`
 
 ```
 [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
@@ -415,7 +436,8 @@ First seen: `2026-04-10T09:34:08.705Z`
 
 ## Stack #22 — count 1
 
-First seen: `2026-04-09T10:46:42.894Z`
+First seen: `2026-04-09T10:46:42.894Z`  
+Last seen: `2026-04-09T10:46:42.894Z`
 
 ```
 [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
@@ -437,11 +459,12 @@ First seen: `2026-04-09T10:46:42.894Z`
 [52] __libc_start_main at :0
 ```
 
-**OPM issue:** [#13883](https://github.com/OPM/ResInsight/issues/13883)
+**OPM issue:** [#13883](https://github.com/OPM/ResInsight/issues/13883) — CLOSED
 
 ## Stack #23 — count 1
 
-First seen: `2026-04-09T10:37:57.767Z`
+First seen: `2026-04-09T10:37:57.767Z`  
+Last seen: `2026-04-09T10:37:57.767Z`
 
 ```
 [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
@@ -464,11 +487,12 @@ First seen: `2026-04-09T10:37:57.767Z`
 [76] __libc_start_main at :0
 ```
 
-**OPM issue:** [#13883](https://github.com/OPM/ResInsight/issues/13883)
+**OPM issue:** [#13883](https://github.com/OPM/ResInsight/issues/13883) — CLOSED
 
 ## Stack #24 — count 1
 
-First seen: `2026-04-09T10:29:18.564Z`
+First seen: `2026-04-09T10:29:18.564Z`  
+Last seen: `2026-04-09T10:29:18.564Z`
 
 ```
 [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
@@ -484,11 +508,12 @@ First seen: `2026-04-09T10:29:18.564Z`
 [60] __libc_start_main at :0
 ```
 
-**OPM issue:** [#13878](https://github.com/OPM/ResInsight/issues/13878)
+**OPM issue:** [#13878](https://github.com/OPM/ResInsight/issues/13878) — CLOSED
 
 ## Stack #25 — count 1
 
-First seen: `2026-04-09T10:07:57.999Z`
+First seen: `2026-04-09T10:07:57.999Z`  
+Last seen: `2026-04-09T10:07:57.999Z`
 
 ```
 [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
@@ -510,11 +535,12 @@ First seen: `2026-04-09T10:07:57.999Z`
 [30] __libc_start_main at :0
 ```
 
-**OPM issue:** [#13882](https://github.com/OPM/ResInsight/issues/13882)
+**OPM issue:** [#13882](https://github.com/OPM/ResInsight/issues/13882) — CLOSED
 
 ## Stack #26 — count 1
 
-First seen: `2026-04-08T13:00:08.832Z`
+First seen: `2026-04-08T13:00:08.832Z`  
+Last seen: `2026-04-08T13:00:08.832Z`
 
 ```
 [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
@@ -529,7 +555,8 @@ First seen: `2026-04-08T13:00:08.832Z`
 
 ## Stack #27 — count 1
 
-First seen: `2026-04-08T09:55:07.859Z`
+First seen: `2026-04-08T09:55:07.859Z`  
+Last seen: `2026-04-08T09:55:07.859Z`
 
 ```
 [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
@@ -553,7 +580,8 @@ First seen: `2026-04-08T09:55:07.859Z`
 
 ## Stack #28 — count 1
 
-First seen: `2026-04-08T06:06:10.041Z`
+First seen: `2026-04-08T06:06:10.041Z`  
+Last seen: `2026-04-08T06:06:10.041Z`
 
 ```
 [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
@@ -577,11 +605,12 @@ First seen: `2026-04-08T06:06:10.041Z`
 [68] __libc_start_main at :0
 ```
 
-**OPM issue:** [#13872](https://github.com/OPM/ResInsight/issues/13872)
+**OPM issue:** [#13872](https://github.com/OPM/ResInsight/issues/13872) — CLOSED
 
 ## Stack #29 — count 1
 
-First seen: `2026-03-30T04:08:38.358Z`
+First seen: `2026-03-30T04:08:38.358Z`  
+Last seen: `2026-03-30T04:08:38.358Z`
 
 ```
 [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
@@ -596,7 +625,8 @@ First seen: `2026-03-30T04:08:38.358Z`
 
 ## Stack #30 — count 1
 
-First seen: `2026-03-25T12:55:49.978Z`
+First seen: `2026-03-25T12:55:49.978Z`  
+Last seen: `2026-03-25T12:55:49.978Z`
 
 ```
 [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
@@ -614,11 +644,12 @@ First seen: `2026-03-25T12:55:49.978Z`
 [26] __libc_start_main at :0
 ```
 
-**OPM issue:** [#13876](https://github.com/OPM/ResInsight/issues/13876)
+**OPM issue:** [#13876](https://github.com/OPM/ResInsight/issues/13876) — CLOSED
 
 ## Stack #31 — count 1
 
-First seen: `2026-03-24T21:10:48.77Z`
+First seen: `2026-03-24T21:10:48.77Z`  
+Last seen: `2026-03-24T21:10:48.77Z`
 
 ```
 [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
@@ -629,11 +660,12 @@ First seen: `2026-03-24T21:10:48.77Z`
 [31] __libc_start_main at :0
 ```
 
-**OPM issue:** [#13881](https://github.com/OPM/ResInsight/issues/13881)
+**OPM issue:** [#13881](https://github.com/OPM/ResInsight/issues/13881) — CLOSED
 
 ## Stack #32 — count 1
 
-First seen: `2026-03-24T08:14:19.702Z`
+First seen: `2026-03-24T08:14:19.702Z`  
+Last seen: `2026-03-24T08:14:19.702Z`
 
 ```
 [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
@@ -654,11 +686,12 @@ First seen: `2026-03-24T08:14:19.702Z`
 [44] __libc_start_main at :0
 ```
 
-**OPM issue:** [#13884](https://github.com/OPM/ResInsight/issues/13884)
+**OPM issue:** [#13884](https://github.com/OPM/ResInsight/issues/13884) — CLOSED
 
 ## Stack #33 — count 1
 
-First seen: `2026-03-23T14:37:58.284Z`
+First seen: `2026-03-23T14:37:58.284Z`  
+Last seen: `2026-03-23T14:37:58.284Z`
 
 ```
 [0] manageSegFailure(int) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:86
@@ -672,11 +705,12 @@ First seen: `2026-03-23T14:37:58.284Z`
 [34] __libc_start_main at :0
 ```
 
-**OPM issue:** [#13878](https://github.com/OPM/ResInsight/issues/13878)
+**OPM issue:** [#13878](https://github.com/OPM/ResInsight/issues/13878) — CLOSED
 
 ## Stack #34 — count 1
 
-First seen: `2026-03-16T11:29:14.634Z`
+First seen: `2026-03-16T11:29:14.634Z`  
+Last seen: `2026-03-16T11:29:14.634Z`
 
 ```
 [0] manageSegFailure(int) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:86
@@ -693,4 +727,4 @@ First seen: `2026-03-16T11:29:14.634Z`
 [27] __libc_start_main at :0
 ```
 
-**OPM issue:** [#13885](https://github.com/OPM/ResInsight/issues/13885)
+**OPM issue:** [#13885](https://github.com/OPM/ResInsight/issues/13885) — CLOSED

--- a/stacktrace-reports/reports/2026-04-14.md
+++ b/stacktrace-reports/reports/2026-04-14.md
@@ -21,7 +21,7 @@ First seen: `2026-04-13T08:14:54.227Z`
 [14] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
 ```
 
-**OPM issue:** none found
+**OPM issue:** [#13883](https://github.com/OPM/ResInsight/issues/13883)
 
 ## Stack #2 — count 27
 
@@ -105,7 +105,7 @@ First seen: `2026-03-29T07:44:10.472Z`
 [26] __libc_start_main at :0
 ```
 
-**OPM issue:** none found
+**OPM issue:** [#13881](https://github.com/OPM/ResInsight/issues/13881)
 
 ## Stack #9 — count 4
 
@@ -126,7 +126,7 @@ First seen: `2026-03-25T12:54:55.433Z`
 [24] __libc_start_main at :0
 ```
 
-**OPM issue:** none found
+**OPM issue:** [#13876](https://github.com/OPM/ResInsight/issues/13876)
 
 ## Stack #10 — count 3
 
@@ -172,7 +172,7 @@ First seen: `2026-04-13T08:14:54.995Z`
 [77] __libc_start_main at :0
 ```
 
-**OPM issue:** none found
+**OPM issue:** [#13883](https://github.com/OPM/ResInsight/issues/13883)
 
 ## Stack #12 — count 2
 
@@ -239,7 +239,7 @@ First seen: `2026-04-09T11:05:37.642Z`
 [52] __libc_start_main at :0
 ```
 
-**OPM issue:** none found
+**OPM issue:** [#13883](https://github.com/OPM/ResInsight/issues/13883)
 
 ## Stack #15 — count 2
 
@@ -268,7 +268,7 @@ First seen: `2026-04-09T08:18:03.482Z`
 [33] __libc_start_main at :0
 ```
 
-**OPM issue:** none found
+**OPM issue:** [#13877](https://github.com/OPM/ResInsight/issues/13877)
 
 ## Stack #16 — count 1
 
@@ -294,7 +294,7 @@ First seen: `2026-04-13T07:26:09.516Z`
 [52] __libc_start_main at :0
 ```
 
-**OPM issue:** none found
+**OPM issue:** [#13883](https://github.com/OPM/ResInsight/issues/13883)
 
 ## Stack #17 — count 1
 
@@ -313,7 +313,7 @@ First seen: `2026-04-10T13:26:29.41Z`
 [41] __libc_start_main at :0
 ```
 
-**OPM issue:** none found
+**OPM issue:** [#13874](https://github.com/OPM/ResInsight/issues/13874)
 
 ## Stack #18 — count 1
 
@@ -336,7 +336,7 @@ First seen: `2026-04-10T13:22:59.604Z`
 [47] __libc_start_main at :0
 ```
 
-**OPM issue:** none found
+**OPM issue:** [#13875](https://github.com/OPM/ResInsight/issues/13875)
 
 ## Stack #19 — count 1
 
@@ -374,7 +374,7 @@ First seen: `2026-04-10T10:39:06.081Z`
 [81] __libc_start_main at :0
 ```
 
-**OPM issue:** none found
+**OPM issue:** [#13875](https://github.com/OPM/ResInsight/issues/13875)
 
 ## Stack #20 — count 1
 
@@ -397,7 +397,7 @@ First seen: `2026-04-10T10:39:05.787Z`
 [35] __libc_start_main at :0
 ```
 
-**OPM issue:** none found
+**OPM issue:** [#13875](https://github.com/OPM/ResInsight/issues/13875)
 
 ## Stack #21 — count 1
 
@@ -437,7 +437,7 @@ First seen: `2026-04-09T10:46:42.894Z`
 [52] __libc_start_main at :0
 ```
 
-**OPM issue:** none found
+**OPM issue:** [#13883](https://github.com/OPM/ResInsight/issues/13883)
 
 ## Stack #23 — count 1
 
@@ -464,7 +464,7 @@ First seen: `2026-04-09T10:37:57.767Z`
 [76] __libc_start_main at :0
 ```
 
-**OPM issue:** none found
+**OPM issue:** [#13883](https://github.com/OPM/ResInsight/issues/13883)
 
 ## Stack #24 — count 1
 
@@ -484,7 +484,7 @@ First seen: `2026-04-09T10:29:18.564Z`
 [60] __libc_start_main at :0
 ```
 
-**OPM issue:** none found
+**OPM issue:** [#13878](https://github.com/OPM/ResInsight/issues/13878)
 
 ## Stack #25 — count 1
 
@@ -510,7 +510,7 @@ First seen: `2026-04-09T10:07:57.999Z`
 [30] __libc_start_main at :0
 ```
 
-**OPM issue:** none found
+**OPM issue:** [#13882](https://github.com/OPM/ResInsight/issues/13882)
 
 ## Stack #26 — count 1
 
@@ -577,7 +577,7 @@ First seen: `2026-04-08T06:06:10.041Z`
 [68] __libc_start_main at :0
 ```
 
-**OPM issue:** none found
+**OPM issue:** [#13872](https://github.com/OPM/ResInsight/issues/13872)
 
 ## Stack #29 — count 1
 
@@ -614,7 +614,7 @@ First seen: `2026-03-25T12:55:49.978Z`
 [26] __libc_start_main at :0
 ```
 
-**OPM issue:** none found
+**OPM issue:** [#13876](https://github.com/OPM/ResInsight/issues/13876)
 
 ## Stack #31 — count 1
 
@@ -629,7 +629,7 @@ First seen: `2026-03-24T21:10:48.77Z`
 [31] __libc_start_main at :0
 ```
 
-**OPM issue:** none found
+**OPM issue:** [#13881](https://github.com/OPM/ResInsight/issues/13881)
 
 ## Stack #32 — count 1
 
@@ -654,7 +654,7 @@ First seen: `2026-03-24T08:14:19.702Z`
 [44] __libc_start_main at :0
 ```
 
-**OPM issue:** none found
+**OPM issue:** [#13884](https://github.com/OPM/ResInsight/issues/13884)
 
 ## Stack #33 — count 1
 
@@ -672,7 +672,7 @@ First seen: `2026-03-23T14:37:58.284Z`
 [34] __libc_start_main at :0
 ```
 
-**OPM issue:** none found
+**OPM issue:** [#13878](https://github.com/OPM/ResInsight/issues/13878)
 
 ## Stack #34 — count 1
 
@@ -693,4 +693,4 @@ First seen: `2026-03-16T11:29:14.634Z`
 [27] __libc_start_main at :0
 ```
 
-**OPM issue:** none found
+**OPM issue:** [#13885](https://github.com/OPM/ResInsight/issues/13885)


### PR DESCRIPTION
## Summary

- Adds a `stacktrace-reports/` folder that publishes weekly ResInsight crash telemetry as Jekyll pages, with per-stack counts, first/last-seen timestamps, and cross-links (including OPEN/CLOSED state) to upstream issues on OPM/ResInsight.
- Ships the analyzer (`analyze_crashes.py`) with a new `--format md` mode so a maintainer can regenerate a weekly report in one command.
- Seeds the folder with one backfill week (`2026-04-14`, 163 raw rows → 34 unique stacks, 21 linked to OPM issues).

Implements #2.

## What's in the folder

```
stacktrace-reports/
  README.md                 # workflow + Jekyll conventions
  analyze_crashes.py        # grouping by RI-specific stack frames; text or md output
  analyzer-README.md        # command-line reference
  incoming-csvs.md          # table of every raw CSV received
  index.md                  # table of every weekly report, newest first
  csv/2026-04-14-query_data.csv
  reports/2026-04-14.md
```

Pages live at the repo root (not as a Jekyll collection) so the folder name matches the URL. Each MD uses the same `layout: default` front-matter as `_docs/`.

## Weekly update procedure

Documented in `stacktrace-reports/README.md`:

1. Drop the new CSV in `csv/`.
2. `python stacktrace-reports/analyze_crashes.py <csv> --format md --output stacktrace-reports/reports/<date>.md`
3. For each unique stack, `gh search issues --repo OPM/ResInsight ...` and `gh issue view NNNN --json state` to paste an `[#NNNN](url) — OPEN/CLOSED` link.
4. Append a row to `incoming-csvs.md` and `index.md`.
5. Commit together on a feature branch.

## Test plan

- [ ] Merge preview: after merge, confirm https://ceetronsolutions.github.io/resinsight-system-doc/stacktrace-reports/ renders the landing page, and that `/stacktrace-reports/reports/2026-04-14/` resolves the weekly report with the `jekyll-theme-tactile` styling.
- [ ] Click through from `incoming-csvs.md` → CSV file → weekly report to confirm relative links resolve.
- [ ] Spot-check a few OPM issue links — especially stack #33 (`Rim3dView::scaleZ` → #13878, linked by inference from the view-linking null-pointer fix) and the six stacks linked to #13883 (summary race condition) to confirm the mapping looks reasonable.
- [ ] Re-run `python stacktrace-reports/analyze_crashes.py stacktrace-reports/csv/2026-04-14-query_data.csv` (text mode) and confirm the totals still match: 163 total, 34 unique.