### PR TITLE
Triage 2c12a4cbd830: OPM #14209 / PR #14210

### DIFF
--- a/stacktrace-reports/registry.json
+++ b/stacktrace-reports/registry.json
@@ -1471,8 +1471,16 @@
     "2c12a4cbd830": {
       "last_updated": "2026-06-11",
       "notes": "",
-      "opm_issue": null,
-      "pr": null,
+      "opm_issue": {
+        "number": 14209,
+        "state": "OPEN",
+        "url": "https://github.com/OPM/ResInsight/issues/14209"
+      },
+      "pr": {
+        "branch": "fix-14209-contour-map-result-index",
+        "number": 14210,
+        "url": "https://github.com/OPM/ResInsight/pull/14210"
+      },
       "representative_stack": [
         "[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147",
         "[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227",
@@ -1484,7 +1492,7 @@
         "RigEclipseContourMapProjection::generateResults"
       ],
       "signature_id": "2c12a4cbd830",
-      "status": "new",
+      "status": "pr-open",
       "top_frame": "RigContourMapCalculator::calculateMeanValue",
       "weeks": {
         "2026-04-29": {

--- a/stacktrace-reports/reports/2026-05-08.md
+++ b/stacktrace-reports/reports/2026-05-08.md
@@ -124,7 +124,7 @@ Last seen: `2026-04-20T11:30:38.961Z`
 [4] RigEclipseContourMapProjection::generateResults(RigEclipseContourMapProjection const&, RigContourMapGrid const&, RigCaseCellResultsData&, RigEclipseResultAddress const&, RigContourMapCalculator::ResultAggregationType, int, RigFloodingSettings&) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ReservoirDataModel/ContourMap/RigEclipseContourMapProjection.cpp:150
 ```
 
-**OPM issue:** none found
+**OPM issue:** [#14209](https://github.com/OPM/ResInsight/issues/14209) — OPEN
 
 ## Stack #14 — count 4
 


### PR DESCRIPTION
Records the crash-triage outcome for signature `2c12a4cbd830` (`RigContourMapCalculator::calculateMeanValue`, out-of-range result index).

- OPM issue: OPM/ResInsight#14209
- Fix PR: OPM/ResInsight#14210

Sets the signature to `pr-open` with the issue/PR/branch metadata and re-renders `reports/2026-05-08.md`.
