### PR TITLE
#13922 Link second polygon-filter K-index crash path to merged fix

### DIFF
--- a/stacktrace-reports/registry.json
+++ b/stacktrace-reports/registry.json
@@ -4234,10 +4234,18 @@
       }
     },
     "97c5e7cd9241": {
-      "last_updated": "2026-06-11",
-      "notes": "",
-      "opm_issue": null,
-      "pr": null,
+      "last_updated": "2026-06-12",
+      "notes": "Already fixed on dev. Same root cause as signature 3201b263a461 (out-of-range K forwarded to LGR grids in updateCellsKIndexEclipse, crashing in cvf::Vec3d::set inside the OpenMP parallel-for), reached here via RivReservoirViewPartMgr::computeFilterVisibility during display-model creation. PR #13923 (merged 2026-04-29, issue #13922) added the per-grid K-range guard at function entry, which covers this call path too. Both field hits occurred 2026-04-14, predating the fix.",
+      "opm_issue": {
+        "number": 13922,
+        "state": "CLOSED",
+        "url": "https://github.com/OPM/ResInsight/issues/13922"
+      },
+      "pr": {
+        "branch": "",
+        "number": 13923,
+        "url": "https://github.com/OPM/ResInsight/pull/13923"
+      },
       "representative_stack": [
         "[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147",
         "[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227",
@@ -4267,7 +4275,7 @@
         "RimPolygonFilter::updateCells"
       ],
       "signature_id": "97c5e7cd9241",
-      "status": "new",
+      "status": "resolved",
       "top_frame": "void cvf::Vector3<double>::set<cvf::Vector3<double> >",
       "weeks": {
         "2026-04-29": {

--- a/stacktrace-reports/reports/2026-05-08.md
+++ b/stacktrace-reports/reports/2026-05-08.md
@@ -128,35 +128,6 @@ Last seen: `2026-05-05T18:22:03.063Z`
 
 **OPM issue:** none found
 
-## Stack #25 — count 2
-
-First seen: `2026-04-14T11:04:31.845Z`  
-Last seen: `2026-04-14T11:36:29.383Z`
-
-```
-[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
-[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
-[3] void cvf::Vector3<double>::set<cvf::Vector3<double> >(cvf::Vector3<double> const&) at ResInsight/Fwk/VizFwk/LibCore/cvfVector3.inl:406
-[4] RimPolygonFilter::updateCellsKIndexEclipse(std::vector<cvf::Vector3<double>, std::allocator<cvf::Vector3<double> > > const&, RigGridBase const*, int) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/CellFilters/RimPolygonFilter.cpp:523
-[6] RimPolygonFilter::updateCellsKIndexEclipse(std::vector<cvf::Vector3<double>, std::allocator<cvf::Vector3<double> > > const&, RigGridBase const*, int) at ResInsight/ApplicationLibCode/ProjectDataModel/CellFilters/RimPolygonFilter.cpp:512
-[7] RimPolygonFilter::updateCellsForEclipse(std::vector<cvf::Vector3<double>, std::allocator<cvf::Vector3<double> > > const&, RimEclipseCase*) at ResInsight/ApplicationLibCode/ProjectDataModel/CellFilters/RimPolygonFilter.cpp:601
-[8] RimPolygonFilter::updateCells() at ResInsight/ApplicationLibCode/ProjectDataModel/CellFilters/RimPolygonFilter.cpp:817
-[9] RimPolygonFilter::updateCellIndexFilter(cvf::Array<unsigned char>*, cvf::Array<unsigned char>*, int) at ResInsight/ApplicationLibCode/ProjectDataModel/CellFilters/RimPolygonFilter.cpp:408
-[10] RimCellFilterCollection::updateCellVisibilityByIndex(cvf::Array<unsigned char>*, cvf::Array<unsigned char>*, unsigned long) const at ResInsight/ApplicationLibCode/ProjectDataModel/CellFilters/RimCellFilterCollection.cpp:605
-[11] RivReservoirViewPartMgr::computeFilterVisibility(RivCellSetEnum, cvf::Array<unsigned char>*, RigGridBase const*, cvf::Array<unsigned char> const*, RimCellFilterCollection const*) at ResInsight/ApplicationLibCode/ModelVisualization/RivReservoirViewPartMgr.cpp:752
-[12] RivReservoirViewPartMgr::computeVisibility(cvf::Array<unsigned char>*, RivCellSetEnum, RigGridBase*, unsigned long) at ResInsight/ApplicationLibCode/ModelVisualization/RivReservoirViewPartMgr.cpp:349
-[13] RivReservoirViewPartMgr::createGeometry(RivCellSetEnum) at ResInsight/ApplicationLibCode/ModelVisualization/RivReservoirViewPartMgr.cpp:275
-[14] RivReservoirViewPartMgr::appendStaticGeometryPartsToModel(cvf::ModelBasicList*, RivCellSetEnum, std::vector<unsigned long, std::allocator<unsigned long> > const&) at ResInsight/ApplicationLibCode/ModelVisualization/RivReservoirViewPartMgr.cpp:202
-[15] RimEclipseView::onCreateDisplayModel() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp:687
-[16] Rim3dView::createDisplayModelAndRedraw() at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:718
-[17] RiaViewRedrawScheduler::updateAndRedrawScheduledViews() at ResInsight/ApplicationLibCode/Application/RiaViewRedrawScheduler.cpp:93
-[22] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
-[32] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
-[33] __libc_start_main at :0
-```
-
-**OPM issue:** none found
-
 ## Stack #31 — count 1
 
 First seen: `2026-05-06T16:41:31.182Z`  
@@ -1154,6 +1125,35 @@ Last seen: `2026-04-30T11:01:21.351Z`
 ```
 
 **OPM issue:** [#14179](https://github.com/OPM/ResInsight/issues/14179) — CLOSED
+
+## Stack #25 — count 2
+
+First seen: `2026-04-14T11:04:31.845Z`  
+Last seen: `2026-04-14T11:36:29.383Z`
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[3] void cvf::Vector3<double>::set<cvf::Vector3<double> >(cvf::Vector3<double> const&) at ResInsight/Fwk/VizFwk/LibCore/cvfVector3.inl:406
+[4] RimPolygonFilter::updateCellsKIndexEclipse(std::vector<cvf::Vector3<double>, std::allocator<cvf::Vector3<double> > > const&, RigGridBase const*, int) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/CellFilters/RimPolygonFilter.cpp:523
+[6] RimPolygonFilter::updateCellsKIndexEclipse(std::vector<cvf::Vector3<double>, std::allocator<cvf::Vector3<double> > > const&, RigGridBase const*, int) at ResInsight/ApplicationLibCode/ProjectDataModel/CellFilters/RimPolygonFilter.cpp:512
+[7] RimPolygonFilter::updateCellsForEclipse(std::vector<cvf::Vector3<double>, std::allocator<cvf::Vector3<double> > > const&, RimEclipseCase*) at ResInsight/ApplicationLibCode/ProjectDataModel/CellFilters/RimPolygonFilter.cpp:601
+[8] RimPolygonFilter::updateCells() at ResInsight/ApplicationLibCode/ProjectDataModel/CellFilters/RimPolygonFilter.cpp:817
+[9] RimPolygonFilter::updateCellIndexFilter(cvf::Array<unsigned char>*, cvf::Array<unsigned char>*, int) at ResInsight/ApplicationLibCode/ProjectDataModel/CellFilters/RimPolygonFilter.cpp:408
+[10] RimCellFilterCollection::updateCellVisibilityByIndex(cvf::Array<unsigned char>*, cvf::Array<unsigned char>*, unsigned long) const at ResInsight/ApplicationLibCode/ProjectDataModel/CellFilters/RimCellFilterCollection.cpp:605
+[11] RivReservoirViewPartMgr::computeFilterVisibility(RivCellSetEnum, cvf::Array<unsigned char>*, RigGridBase const*, cvf::Array<unsigned char> const*, RimCellFilterCollection const*) at ResInsight/ApplicationLibCode/ModelVisualization/RivReservoirViewPartMgr.cpp:752
+[12] RivReservoirViewPartMgr::computeVisibility(cvf::Array<unsigned char>*, RivCellSetEnum, RigGridBase*, unsigned long) at ResInsight/ApplicationLibCode/ModelVisualization/RivReservoirViewPartMgr.cpp:349
+[13] RivReservoirViewPartMgr::createGeometry(RivCellSetEnum) at ResInsight/ApplicationLibCode/ModelVisualization/RivReservoirViewPartMgr.cpp:275
+[14] RivReservoirViewPartMgr::appendStaticGeometryPartsToModel(cvf::ModelBasicList*, RivCellSetEnum, std::vector<unsigned long, std::allocator<unsigned long> > const&) at ResInsight/ApplicationLibCode/ModelVisualization/RivReservoirViewPartMgr.cpp:202
+[15] RimEclipseView::onCreateDisplayModel() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp:687
+[16] Rim3dView::createDisplayModelAndRedraw() at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:718
+[17] RiaViewRedrawScheduler::updateAndRedrawScheduledViews() at ResInsight/ApplicationLibCode/Application/RiaViewRedrawScheduler.cpp:93
+[22] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[32] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[33] __libc_start_main at :0
+```
+
+**OPM issue:** [#13922](https://github.com/OPM/ResInsight/issues/13922) — CLOSED
 
 ## Stack #26 — count 2
 


### PR DESCRIPTION
Signature 97c5e7cd9241 (cvf::Vec3d::set in RimPolygonFilter::updateCellsKIndexEclipse) is already fixed on dev.

## Findings
Same root cause as signature 3201b263a461: an out-of-range K layer forwarded to LGR grids in updateCellsKIndexEclipse produces an out-of-range cell whose corner-vertex access crashes in cvf::Vec3d::set inside the OpenMP parallel-for. This signature is the same fault reached via RivReservoirViewPartMgr::computeFilterVisibility during display-model creation.

## Resolution
Fixed upstream by PR OPM/ResInsight#13923 (merged 2026-04-29) for issue OPM/ResInsight#13922, which added a per-grid K-range guard at function entry, covering this call path too. Both field hits occurred 2026-04-14, predating the fix.

Registry updated: status=resolved, linked issue #13922 + PR #13923; report 2026-05-08 re-rendered.