### PR TITLE
#13922 Link polygon-filter K-index crash to merged fix

### DIFF
--- a/stacktrace-reports/registry.json
+++ b/stacktrace-reports/registry.json
@@ -1790,10 +1790,18 @@
       }
     },
     "3201b263a461": {
-      "last_updated": "2026-06-11",
-      "notes": "",
-      "opm_issue": null,
-      "pr": null,
+      "last_updated": "2026-06-12",
+      "notes": "Already fixed on dev. updateCellsKIndexEclipse received a K layer computed against the main grid and forwarded it to LGR grids with smaller cellCountK; the unguarded cellIndexFromIJKUnguarded + bounds-unchecked cell() produced an out-of-range cell whose corner-vertex access crashed in cvf::Vec3d::set inside the OpenMP parallel-for. PR #13923 (merged 2026-04-29) added a per-grid K-range guard. All 14 field hits occurred 2026-04-14, predating the fix.",
+      "opm_issue": {
+        "number": 13922,
+        "state": "CLOSED",
+        "url": "https://github.com/OPM/ResInsight/issues/13922"
+      },
+      "pr": {
+        "branch": "",
+        "number": 13923,
+        "url": "https://github.com/OPM/ResInsight/pull/13923"
+      },
       "representative_stack": [
         "[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147",
         "[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227",
@@ -1805,7 +1813,7 @@
         "RimPolygonFilter::updateCellsKIndexEclipse"
       ],
       "signature_id": "3201b263a461",
-      "status": "new",
+      "status": "resolved",
       "top_frame": "void cvf::Vector3<double>::set<cvf::Vector3<double> >",
       "weeks": {
         "2026-04-29": {

--- a/stacktrace-reports/reports/2026-05-08.md
+++ b/stacktrace-reports/reports/2026-05-08.md
@@ -39,20 +39,6 @@ Last seen: `2026-05-07T13:20:21.603Z`
 
 **OPM issue:** [#11342](https://github.com/OPM/ResInsight/issues/11342) — OPEN
 
-## Stack #4 — count 14
-
-First seen: `2026-04-14T11:04:31.079Z`  
-Last seen: `2026-04-14T11:36:29.437Z`
-
-```
-[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
-[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
-[3] void cvf::Vector3<double>::set<cvf::Vector3<double> >(cvf::Vector3<double> const&) at ResInsight/Fwk/VizFwk/LibCore/cvfVector3.inl:406
-[4] RimPolygonFilter::updateCellsKIndexEclipse(std::vector<cvf::Vector3<double>, std::allocator<cvf::Vector3<double> > > const&, RigGridBase const*, int) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/CellFilters/RimPolygonFilter.cpp:523
-```
-
-**OPM issue:** none found
-
 ## Stack #6 — count 11
 
 First seen: `2026-04-09T10:37:57.767Z`  
@@ -778,6 +764,20 @@ Last seen: `2026-05-06T14:30:34.722Z`
 ```
 
 **OPM issue:** [#13924](https://github.com/OPM/ResInsight/issues/13924) — CLOSED
+
+## Stack #4 — count 14
+
+First seen: `2026-04-14T11:04:31.079Z`  
+Last seen: `2026-04-14T11:36:29.437Z`
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[3] void cvf::Vector3<double>::set<cvf::Vector3<double> >(cvf::Vector3<double> const&) at ResInsight/Fwk/VizFwk/LibCore/cvfVector3.inl:406
+[4] RimPolygonFilter::updateCellsKIndexEclipse(std::vector<cvf::Vector3<double>, std::allocator<cvf::Vector3<double> > > const&, RigGridBase const*, int) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/CellFilters/RimPolygonFilter.cpp:523
+```
+
+**OPM issue:** [#13922](https://github.com/OPM/ResInsight/issues/13922) — CLOSED
 
 ## Stack #5 — count 14
 


### PR DESCRIPTION
Signature 3201b263a461 (cvf::Vec3d::set in RimPolygonFilter::updateCellsKIndexEclipse) is already fixed on dev.

## Findings
updateCellsKIndexEclipse received a K layer computed against the main grid and forwarded it to LGR grids with smaller cellCountK. The unguarded cellIndexFromIJKUnguarded combined with the bounds-unchecked cell() accessor produced an out-of-range cell whose corner-vertex access crashed in cvf::Vec3d::set, inside the OpenMP parallel-for.

## Resolution
Fixed upstream by PR OPM/ResInsight#13923 (merged 2026-04-29) for issue OPM/ResInsight#13922, which added a per-grid K-range guard. All 14 field hits occurred 2026-04-14, predating the fix.

Registry updated: status=resolved, linked issue #13922 + PR #13923; report 2026-05-08 re-rendered.