### PR TITLE
Triage c250d46477d4: OPM #14213 / PR #14214 (HDF5 createGroup null guard)

### DIFF
--- a/stacktrace-reports/registry.json
+++ b/stacktrace-reports/registry.json
@@ -5158,10 +5158,18 @@
       }
     },
     "c250d46477d4": {
-      "last_updated": "2026-06-11",
-      "notes": "",
-      "opm_issue": null,
-      "pr": null,
+      "last_updated": "2026-06-12",
+      "notes": "Null deref of m_hdfFile in RifHdf5Exporter::createGroup. Constructor swallows a throwing 'new H5::H5File' (#13883 made m_hdfFile reliably null on failure but did not guard the use); createGroup(nullptr, ...) then dereferences the null m_hdfFile, and the surrounding try/catch(...) cannot catch the SIGSEGV. Fix guards the else branch with 'else if ( m_hdfFile )'. Build-verified (ApplicationLibCode target, clean).",
+      "opm_issue": {
+        "number": 14213,
+        "state": "OPEN",
+        "url": "https://github.com/OPM/ResInsight/issues/14213"
+      },
+      "pr": {
+        "branch": "fix-14213-hdf5-creategroup-null",
+        "number": 14214,
+        "url": "https://github.com/OPM/ResInsight/pull/14214"
+      },
       "representative_stack": [
         "[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147",
         "[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227",
@@ -5181,7 +5189,7 @@
         "RimFileSummaryCase::findRelatedFilesAndCreateReader"
       ],
       "signature_id": "c250d46477d4",
-      "status": "new",
+      "status": "pr-open",
       "top_frame": "RifHdf5Exporter::createGroup",
       "weeks": {
         "2026-05-22": {

--- a/stacktrace-reports/registry.json
+++ b/stacktrace-reports/registry.json
@@ -182,10 +182,18 @@
       }
     },
     "041e8de8fa69": {
-      "last_updated": "2026-06-11",
-      "notes": "",
-      "opm_issue": null,
-      "pr": null,
+      "last_updated": "2026-06-12",
+      "notes": "Already fixed on dev. setValidTimeStepRangeForCase's isTimeStepInCase lambda called std::find( m_case->timeStepDates().cbegin(), m_case->timeStepDates().cend(), ... ). RimCase::timeStepDates() returns std::vector<QDateTime> by value, so cbegin()/cend() in separate invocations produced iterators into two different temporaries; passing the mismatched iterators to std::find is UB and walked off freed memory, crashing in the lambda (operator()). PR #14156 (merged 2026-06-08, issue #14155) snapshots timeStepDates() into a single local vector. All field hits (2026-05-18..2026-06-01) predate the fix.",
+      "opm_issue": {
+        "number": 14155,
+        "state": "CLOSED",
+        "url": "https://github.com/OPM/ResInsight/issues/14155"
+      },
+      "pr": {
+        "branch": "",
+        "number": 14156,
+        "url": "https://github.com/OPM/ResInsight/pull/14156"
+      },
       "representative_stack": [
         "[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147",
         "[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227",
@@ -210,7 +218,7 @@
         "caf::CmdFeature::actionTriggered"
       ],
       "signature_id": "041e8de8fa69",
-      "status": "new",
+      "status": "resolved",
       "top_frame": "operator",
       "weeks": {
         "2026-05-22": {

--- a/stacktrace-reports/reports/2026-06-05.md
+++ b/stacktrace-reports/reports/2026-06-05.md
@@ -165,7 +165,7 @@ Last seen: `2026-05-29T13:31:33.488Z`
 [11] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
 ```
 
-**OPM issue:** none found
+**OPM issue:** [#14213](https://github.com/OPM/ResInsight/issues/14213) — OPEN
 
 ## Stack #25 — count 2
 

--- a/stacktrace-reports/reports/2026-06-05.md
+++ b/stacktrace-reports/reports/2026-06-05.md
@@ -103,30 +103,6 @@ Last seen: `2026-06-02T20:12:32.248Z`
 
 **OPM issue:** none found
 
-## Stack #15 — count 2
-
-First seen: `2026-05-18T12:56:56.42Z`  
-Last seen: `2026-06-01T11:02:54.109Z`
-
-```
-[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
-[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
-[6] operator() at ResInsight/ApplicationLibCode/ProjectDataModel/Flow/RimWellAllocationOverTimePlot.cpp:813
-[7] RimWellAllocationOverTimePlot::setValidTimeStepRangeForCase() at ResInsight/ApplicationLibCode/ProjectDataModel/Flow/RimWellAllocationOverTimePlot.cpp:815
-[8] RimWellAllocationOverTimePlot::setFromSimulationWell(RimSimWellInView*) at ResInsight/ApplicationLibCode/ProjectDataModel/Flow/RimWellAllocationOverTimePlot.cpp:164
-[9] RicShowWellAllocationPlotFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/FlowCommands/RicShowWellAllocationPlotFeature.cpp:99
-[10] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
-[19] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
-[25] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
-[37] RiuViewerCommands::displayContextMenu(QMouseEvent*) at ResInsight/ApplicationLibCode/UserInterface/RiuViewerCommands.cpp:648
-[41] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
-[47] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
-[58] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
-[59] __libc_start_main at :0
-```
-
-**OPM issue:** none found
-
 ## Stack #22 — count 2
 
 First seen: `2026-06-04T13:25:41.101Z`  
@@ -1072,6 +1048,30 @@ Last seen: `2026-06-05T10:08:05.555Z`
 ```
 
 **OPM issue:** [#14007](https://github.com/OPM/ResInsight/issues/14007) — CLOSED
+
+## Stack #15 — count 2
+
+First seen: `2026-05-18T12:56:56.42Z`  
+Last seen: `2026-06-01T11:02:54.109Z`
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[6] operator() at ResInsight/ApplicationLibCode/ProjectDataModel/Flow/RimWellAllocationOverTimePlot.cpp:813
+[7] RimWellAllocationOverTimePlot::setValidTimeStepRangeForCase() at ResInsight/ApplicationLibCode/ProjectDataModel/Flow/RimWellAllocationOverTimePlot.cpp:815
+[8] RimWellAllocationOverTimePlot::setFromSimulationWell(RimSimWellInView*) at ResInsight/ApplicationLibCode/ProjectDataModel/Flow/RimWellAllocationOverTimePlot.cpp:164
+[9] RicShowWellAllocationPlotFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/FlowCommands/RicShowWellAllocationPlotFeature.cpp:99
+[10] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+[19] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[25] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[37] RiuViewerCommands::displayContextMenu(QMouseEvent*) at ResInsight/ApplicationLibCode/UserInterface/RiuViewerCommands.cpp:648
+[41] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[47] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[58] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[59] __libc_start_main at :0
+```
+
+**OPM issue:** [#14155](https://github.com/OPM/ResInsight/issues/14155) — CLOSED
 
 ## Stack #16 — count 2
 


### PR DESCRIPTION
Signature c250d46477d4 — null deref in RifHdf5Exporter::createGroup. Verified fix, OPM issue #14213 filed and PR OPM/ResInsight#14214 opened.

## Root cause
The RifHdf5Exporter constructor swallows a throwing 'new H5::H5File' and leaves m_hdfFile null (#13883 made this reliable but did not guard the use). When HDF5 summary export targets a file that cannot be created (unwritable directory, locked file, disk full, invalid path), writeGeneralSection calls createGroup(nullptr, "general"), which dereferences the null m_hdfFile. The surrounding try/catch(...) cannot catch the resulting SIGSEGV. Crashes are dated after #13883, confirming it is still live.

## Fix
Guard the else branch with 'else if ( m_hdfFile )', mirroring the existing parentGroup null check in the same function. Build-verified (ApplicationLibCode target, clean).

Registry updated: status=pr-open, linked issue #14213 + PR #14214; report 2026-06-05 re-rendered.