### PR TITLE
#13924 Link contour-map updateGeometry crash to merged fix

### DIFF
--- a/stacktrace-reports/registry.json
+++ b/stacktrace-reports/registry.json
@@ -1471,8 +1471,16 @@
     "2c12a4cbd830": {
       "last_updated": "2026-06-11",
       "notes": "",
-      "opm_issue": null,
-      "pr": null,
+      "opm_issue": {
+        "number": 14209,
+        "state": "OPEN",
+        "url": "https://github.com/OPM/ResInsight/issues/14209"
+      },
+      "pr": {
+        "branch": "fix-14209-contour-map-result-index",
+        "number": 14210,
+        "url": "https://github.com/OPM/ResInsight/pull/14210"
+      },
       "representative_stack": [
         "[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147",
         "[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227",
@@ -1484,7 +1492,7 @@
         "RigEclipseContourMapProjection::generateResults"
       ],
       "signature_id": "2c12a4cbd830",
-      "status": "new",
+      "status": "pr-open",
       "top_frame": "RigContourMapCalculator::calculateMeanValue",
       "weeks": {
         "2026-04-29": {

--- a/stacktrace-reports/registry.json
+++ b/stacktrace-reports/registry.json
@@ -912,10 +912,18 @@
       }
     },
     "1b9375c78288": {
-      "last_updated": "2026-06-11",
-      "notes": "",
-      "opm_issue": null,
-      "pr": null,
+      "last_updated": "2026-06-12",
+      "notes": "Already fixed on dev. Original code in RimEclipseContourMapView append-to-model methods called legendConfig()->scalarMapper() unchecked; a null cvf::ref<cvf::ScalarMapper> deref via .p() produced the top frame. PR #13925 (merged 2026-04-29) added mapGrid/legendConfig/scalarMapper null guards. Field crash reports (last_seen 2026-05-06) come from released builds predating the fix.",
+      "opm_issue": {
+        "number": 13924,
+        "state": "CLOSED",
+        "url": "https://github.com/OPM/ResInsight/issues/13924"
+      },
+      "pr": {
+        "branch": "",
+        "number": 13925,
+        "url": "https://github.com/OPM/ResInsight/pull/13925"
+      },
       "representative_stack": [
         "[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147",
         "[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227",
@@ -944,7 +952,7 @@
         "RimEclipseView::onCreateDisplayModel"
       ],
       "signature_id": "1b9375c78288",
-      "status": "new",
+      "status": "resolved",
       "top_frame": "cvf::ref<cvf::ScalarMapper>::p",
       "weeks": {
         "2026-04-29": {

--- a/stacktrace-reports/reports/2026-05-08.md
+++ b/stacktrace-reports/reports/2026-05-08.md
@@ -124,7 +124,7 @@ Last seen: `2026-04-20T11:30:38.961Z`
 [4] RigEclipseContourMapProjection::generateResults(RigEclipseContourMapProjection const&, RigContourMapGrid const&, RigCaseCellResultsData&, RigEclipseResultAddress const&, RigContourMapCalculator::ResultAggregationType, int, RigFloodingSettings&) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ReservoirDataModel/ContourMap/RigEclipseContourMapProjection.cpp:150
 ```
 
-**OPM issue:** none found
+**OPM issue:** [#14209](https://github.com/OPM/ResInsight/issues/14209) — OPEN
 
 ## Stack #14 — count 4
 

--- a/stacktrace-reports/reports/2026-05-08.md
+++ b/stacktrace-reports/reports/2026-05-08.md
@@ -39,34 +39,6 @@ Last seen: `2026-05-07T13:20:21.603Z`
 
 **OPM issue:** [#11342](https://github.com/OPM/ResInsight/issues/11342) — OPEN
 
-## Stack #3 — count 19
-
-First seen: `2026-04-21T07:23:02.833Z`  
-Last seen: `2026-05-06T14:30:34.722Z`
-
-```
-[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
-[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
-[3] cvf::ref<cvf::ScalarMapper>::p() at ResInsight/Fwk/VizFwk/LibCore/cvfObject.inl:307
-[4] RimEclipseContourMapView::updateGeometry() at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapView.cpp:296
-[5] Rim3dView::updateDisplayModelForCurrentTimeStepAndRedraw() at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:673
-[6] RiuViewer::setCurrentFrame(int) at ResInsight/ApplicationLibCode/UserInterface/RiuViewer.cpp:1008
-[7] RimEclipseView::onCreateDisplayModel() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp:791
-[8] RimEclipseContourMapView::onCreateDisplayModel() at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapView.cpp:205
-[9] Rim3dView::createDisplayModelAndRedraw() at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:718
-[10] RicNewContourMapViewFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/RicNewContourMapViewFeature.cpp:149
-[11] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
-[20] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
-[26] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
-[38] RiuMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:2056
-[46] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
-[51] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
-[62] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
-[63] __libc_start_main at :0
-```
-
-**OPM issue:** none found
-
 ## Stack #4 — count 14
 
 First seen: `2026-04-14T11:04:31.079Z`  
@@ -778,6 +750,34 @@ Last seen: `2026-04-13T21:49:39.658Z`
 **OPM issue:** none found
 
 ## Closed issues
+
+## Stack #3 — count 19
+
+First seen: `2026-04-21T07:23:02.833Z`  
+Last seen: `2026-05-06T14:30:34.722Z`
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[3] cvf::ref<cvf::ScalarMapper>::p() at ResInsight/Fwk/VizFwk/LibCore/cvfObject.inl:307
+[4] RimEclipseContourMapView::updateGeometry() at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapView.cpp:296
+[5] Rim3dView::updateDisplayModelForCurrentTimeStepAndRedraw() at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:673
+[6] RiuViewer::setCurrentFrame(int) at ResInsight/ApplicationLibCode/UserInterface/RiuViewer.cpp:1008
+[7] RimEclipseView::onCreateDisplayModel() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp:791
+[8] RimEclipseContourMapView::onCreateDisplayModel() at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapView.cpp:205
+[9] Rim3dView::createDisplayModelAndRedraw() at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:718
+[10] RicNewContourMapViewFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/RicNewContourMapViewFeature.cpp:149
+[11] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+[20] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[26] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[38] RiuMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:2056
+[46] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[51] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[62] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[63] __libc_start_main at :0
+```
+
+**OPM issue:** [#13924](https://github.com/OPM/ResInsight/issues/13924) — CLOSED
 
 ## Stack #5 — count 14
 


### PR DESCRIPTION
Signature 1b9375c78288 (cvf::ref<cvf::ScalarMapper>::p in RimEclipseContourMapView::updateGeometry) is already fixed on dev.

## Findings
The original append-to-model methods in RimEclipseContourMapView called legendConfig()->scalarMapper() unchecked; a null cvf::ref<cvf::ScalarMapper> dereferenced via .p() produced the reported top frame inside updateGeometry().

## Resolution
Fixed upstream by PR OPM/ResInsight#13925 (merged 2026-04-29) for issue OPM/ResInsight#13924, which added mapGrid/legendConfig/scalarMapper null guards. Field crash reports (last_seen 2026-05-06) come from released builds predating the fix.

Registry updated: status=resolved, linked issue #13924 + PR #13925; report 2026-05-08 re-rendered.