### PR TITLE
Add 2026-06-20 stacktrace report (223 reports, 73 stacks)

### DIFF
--- a/stacktrace-reports/csv/2026-06-20-query_data.csv
+++ b/stacktrace-reports/csv/2026-06-20-query_data.csv
@@ -1,0 +1,11081 @@
+timestamp,APPversion,rawstack
+2026-06-19T19:00:34.761Z,2026.06.0,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:167
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:263
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] caf::PdmFieldUiCap<caf::PdmPtrField<RimSummaryEnsemble*> >::setValueFromUiEditor(QVariant const&, bool) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafInternalPdmUiFieldCapability.inl:30
+  [6] caf::CmdFieldChangeExec::redo() at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFieldChangeExec.cpp:139
+  [7] QUndoStack::push(QUndoCommand*) at :0
+  [8] caf::CmdUiCommandSystemImpl::fieldChangedCommand(std::vector<caf::PdmFieldHandle*, std::allocator<caf::PdmFieldHandle*> > const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdUiCommandSystemImpl.cpp:146
+  [9] caf::PdmUiCommandSystemProxy::setUiValueToField(caf::PdmUiFieldHandle*, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiCommandSystemProxy.cpp:113
+  [10] caf::PdmUiComboBoxEditor::slotIndexActivated(int) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiComboBoxEditor.cpp:455
+  [11]  at :0
+  [12] QComboBox::activated(int) at :0
+  [13]  at :0
+  [14]  at :0
+  [15]  at :0
+  [16] QComboBoxPrivateContainer::itemSelected(QModelIndex const&) at :0
+  [17] QComboBoxPrivateContainer::eventFilter(QObject*, QEvent*) at :0
+  [18] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [19] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [20] QApplication::notify(QObject*, QEvent*) at :0
+  [21] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1831
+  [22] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [23] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [24]  at :0
+  [25]  at :0
+  [26] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [27] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1831
+  [28] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [29] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [30] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [31]  at :0
+  [32] g_main_context_dispatch at :0
+  [33] g_main_context_iterate.isra.20 at :0
+  [34] g_main_context_iteration at :0
+  [35] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [36] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [37] QCoreApplication::exec() at :0
+  [38] main at ResInsight/ApplicationExeCode/RiaMain.cpp:258
+  [39] __libc_start_main at :0
+  [40] _start at :0
+  [41]  at :0
+"
+2026-06-19T15:16:33.637Z,2026.06.1-dev.01,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:167
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:263
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() at /var/tmp/vkip/gcc-13.3.0_source/gcc-13.3.0/libstdc++-v3/libsupc++/vterminate.cc:95
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at /var/tmp/vkip/gcc-13.3.0_source/gcc-13.3.0/libstdc++-v3/libsupc++/eh_terminate.cc:48
+  [9] std::terminate() at /var/tmp/vkip/gcc-13.3.0_source/gcc-13.3.0/libstdc++-v3/libsupc++/eh_terminate.cc:58
+  [10] __cxa_throw at /var/tmp/vkip/gcc-13.3.0_source/gcc-13.3.0/libstdc++-v3/libsupc++/eh_throw.cc:98
+  [11] std::__throw_out_of_range(char const*) at /var/tmp/vkip/gcc-13.3.0_source/gcc-13.3.0/libstdc++-v3/src/c++11/functexcept.cc:86
+  [12] std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<int, std::allocator<int> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::vector<int, std::allocator<int> > > > >::at(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/stl_map.h:562
+  [13] ecl_file_view_iget_named_file_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_view.cpp:127
+  [14] ecl_file_view_iget_named_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_view.cpp:224
+  [15] RifEclipseOutputFileTools::findAvailablePhases(ecl_file_struct const*) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseOutputFileTools.cpp:585
+  [16] RifEclipseUnifiedRestartFileAccess::openFile() at ResInsight/ApplicationLibCode/FileInterface/RifEclipseUnifiedRestartFileAccess.cpp:125
+  [17] RifEclipseUnifiedRestartFileAccess::extractTimestepsFromEclipse() at ResInsight/ApplicationLibCode/FileInterface/RifEclipseUnifiedRestartFileAccess.cpp:152
+  [18] RifEclipseUnifiedRestartFileAccess::timeSteps(std::vector<QDateTime, std::allocator<QDateTime> >*, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseUnifiedRestartFileAccess.cpp:206
+  [19] RimEclipseResultCase::importGridAndResultMetaData(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultCase.cpp:216
+  [20] RiaImportEclipseCaseTools::openEclipseCaseShowTimeStepFilterImpl(QString const&, bool, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:372
+  [21] RiaImportEclipseCaseTools::openEclipseCasesFromFile(QList<QString> const&, bool, std::map<QString, int, std::less<QString>, std::allocator<std::pair<QString const, int> > >*, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:107
+  [22] RicImportGeneralDataFeature::openEclipseCaseFromFileNames(QList<QString> const&, bool, std::vector<int, std::allocator<int> >&, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:363
+  [23] RicImportGeneralDataFeature::openEclipseFilesFromFileNames(QList<QString> const&, bool, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:105
+  [24] RicImportGeneralDataFeature::openEclipseFilesFromFileNames(QList<QString> const&, bool, bool) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:56
+  [25] RiaGuiApplication::handleArguments(gsl::not_null<cvf::ProgramOptions*>) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:847
+  [26] main at ResInsight/ApplicationExeCode/RiaMain.cpp:202
+  [27] __libc_start_main at :0
+  [28] _start at :0
+  [29]  at :0
+"
+2026-06-19T10:45:44.403Z,2026.06.0,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:167
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:263
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RimEclipsePropertyFilterCollection* caf::PdmObjectHandle::firstAncestorOrThisOfTypeAsserted<RimEclipsePropertyFilterCollection>() const at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmObjectHandle.h:249
+  [6] QUndoStack::push(QUndoCommand*) at :0
+  [7] RicEclipsePropertyFilterInsertFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/EclipseCommands/RicEclipsePropertyFilterInsertFeature.cpp:58
+  [8] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+  [9]  at :0
+  [10] QAction::triggered(bool) at :0
+  [11] QAction::activate(QAction::ActionEvent) at :0
+  [12]  at :0
+  [13]  at :0
+  [14] QWidget::event(QEvent*) at :0
+  [15] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [16] QApplication::notify(QObject*, QEvent*) at :0
+  [17] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1831
+  [18] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [19] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [20]  at :0
+  [21]  at :0
+  [22] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [23] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1831
+  [24] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [25] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [26] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [27]  at :0
+  [28] g_main_context_dispatch at :0
+  [29] g_main_context_iterate.isra.20 at :0
+  [30] g_main_context_iteration at :0
+  [31] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [32] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [33]  at :0
+  [34] QMenu::exec(QPoint const&, QAction*) at :0
+  [35] RiuMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:2092
+  [36]  at :0
+  [37] QWidget::customContextMenuRequested(QPoint const&) at :0
+  [38] QWidget::event(QEvent*) at :0
+  [39] QFrame::event(QEvent*) at :0
+  [40] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [41] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [42] QApplication::notify(QObject*, QEvent*) at :0
+  [43] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1831
+  [44] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [45]  at :0
+  [46]  at :0
+  [47] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [48] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1831
+  [49] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [50] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [51] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [52]  at :0
+  [53] g_main_context_dispatch at :0
+  [54] g_main_context_iterate.isra.20 at :0
+  [55] g_main_context_iteration at :0
+  [56] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [57] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [58] QCoreApplication::exec() at :0
+  [59] main at ResInsight/ApplicationExeCode/RiaMain.cpp:258
+  [60] __libc_start_main at :0
+  [61] _start at :0
+  [62]  at :0
+"
+2026-06-18T13:25:23.569Z,2026.06.0,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:167
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:263
+  [2]  at :0
+  [3] caf::PdmUiFieldHandle::enableAutoValue(bool, bool) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiFieldHandle.cpp:164
+  [4] caf::PdmUiLineEditor::slotEditingFinished() at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiLineEditor.cpp:355
+  [5]  at :0
+  [6] QLineEdit::focusOutEvent(QFocusEvent*) at :0
+  [7] QWidget::event(QEvent*) at :0
+  [8] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [9] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1831
+  [10] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [11] QApplicationPrivate::setFocusWidget(QWidget*, Qt::FocusReason) at :0
+  [12] QWidget::setFocus(Qt::FocusReason) at :0
+  [13] QWidget::focusNextPrevChild(bool) at :0
+  [14] QScrollArea::focusNextPrevChild(bool) at :0
+  [15] QScrollArea::focusNextPrevChild(bool) at :0
+  [16] QWidgetPrivate::hide_helper() at :0
+  [17] QWidgetPrivate::setVisible(bool) at :0
+  [18] caf::PdmUiFormLayoutObjectEditor::cleanupBeforeSettingPdmObject() at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiFormLayoutObjectEditor.cpp:607
+  [19] caf::PdmUiObjectEditorHandle::setPdmObject(caf::PdmObjectHandle*) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiObjectEditorHandle.cpp:66
+  [20] caf::PdmUiPropertyView::showProperties(caf::PdmObjectHandle*) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiPropertyView.cpp:211
+  [21] RiuPlotMainWindow::selectedObjectsChanged(caf::PdmUiTreeView*, caf::PdmUiPropertyView*) at ResInsight/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp:962
+  [22]  at :0
+  [23] caf::PdmUiTreeView::slotOnSelectionChanged() at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeView.cpp:154
+  [24]  at :0
+  [25]  at :0
+  [26] QItemSelectionModel::selectionChanged(QItemSelection const&, QItemSelection const&) at :0
+  [27]  at :0
+  [28]  at :0
+  [29] QAbstractItemModel::rowsAboutToBeRemoved(QModelIndex const&, int, int, QAbstractItemModel::QPrivateSignal) at :0
+  [30] QAbstractItemModel::beginRemoveRows(QModelIndex const&, int, int) at :0
+  [31]  at :0
+  [32]  at :0
+  [33]  at :0
+  [34]  at :0
+  [35] QAbstractItemModel::rowsAboutToBeRemoved(QModelIndex const&, int, int, QAbstractItemModel::QPrivateSignal) at :0
+  [36] QAbstractItemModel::beginRemoveRows(QModelIndex const&, int, int) at :0
+  [37] caf::PdmUiTreeViewQModel::updateSubTreeRecursive(QModelIndex const&, caf::PdmUiTreeOrdering*, caf::PdmUiTreeOrdering*, bool) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeViewQModel.cpp:268
+  [38] caf::PdmUiTreeViewQModel::updateSubTree(caf::PdmUiItem*, bool) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeViewQModel.cpp:202
+  [39] caf::PdmUiTreeViewEditor::updateMySubTree(caf::PdmUiItem*, bool) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeViewEditor.cpp:332
+  [40] caf::PdmUiEditorHandle::updateUi() at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiEditorHandle.cpp:84
+  [41] caf::PdmUiItem::updateConnectedEditors() const at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiItem.cpp:493
+  [42] RimEnsembleCurveSetCollection::onChildDeleted(caf::PdmChildArrayFieldHandle*, std::vector<caf::PdmObjectHandle*, std::allocator<caf::PdmObjectHandle*> >&) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimEnsembleCurveSetCollection.cpp:333
+  [43] RicDeleteItemExec::redo() at ResInsight/ApplicationLibCode/Commands/RicDeleteItemExec.cpp:71
+  [44] RicDeleteItemFeature::deleteObject(caf::PdmObject*) at ResInsight/ApplicationLibCode/Commands/RicDeleteItemFeature.cpp:128
+  [45] RicDeleteItemFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/RicDeleteItemFeature.cpp:68
+  [46] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+  [47] RiuTreeViewEventFilter::activateFirstEnabledFeature(std::vector<caf::CmdFeature*, std::allocator<caf::CmdFeature*> > const&) at ResInsight/ApplicationLibCode/UserInterface/RiuTreeViewEventFilter.cpp:95
+  [48] RiuTreeViewEventFilter::activateFeatureFromKeyEvent(QKeyEvent*) at ResInsight/ApplicationLibCode/UserInterface/RiuTreeViewEventFilter.cpp:73
+  [49] RiuPlotMainWindow::keyPressEvent(QKeyEvent*) at ResInsight/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp:322
+  [50] QWidget::event(QEvent*) at :0
+  [51] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [52] QApplication::notify(QObject*, QEvent*) at :0
+  [53] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1831
+  [54] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [55]  at :0
+  [56] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [57] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1831
+  [58] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [59] QGuiApplicationPrivate::processKeyEvent(QWindowSystemInterfacePrivate::KeyEvent*) at :0
+  [60] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [61]  at :0
+  [62] g_main_context_dispatch at :0
+  [63] g_main_context_iterate.isra.20 at :0
+  [64] g_main_context_iteration at :0
+  [65] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [66] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [67] QCoreApplication::exec() at :0
+  [68] main at ResInsight/ApplicationExeCode/RiaMain.cpp:258
+  [69] __libc_start_main at :0
+  [70] _start at :0
+  [71]  at :0
+"
+2026-06-18T12:59:43.828Z,2026.06.0,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:167
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:263
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] std::terminate() at :0
+  [10] __cxa_rethrow at :0
+  [11] main at ResInsight/ApplicationExeCode/RiaMain.cpp:264
+  [12] __libc_start_main at :0
+  [13] _start at :0
+  [14]  at :0
+"
+2026-06-18T12:59:12.102Z,2026.06.0,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:167
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:263
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] std::terminate() at :0
+  [10] __cxa_rethrow at :0
+  [11] main at ResInsight/ApplicationExeCode/RiaMain.cpp:264
+  [12] __libc_start_main at :0
+  [13] _start at :0
+  [14]  at :0
+"
+2026-06-18T12:58:39.955Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] std::terminate() at :0
+  [10] __cxa_rethrow at :0
+  [11] main at ResInsight/ApplicationExeCode/RiaMain.cpp:232
+  [12] __libc_start_main at :0
+  [13] _start at :0
+  [14]  at :0
+"
+2026-06-18T06:55:30.718Z,2026.06.0,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:167
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:263
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] caf::PdmUiEditorHandle::updateUi(QString const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiEditorHandle.cpp:65
+  [6] caf::PdmUiPropertyView::showProperties(caf::PdmObjectHandle*) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiPropertyView.cpp:213
+  [7] RiuMainWindow::selectedObjectsChanged() at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:1539
+  [8]  at :0
+  [9] caf::PdmUiTreeView::slotOnSelectionChanged() at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeView.cpp:154
+  [10]  at :0
+  [11]  at :0
+  [12] QItemSelectionModel::selectionChanged(QItemSelection const&, QItemSelection const&) at :0
+  [13] QItemSelectionModel::emitSelectionChanged(QItemSelection const&, QItemSelection const&) at :0
+  [14] QItemSelectionModel::select(QItemSelection const&, QFlags<QItemSelectionModel::SelectionFlag>) at :0
+  [15] QTreeViewPrivate::select(QModelIndex const&, QModelIndex const&, QFlags<QItemSelectionModel::SelectionFlag>) at :0
+  [16] QTreeView::setSelection(QRect const&, QFlags<QItemSelectionModel::SelectionFlag>) at :0
+  [17] QAbstractItemView::mousePressEvent(QMouseEvent*) at :0
+  [18] QWidget::event(QEvent*) at :0
+  [19] QFrame::event(QEvent*) at :0
+  [20] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [21] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [22] QApplication::notify(QObject*, QEvent*) at :0
+  [23] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1831
+  [24] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [25] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [26]  at :0
+  [27]  at :0
+  [28] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [29] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1831
+  [30] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [31] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [32] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [33]  at :0
+  [34] g_main_context_dispatch at :0
+  [35] g_main_context_iterate.isra.20 at :0
+  [36] g_main_context_iteration at :0
+  [37] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [38] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [39] QCoreApplication::exec() at :0
+  [40] main at ResInsight/ApplicationExeCode/RiaMain.cpp:258
+  [41] __libc_start_main at :0
+  [42] _start at :0
+  [43]  at :0
+"
+2026-06-17T10:18:08.147Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] ecl_kw_get_data_type at ResInsight/ThirdParty/Ert/lib/ecl/ecl_kw.cpp:1776
+  [4] ecl_file_kw_assert_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_kw.cpp:211
+  [5] ecl_file_kw_load_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_kw.cpp:244
+  [6] ecl_file_view_get_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_view.cpp:149
+  [7] RifEclipseSummaryTools::getRestartRelativeFilePathResdata(QString const&) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseSummaryTools.cpp:336
+  [8] RifEclipseSummaryTools::getRestartFileNames(QString const&, bool, std::vector<QString, std::allocator<QString> >&) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseSummaryTools.cpp:220
+  [9] RifEclipseSummaryTools::getRestartFileNames(QString const&, std::vector<QString, std::allocator<QString> >&) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseSummaryTools.cpp:164
+  [10] operator() at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:190
+  [11] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:110
+  [12] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+  [13] gomp_thread_start at :0
+  [14] start_thread at :0
+  [15] __GI___clone at :0
+  [16]  at :0
+"
+2026-06-17T09:53:44.703Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __libc_message at :0
+  [6] malloc_printerr at :0
+  [7] _int_free at :0
+  [8] __malloc_arena_thread_freeres at :0
+  [9] start_thread at :0
+  [10] __GI___clone at :0
+  [11]  at :0
+"
+2026-06-17T07:48:11.18Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] caf::PdmFieldUiCap<caf::PdmPtrField<RimSummaryEnsemble*> >::setValueFromUiEditor(QVariant const&, bool) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafInternalPdmUiFieldCapability.inl:30
+  [6] caf::CmdFieldChangeExec::redo() at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFieldChangeExec.cpp:139
+  [7] QUndoStack::push(QUndoCommand*) at :0
+  [8] caf::CmdUiCommandSystemImpl::fieldChangedCommand(std::vector<caf::PdmFieldHandle*, std::allocator<caf::PdmFieldHandle*> > const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdUiCommandSystemImpl.cpp:146
+  [9] caf::PdmUiCommandSystemProxy::setUiValueToField(caf::PdmUiFieldHandle*, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiCommandSystemProxy.cpp:113
+  [10] caf::PdmUiComboBoxEditor::slotIndexActivated(int) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiComboBoxEditor.cpp:455
+  [11]  at :0
+  [12] QComboBox::activated(int) at :0
+  [13]  at :0
+  [14]  at :0
+  [15]  at :0
+  [16] QComboBoxPrivateContainer::itemSelected(QModelIndex const&) at :0
+  [17] QComboBoxPrivateContainer::eventFilter(QObject*, QEvent*) at :0
+  [18] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [19] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [20] QApplication::notify(QObject*, QEvent*) at :0
+  [21] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [22] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [23] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [24]  at :0
+  [25]  at :0
+  [26] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [27] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [28] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [29] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [30] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [31]  at :0
+  [32] g_main_context_dispatch at :0
+  [33] g_main_context_iterate.isra.20 at :0
+  [34] g_main_context_iteration at :0
+  [35] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [36] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [37] QCoreApplication::exec() at :0
+  [38] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [39] __libc_start_main at :0
+  [40] _start at :0
+  [41]  at :0
+"
+2026-06-17T07:33:25.7Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] caf::PdmFieldUiCap<caf::PdmPtrField<RimSummaryEnsemble*> >::setValueFromUiEditor(QVariant const&, bool) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafInternalPdmUiFieldCapability.inl:30
+  [6] caf::CmdFieldChangeExec::redo() at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFieldChangeExec.cpp:139
+  [7] QUndoStack::push(QUndoCommand*) at :0
+  [8] caf::CmdUiCommandSystemImpl::fieldChangedCommand(std::vector<caf::PdmFieldHandle*, std::allocator<caf::PdmFieldHandle*> > const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdUiCommandSystemImpl.cpp:146
+  [9] caf::PdmUiCommandSystemProxy::setUiValueToField(caf::PdmUiFieldHandle*, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiCommandSystemProxy.cpp:113
+  [10] caf::PdmUiComboBoxEditor::slotIndexActivated(int) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiComboBoxEditor.cpp:455
+  [11]  at :0
+  [12] QComboBox::activated(int) at :0
+  [13]  at :0
+  [14]  at :0
+  [15]  at :0
+  [16] QComboBoxPrivateContainer::itemSelected(QModelIndex const&) at :0
+  [17] QComboBoxPrivateContainer::eventFilter(QObject*, QEvent*) at :0
+  [18] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [19] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [20] QApplication::notify(QObject*, QEvent*) at :0
+  [21] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [22] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [23] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [24]  at :0
+  [25]  at :0
+  [26] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [27] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [28] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [29] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [30] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [31]  at :0
+  [32] g_main_context_dispatch at :0
+  [33] g_main_context_iterate.isra.20 at :0
+  [34] g_main_context_iteration at :0
+  [35] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [36] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [37] QCoreApplication::exec() at :0
+  [38] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [39] __libc_start_main at :0
+  [40] _start at :0
+  [41]  at :0
+"
+2026-06-17T07:29:26.214Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] QtSharedPointer::ExternalRefCountData::getAndRef(QObject const*) at :0
+  [4] QApplication::notify(QObject*, QEvent*) at :0
+  [5] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [6] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [7] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [8]  at :0
+  [9]  at :0
+  [10] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [11] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [12] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [13] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [14] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [15]  at :0
+  [16] g_main_context_dispatch at :0
+  [17] g_main_context_iterate.isra.20 at :0
+  [18] g_main_context_iteration at :0
+  [19] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [20] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [21] QCoreApplication::exec() at :0
+  [22] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [23] __libc_start_main at :0
+  [24] _start at :0
+  [25]  at :0
+"
+2026-06-16T20:38:28.725Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] operator() at ResInsight/ApplicationLibCode/UserInterface/RiuMultiPlotPage.cpp:1131
+  [6] RiuMultiPlotPage::alignAxes() at ResInsight/ApplicationLibCode/UserInterface/RiuMultiPlotPage.cpp:1110
+  [7] RiuMultiPlotPage::performUpdate(RiaDefines::MultiPlotPageUpdateType) at ResInsight/ApplicationLibCode/UserInterface/RiuMultiPlotPage.cpp:573
+  [8] QWidget::event(QEvent*) at :0
+  [9] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [10] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [11] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [12] QWidgetPrivate::show_helper() at :0
+  [13] QWidgetPrivate::showChildren(bool) at :0
+  [14] QWidgetPrivate::show_helper() at :0
+  [15] QWidgetPrivate::showChildren(bool) at :0
+  [16] QWidgetPrivate::show_helper() at :0
+  [17] QWidgetPrivate::showChildren(bool) at :0
+  [18] QWidgetPrivate::show_helper() at :0
+  [19] QWidgetPrivate::showChildren(bool) at :0
+  [20] QWidgetPrivate::show_helper() at :0
+  [21] QWidgetPrivate::showChildren(bool) at :0
+  [22] QWidgetPrivate::show_helper() at :0
+  [23] QWidgetPrivate::setVisible(bool) at :0
+  [24]  at :0
+  [25] QMdiSubWindow::changeEvent(QEvent*) at :0
+  [26] QWidget::event(QEvent*) at :0
+  [27] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [28] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [29] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [30] QWidget::setWindowState(QFlags<Qt::WindowState>) at :0
+  [31] QWidget::showNormal() at :0
+  [32]  at :0
+  [33]  at :0
+  [34]  at :0
+  [35]  at :0
+  [36] QApplication::focusChanged(QWidget*, QWidget*) at :0
+  [37] QWidget::setFocus(Qt::FocusReason) at :0
+  [38] QWidget::focusNextPrevChild(bool) at :0
+  [39] QWidgetPrivate::hide_helper() at :0
+  [40] QWidgetPrivate::setVisible(bool) at :0
+  [41] QWidgetAction::releaseWidget(QWidget*) at :0
+  [42]  at :0
+  [43] QToolBar::actionEvent(QActionEvent*) at :0
+  [44] QWidget::event(QEvent*) at :0
+  [45] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [46] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [47] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [48] QWidget::removeAction(QAction*) at :0
+  [49] QToolBar::clear() at :0
+  [50] caf::PdmUiToolBarEditor::clear() at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiToolBarEditor.cpp:265
+  [51] caf::PdmUiToolBarEditor::setFields(std::vector<caf::PdmFieldHandle*, std::allocator<caf::PdmFieldHandle*> >&) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiToolBarEditor.cpp:246
+  [52] RiuPlotMainWindow::updateMultiPlotToolBar() at ResInsight/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp:758
+  [53] RimMultiPlot::fieldChangedByUi(caf::PdmFieldHandle const*, QVariant const&, QVariant const&) at ResInsight/ApplicationLibCode/ProjectDataModel/RimMultiPlot.cpp:696
+  [54] caf::PdmUiFieldHandle::notifyFieldChanged(QVariant const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiFieldHandle.cpp:74
+  [55] caf::PdmFieldUiCap<caf::PdmField<caf::AppEnum<RiaDefines::RowCount> > >::setValueFromUiEditor(QVariant const&, bool) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafInternalPdmUiFieldCapability.inl:110
+  [56] caf::CmdFieldChangeExec::redo() at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFieldChangeExec.cpp:139
+  [57] QUndoStack::push(QUndoCommand*) at :0
+  [58] caf::CmdUiCommandSystemImpl::fieldChangedCommand(std::vector<caf::PdmFieldHandle*, std::allocator<caf::PdmFieldHandle*> > const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdUiCommandSystemImpl.cpp:146
+  [59] caf::PdmUiCommandSystemProxy::setUiValueToField(caf::PdmUiFieldHandle*, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiCommandSystemProxy.cpp:113
+  [60] caf::PdmUiComboBoxEditor::slotIndexActivated(int) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiComboBoxEditor.cpp:455
+  [61]  at :0
+  [62] QComboBox::activated(int) at :0
+  [63]  at :0
+  [64]  at :0
+  [65]  at :0
+  [66] QComboBoxPrivateContainer::itemSelected(QModelIndex const&) at :0
+  [67] QComboBoxPrivateContainer::eventFilter(QObject*, QEvent*) at :0
+  [68] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [69] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [70] QApplication::notify(QObject*, QEvent*) at :0
+  [71] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [72] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [73] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [74]  at :0
+  [75]  at :0
+  [76] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [77] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [78] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [79] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [80] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [81]  at :0
+  [82] g_main_context_dispatch at :0
+  [83] g_main_context_iterate.isra.20 at :0
+  [84] g_main_context_iteration at :0
+  [85] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [86] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [87] QCoreApplication::exec() at :0
+  [88] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [89] __libc_start_main at :0
+  [90] _start at :0
+  [91]  at :0
+"
+2026-06-16T13:04:51.343Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] RimWellFlowRateCurve::updateCurveAppearance() at ResInsight/ApplicationLibCode/ProjectDataModel/Flow/RimWellFlowRateCurve.cpp:227
+  [4] RimWellFlowRateCurve::onLoadDataAndUpdate(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Flow/RimWellFlowRateCurve.cpp:164
+  [5] RimPlotCurve::loadDataAndUpdate(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimPlotCurve.cpp:587
+  [6] non-virtual thunk to RimWellFlowRateCurve::fieldChangedByUi(caf::PdmFieldHandle const*, QVariant const&, QVariant const&) at ResInsight/ApplicationLibCode/ProjectDataModel/Flow/RimWellFlowRateCurve.h:63
+  [7] caf::PdmUiFieldHandle::notifyFieldChanged(QVariant const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiFieldHandle.cpp:74
+  [8] caf::PdmFieldUiCap<caf::PdmField<bool> >::setValueFromUiEditor(QVariant const&, bool) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafInternalPdmUiFieldCapability.inl:110
+  [9] caf::CmdFieldChangeExec::redo() at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFieldChangeExec.cpp:139
+  [10] QUndoStack::push(QUndoCommand*) at :0
+  [11] caf::CmdUiCommandSystemImpl::fieldChangedCommand(std::vector<caf::PdmFieldHandle*, std::allocator<caf::PdmFieldHandle*> > const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdUiCommandSystemImpl.cpp:146
+  [12] caf::PdmUiCommandSystemProxy::setUiValueToField(caf::PdmUiFieldHandle*, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiCommandSystemProxy.cpp:113
+  [13] caf::PdmUiTreeViewQModel::setData(QModelIndex const&, QVariant const&, int) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeViewQModel.cpp:761
+  [14] QSortFilterProxyModel::setData(QModelIndex const&, QVariant const&, int) at :0
+  [15] QStyledItemDelegate::editorEvent(QEvent*, QAbstractItemModel*, QStyleOptionViewItem const&, QModelIndex const&) at :0
+  [16]  at :0
+  [17] QAbstractItemView::edit(QModelIndex const&, QAbstractItemView::EditTrigger, QEvent*) at :0
+  [18] QAbstractItemView::mouseReleaseEvent(QMouseEvent*) at :0
+  [19] QWidget::event(QEvent*) at :0
+  [20] QFrame::event(QEvent*) at :0
+  [21] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [22] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [23] QApplication::notify(QObject*, QEvent*) at :0
+  [24] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [25] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [26] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [27]  at :0
+  [28]  at :0
+  [29] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [30] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [31] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [32] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [33] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [34]  at :0
+  [35] g_main_context_dispatch at :0
+  [36] g_main_context_iterate.isra.20 at :0
+  [37] g_main_context_iteration at :0
+  [38] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [39] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [40] QCoreApplication::exec() at :0
+  [41] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [42] __libc_start_main at :0
+  [43] _start at :0
+  [44]  at :0
+"
+2026-06-16T13:03:07.752Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __memmove_evex_unaligned_erms at :0
+  [4] QString::append(QChar const*, long long) at :0
+  [5] QString::append(QString const&) at :0
+  [6] QString::operator+=(QString const&) at /private/f_resinsight_build/resbuild/qt/6.6.3/gcc_64/include/QtCore/qstring.h:463
+  [7] RimWellAllocationPlot::onLoadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/Flow/RimWellAllocationPlot.cpp:896
+  [8] RimViewWindow::loadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimViewWindow.cpp:88
+  [9] RimSimWellInViewCollection::updateWellAllocationPlots() at ResInsight/ApplicationLibCode/ProjectDataModel/RimSimWellInViewCollection.cpp:578
+  [10] RimEclipseView::synchronizeWellsWithResults() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp:1744
+  [11] RimEclipseView::onLoadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp:1218
+  [12] RimViewWindow::loadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimViewWindow.cpp:88
+  [13] RimReloadCaseTools::updateAll3dViews(RimEclipseCase*) at ResInsight/ApplicationLibCode/ProjectDataModel/RimReloadCaseTools.cpp:141
+  [14] RimReloadCaseTools::reloadEclipseData(RimEclipseCase*, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimReloadCaseTools.cpp:96
+  [15] RicReplaceCaseFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/RicReplaceCaseFeature.cpp:87
+  [16] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+  [17]  at :0
+  [18] QAction::triggered(bool) at :0
+  [19] QAction::activate(QAction::ActionEvent) at :0
+  [20]  at :0
+  [21]  at :0
+  [22] QWidget::event(QEvent*) at :0
+  [23] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [24] QApplication::notify(QObject*, QEvent*) at :0
+  [25] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [26] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [27] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [28]  at :0
+  [29]  at :0
+  [30] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [31] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [32] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [33] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [34] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [35]  at :0
+  [36] g_main_context_dispatch at :0
+  [37] g_main_context_iterate.isra.20 at :0
+  [38] g_main_context_iteration at :0
+  [39] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [40] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [41]  at :0
+  [42] QMenu::exec(QPoint const&, QAction*) at :0
+  [43] RiuMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:2056
+  [44]  at :0
+  [45] QWidget::customContextMenuRequested(QPoint const&) at :0
+  [46] QWidget::event(QEvent*) at :0
+  [47] QFrame::event(QEvent*) at :0
+  [48] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [49] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [50] QApplication::notify(QObject*, QEvent*) at :0
+  [51] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [52] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [53]  at :0
+  [54]  at :0
+  [55] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [56] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [57] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [58] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [59] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [60]  at :0
+  [61] g_main_context_dispatch at :0
+  [62] g_main_context_iterate.isra.20 at :0
+  [63] g_main_context_iteration at :0
+  [64] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [65] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [66] QCoreApplication::exec() at :0
+  [67] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [68] __libc_start_main at :0
+  [69] _start at :0
+  [70]  at :0
+"
+2026-06-16T10:49:34.724Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] Rim3dView::scaleZ() const at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:1242
+  [4] RimViewController::updateCameraLink() at ResInsight/ApplicationLibCode/ProjectDataModel/RimViewController.cpp:559
+  [5] RimViewController::setManagedView(Rim3dView*) at ResInsight/ApplicationLibCode/ProjectDataModel/RimViewController.cpp:443
+  [6] RimViewController::fieldChangedByUi(caf::PdmFieldHandle const*, QVariant const&, QVariant const&) at ResInsight/ApplicationLibCode/ProjectDataModel/RimViewController.cpp:226
+  [7] caf::PdmUiFieldHandle::notifyFieldChanged(QVariant const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiFieldHandle.cpp:74
+  [8] caf::PdmFieldUiCap<caf::PdmPtrField<Rim3dView*> >::setValueFromUiEditor(QVariant const&, bool) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafInternalPdmUiFieldCapability.inl:111
+  [9] caf::CmdFieldChangeExec::redo() at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFieldChangeExec.cpp:139
+  [10] QUndoStack::push(QUndoCommand*) at :0
+  [11] caf::CmdUiCommandSystemImpl::fieldChangedCommand(std::vector<caf::PdmFieldHandle*, std::allocator<caf::PdmFieldHandle*> > const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdUiCommandSystemImpl.cpp:146
+  [12] caf::PdmUiCommandSystemProxy::setUiValueToField(caf::PdmUiFieldHandle*, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiCommandSystemProxy.cpp:113
+  [13] caf::PdmUiComboBoxEditor::slotIndexActivated(int) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiComboBoxEditor.cpp:455
+  [14]  at :0
+  [15] QComboBox::activated(int) at :0
+  [16]  at :0
+  [17]  at :0
+  [18]  at :0
+  [19] QComboBoxPrivateContainer::itemSelected(QModelIndex const&) at :0
+  [20] QComboBoxPrivateContainer::eventFilter(QObject*, QEvent*) at :0
+  [21] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [22] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [23] QApplication::notify(QObject*, QEvent*) at :0
+  [24] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [25] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [26] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [27]  at :0
+  [28]  at :0
+  [29] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [30] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [31] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [32] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [33] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [34]  at :0
+  [35] g_main_context_dispatch at :0
+  [36] g_main_context_iterate.isra.20 at :0
+  [37] g_main_context_iteration at :0
+  [38] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [39] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [40] QCoreApplication::exec() at :0
+  [41] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [42] __libc_start_main at :0
+  [43] _start at :0
+  [44]  at :0
+"
+2026-06-16T09:12:08.503Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] QWidgetPrivate::shouldPaintOnScreen() const at :0
+  [4] QWidgetRepaintManager::markNeedsFlush(QWidget*, QRegion const&, QPoint const&) at :0
+  [5] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [6] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [7] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [8] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [9] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [10] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [11] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [12] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [13] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [14] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [15] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [16] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [17] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [18] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [19] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [20] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [21] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [22] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [23] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [24] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [25] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [26] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [27] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [28] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [29] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [30] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [31] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [32] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [33] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [34] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [35] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [36] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [37] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [38] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [39] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [40] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [41] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [42] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [43] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [44] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [45] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [46] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [47] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [48] QWidgetRepaintManager::paintAndFlush() at :0
+  [49] QWidget::event(QEvent*) at :0
+  [50] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [51] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [52] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [53] QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*) at :0
+  [54]  at :0
+  [55] g_main_context_dispatch at :0
+  [56] g_main_context_iterate.isra.20 at :0
+  [57] g_main_context_iteration at :0
+  [58] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [59] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [60] QCoreApplication::exec() at :0
+  [61] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [62] __libc_start_main at :0
+  [63] _start at :0
+  [64]  at :0
+"
+2026-06-16T07:48:42.731Z,2026.06.0,"  [0] ResInsight+0x12AFBDD at :0
+  [1] ResInsight+0x12AFB5F at :0
+  [2] ucrtbase!raise+0x1D9 at :0
+  [3] Qt6Core!QObject::qt_static_metacall+0x1816 at :0
+  [4] Qt6Core!QMetaObject::activate+0x84 at :0
+  [5] Qt6Gui!QAction::activate+0x171 at :0
+  [6] Qt6Widgets!QMenu::actionGeometry+0x5D3 at :0
+  [7] Qt6Widgets!QMenu::actionGeometry+0x3B3 at :0
+  [8] Qt6Widgets!QMenu::mouseReleaseEvent+0x11A at :0
+  [9] Qt6Widgets!QWidget::event+0x164 at :0
+  [10] Qt6Widgets!QMenu::event+0x320 at :0
+  [11] Qt6Widgets!QApplicationPrivate::notify_helper+0x10E at :0
+  [12] Qt6Widgets!QApplication::notify+0x750 at :0
+  [13] ResInsight+0x142EBD at :0
+  [14] Qt6Core!QCoreApplication::notifyInternal2+0x11F at :0
+  [15] Qt6Widgets!QApplicationPrivate::sendMouseEvent+0x3EF at :0
+  [16] Qt6Widgets!QWidgetRepaintManager::updateStaticContentsSize+0x2CF1 at :0
+  [17] Qt6Widgets!QWidgetRepaintManager::updateStaticContentsSize+0xCE2 at :0
+  [18] Qt6Widgets!QApplicationPrivate::notify_helper+0x10E at :0
+  [19] Qt6Widgets!QApplication::notify+0x18C1 at :0
+  [20] ResInsight+0x142EBD at :0
+  [21] Qt6Core!QCoreApplication::notifyInternal2+0x11F at :0
+  [22] Qt6Gui!QGuiApplicationPrivate::processMouseEvent+0x77D at :0
+  [23] Qt6Gui!QWindowSystemInterface::sendWindowSystemEvents+0xEA at :0
+  [24] Qt6Core!QEventDispatcherWin32::processEvents+0x90 at :0
+  [25] Qt6Gui!QWindowsGuiEventDispatcher::processEvents+0x19 at :0
+  [26] Qt6Core!QEventLoop::exec+0x19F at :0
+  [27] Qt6Core!QCoreApplication::exec+0x15D at :0
+  [28] ResInsight+0x12AF242 at :0
+  [29] ResInsight!cJSON_malloc+0x440DCD at :0
+  [30] ResInsight!cJSON_malloc+0x43FAAA at :0
+  [31] KERNEL32!BaseThreadInitThunk+0x17 at :0
+  [32] ntdll!RtlUserThreadStart+0x2C at :0
+"
+2026-06-16T07:48:13.847Z,2026.06.0,"  [0] ResInsight+0x12AFBDD at :0
+  [1] ResInsight+0x12AFB5F at :0
+  [2] ucrtbase!raise+0x1D9 at :0
+  [3] Qt6Core!QObject::qt_static_metacall+0x1816 at :0
+  [4] Qt6Core!QMetaObject::activate+0x84 at :0
+  [5] Qt6Gui!QAction::activate+0x171 at :0
+  [6] Qt6Widgets!QMenu::actionGeometry+0x5D3 at :0
+  [7] Qt6Widgets!QMenu::actionGeometry+0x3B3 at :0
+  [8] Qt6Widgets!QMenu::mouseReleaseEvent+0x11A at :0
+  [9] Qt6Widgets!QWidget::event+0x164 at :0
+  [10] Qt6Widgets!QMenu::event+0x320 at :0
+  [11] Qt6Widgets!QApplicationPrivate::notify_helper+0x10E at :0
+  [12] Qt6Widgets!QApplication::notify+0x750 at :0
+  [13] ResInsight+0x142EBD at :0
+  [14] Qt6Core!QCoreApplication::notifyInternal2+0x11F at :0
+  [15] Qt6Widgets!QApplicationPrivate::sendMouseEvent+0x3EF at :0
+  [16] Qt6Widgets!QWidgetRepaintManager::updateStaticContentsSize+0x2CF1 at :0
+  [17] Qt6Widgets!QWidgetRepaintManager::updateStaticContentsSize+0xCE2 at :0
+  [18] Qt6Widgets!QApplicationPrivate::notify_helper+0x10E at :0
+  [19] Qt6Widgets!QApplication::notify+0x18C1 at :0
+  [20] ResInsight+0x142EBD at :0
+  [21] Qt6Core!QCoreApplication::notifyInternal2+0x11F at :0
+  [22] Qt6Gui!QGuiApplicationPrivate::processMouseEvent+0x77D at :0
+  [23] Qt6Gui!QWindowSystemInterface::sendWindowSystemEvents+0xEA at :0
+  [24] Qt6Core!QEventDispatcherWin32::processEvents+0x90 at :0
+  [25] Qt6Gui!QWindowsGuiEventDispatcher::processEvents+0x19 at :0
+  [26] Qt6Core!QEventLoop::exec+0x19F at :0
+  [27] Qt6Core!QCoreApplication::exec+0x15D at :0
+  [28] ResInsight+0x12AF242 at :0
+  [29] ResInsight!cJSON_malloc+0x440DCD at :0
+  [30] ResInsight!cJSON_malloc+0x43FAAA at :0
+  [31] KERNEL32!BaseThreadInitThunk+0x17 at :0
+  [32] ntdll!RtlUserThreadStart+0x2C at :0
+"
+2026-06-16T07:35:01.253Z,2026.06.0,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:167
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:263
+  [2]  at :0
+  [3] raise at :0
+  [4]  at :0
+  [5] QAction::triggered(bool) at :0
+  [6] QAction::activate(QAction::ActionEvent) at :0
+  [7]  at :0
+  [8]  at :0
+  [9] QWidget::event(QEvent*) at :0
+  [10] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [11] QApplication::notify(QObject*, QEvent*) at :0
+  [12] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1831
+  [13] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [14] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [15]  at :0
+  [16]  at :0
+  [17] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [18] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1831
+  [19] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [20] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [21] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [22]  at :0
+  [23] g_main_context_dispatch at :0
+  [24] g_main_context_iterate.isra.20 at :0
+  [25] g_main_context_iteration at :0
+  [26] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [27] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [28] QCoreApplication::exec() at :0
+  [29] main at ResInsight/ApplicationExeCode/RiaMain.cpp:258
+  [30] __libc_start_main at :0
+  [31] _start at :0
+  [32]  at :0
+"
+2026-06-16T07:28:39.146Z,2026.06.0,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:167
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:263
+  [2]  at :0
+  [3] RiuMainWindow::subWindowList(QMdiArea::WindowOrder) at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:1185
+  [4] RiaSocketServer::findReservoir(int) at ResInsight/ApplicationLibCode/SocketInterface/RiaSocketServer.cpp:155
+  [5] RiaGetActiveCellProperty::interpretCommand(RiaSocketServer*, QList<QByteArray> const&, QDataStream&) at ResInsight/ApplicationLibCode/SocketInterface/RiaPropertyDataCommands.cpp:62
+  [6] RiaSocketServer::readCommandFromOctave() at ResInsight/ApplicationLibCode/SocketInterface/RiaSocketServer.cpp:231
+  [7] RiaSocketServer::slotReadyRead() at ResInsight/ApplicationLibCode/SocketInterface/RiaSocketServer.cpp:293
+  [8]  at :0
+  [9]  at :0
+  [10]  at :0
+  [11] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [12] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1831
+  [13] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [14]  at :0
+  [15] g_main_context_dispatch at :0
+  [16] g_main_context_iterate.isra.20 at :0
+  [17] g_main_context_iteration at :0
+  [18] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [19] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [20] QCoreApplication::exec() at :0
+  [21] main at ResInsight/ApplicationExeCode/RiaMain.cpp:258
+  [22] __libc_start_main at :0
+  [23] _start at :0
+  [24]  at :0
+"
+2026-06-15T16:13:16.329Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] nanosleep at :0
+  [4]  at :0
+  [5]  at :0
+  [6]  at :0
+  [7]  at :0
+  [8]  at :0
+  [9]  at :0
+  [10] QRhi::endFrame(QRhiSwapChain*, QFlags<QRhi::EndFrameFlag>) at :0
+  [11]  at :0
+  [12] QPlatformBackingStore::rhiFlush(QWindow*, double, QRegion const&, QPoint const&, QPlatformTextureList*, bool) at :0
+  [13]  at :0
+  [14] QWidgetRepaintManager::flush(QWidget*, QRegion const&, QPlatformTextureList*) at :0
+  [15] QWidgetRepaintManager::flush() at :0
+  [16] QWidgetRepaintManager::paintAndFlush() at :0
+  [17] QWidget::event(QEvent*) at :0
+  [18] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [19] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [20] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [21] QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*) at :0
+  [22]  at :0
+  [23] g_main_context_dispatch at :0
+  [24] g_main_context_iterate.isra.20 at :0
+  [25] g_main_context_iteration at :0
+  [26] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [27] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [28] QCoreApplication::exec() at :0
+  [29] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [30] __libc_start_main at :0
+  [31] _start at :0
+  [32]  at :0
+"
+2026-06-15T16:13:16.274Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __libc_poll at :0
+  [4] g_main_context_iterate.isra.20 at :0
+  [5] g_main_context_iteration at :0
+  [6] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [7] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [8] QCoreApplication::exec() at :0
+  [9] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [10] __libc_start_main at :0
+  [11] _start at :0
+  [12]  at :0
+"
+2026-06-15T15:40:28.364Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] ecl_grid_alloc_EGRID__ at ResInsight/ThirdParty/Ert/lib/ecl/ecl_grid.cpp:3085
+  [4] ecl_grid_alloc_EGRID_all_grids at ResInsight/ThirdParty/Ert/lib/ecl/ecl_grid.cpp:3106
+  [5] RifReaderEclipseOutput::loadAllGrids() const at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp:1161
+  [6] RifReaderEclipseOutput::open(QString const&, RigEclipseCaseData*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp:389
+  [7] RimEclipseResultCase::importGridAndResultMetaData(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultCase.cpp:261
+  [8] RimEclipseCase::openReservoirCase() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCase.cpp:1060
+  [9] RimEclipseView::onLoadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp:1188
+  [10] RimViewWindow::loadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimViewWindow.cpp:88
+  [11] RimEclipseViewCollection::addView(RimEclipseCase*) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseViewCollection.cpp:112
+  [12] RicNewViewFeature::createReservoirView(RimEclipseCase*, RimGeoMechCase*, RimEclipseViewCollection*) at ResInsight/ApplicationLibCode/Commands/RicNewViewFeature.cpp:134
+  [13] RicNewViewFeature::addReservoirView(RimEclipseCase*, RimGeoMechCase*, RimEclipseViewCollection*) at ResInsight/ApplicationLibCode/Commands/RicNewViewFeature.cpp:47
+  [14] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+  [15]  at :0
+  [16] QAction::triggered(bool) at :0
+  [17] QAction::activate(QAction::ActionEvent) at :0
+  [18]  at :0
+  [19]  at :0
+  [20] QWidget::event(QEvent*) at :0
+  [21] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [22] QApplication::notify(QObject*, QEvent*) at :0
+  [23] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [24] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [25] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [26]  at :0
+  [27]  at :0
+  [28] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [29] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [30] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [31] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [32] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [33]  at :0
+  [34] g_main_context_dispatch at :0
+  [35] g_main_context_iterate.isra.20 at :0
+  [36] g_main_context_iteration at :0
+  [37] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [38] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [39]  at :0
+  [40] QMenu::exec(QPoint const&, QAction*) at :0
+  [41] RiuMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:2056
+  [42]  at :0
+  [43] QWidget::customContextMenuRequested(QPoint const&) at :0
+  [44] QWidget::event(QEvent*) at :0
+  [45] QFrame::event(QEvent*) at :0
+  [46] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [47] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [48] QApplication::notify(QObject*, QEvent*) at :0
+  [49] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [50] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [51]  at :0
+  [52]  at :0
+  [53] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [54] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [55] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [56] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [57] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [58]  at :0
+  [59] g_main_context_dispatch at :0
+  [60] g_main_context_iterate.isra.20 at :0
+  [61] g_main_context_iteration at :0
+  [62] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [63] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [64] QCoreApplication::exec() at :0
+  [65] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [66] __libc_start_main at :0
+  [67] _start at :0
+  [68]  at :0
+"
+2026-06-15T14:32:46.294Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] std::terminate() at :0
+  [10] __cxa_rethrow at :0
+  [11] main at ResInsight/ApplicationExeCode/RiaMain.cpp:232
+  [12] __libc_start_main at :0
+  [13] _start at :0
+  [14]  at :0
+"
+2026-06-15T11:43:06.344Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] ecl_kw_get_data_type at ResInsight/ThirdParty/Ert/lib/ecl/ecl_kw.cpp:1776
+  [4] ecl_file_kw_assert_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_kw.cpp:211
+  [5] ecl_file_kw_load_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_kw.cpp:244
+  [6] ecl_file_view_get_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_view.cpp:149
+  [7] RifEclipseSummaryTools::getRestartRelativeFilePathResdata(QString const&) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseSummaryTools.cpp:336
+  [8] RifEclipseSummaryTools::getRestartFileNames(QString const&, bool, std::vector<QString, std::allocator<QString> >&) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseSummaryTools.cpp:225
+  [9] RifEclipseSummaryTools::getRestartFileNames(QString const&, std::vector<QString, std::allocator<QString> >&) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseSummaryTools.cpp:164
+  [10] operator() at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:190
+  [11] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:110
+  [12] RimFileSummaryCase::createSummaryReaderInterface() at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:129
+  [13] RiaSummaryTools::reloadSummaryCaseAndUpdateConnectedPlots(RimSummaryCase*) at ResInsight/ApplicationLibCode/Application/Tools/Summary/RiaSummaryTools.cpp:409
+  [14] RicReloadSummaryCaseFeature::reloadSelectedCasesAndUpdate() at ResInsight/ApplicationLibCode/Commands/RicReloadSummaryCaseFeature.cpp:148
+  [15] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+  [16]  at :0
+  [17] QAction::triggered(bool) at :0
+  [18] QAction::activate(QAction::ActionEvent) at :0
+  [19]  at :0
+  [20]  at :0
+  [21] QWidget::event(QEvent*) at :0
+  [22] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [23] QApplication::notify(QObject*, QEvent*) at :0
+  [24] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [25] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [26] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [27]  at :0
+  [28]  at :0
+  [29] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [30] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [31] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [32] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [33] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [34]  at :0
+  [35] g_main_context_dispatch at :0
+  [36] g_main_context_iterate.isra.20 at :0
+  [37] g_main_context_iteration at :0
+  [38] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [39] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [40]  at :0
+  [41] QMenu::exec(QPoint const&, QAction*) at :0
+  [42] RiuPlotMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp:1058
+  [43]  at :0
+  [44] QWidget::customContextMenuRequested(QPoint const&) at :0
+  [45] QWidget::event(QEvent*) at :0
+  [46] QFrame::event(QEvent*) at :0
+  [47] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [48] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [49] QApplication::notify(QObject*, QEvent*) at :0
+  [50] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [51] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [52]  at :0
+  [53]  at :0
+  [54] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [55] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [56] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [57] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [58] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [59]  at :0
+  [60] g_main_context_dispatch at :0
+  [61] g_main_context_iterate.isra.20 at :0
+  [62] g_main_context_iteration at :0
+  [63] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [64] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [65] QCoreApplication::exec() at :0
+  [66] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [67] __libc_start_main at :0
+  [68] _start at :0
+  [69]  at :0
+"
+2026-06-15T11:42:08.983Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] std::terminate() at :0
+  [10] __cxa_rethrow at :0
+  [11] main at ResInsight/ApplicationExeCode/RiaMain.cpp:232
+  [12] __libc_start_main at :0
+  [13] _start at :0
+  [14]  at :0
+"
+2026-06-15T11:41:43.273Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
+  [6] cvf::Camera::setProjectionAsPerspective(double, double, double) at ResInsight/Fwk/VizFwk/LibRender/cvfCamera.cpp:206
+  [7] caf::Viewer::optimizeClippingPlanes() at ResInsight/Fwk/AppFwk/cafViewer/cafViewer.cpp:465
+  [8] caf::Viewer::paintGL() at ResInsight/Fwk/AppFwk/cafViewer/cafViewer.cpp:884
+  [9]  at :0
+  [10] QWidget::event(QEvent*) at :0
+  [11] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [12] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [13] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [14] QWidgetPrivate::sendPaintEvent(QRegion const&) at :0
+  [15] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [16] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [17] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [18] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [19] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [20] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [21] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [22] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [23] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [24] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [25] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [26] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [27] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [28] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [29] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [30] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [31] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [32] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [33] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [34] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [35] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [36] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [37] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [38] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [39] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [40] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [41] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [42] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [43] QWidgetRepaintManager::paintAndFlush() at :0
+  [44] QWidget::event(QEvent*) at :0
+  [45] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [46] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [47] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [48] QWidgetRepaintManager::sendUpdateRequest(QWidget*, QWidgetRepaintManager::UpdateTime) at :0
+  [49] void QWidgetRepaintManager::markDirty<QRect>(QRect const&, QWidget*, QWidgetRepaintManager::UpdateTime, QWidgetRepaintManager::BufferState) at :0
+  [50] QWidget::repaint(QRect const&) at :0
+  [51] QWidget::repaint() at :0
+  [52]  at :0
+  [53] QAbstractButton::mouseReleaseEvent(QMouseEvent*) at :0
+  [54] QToolButton::mouseReleaseEvent(QMouseEvent*) at :0
+  [55] QWidget::event(QEvent*) at :0
+  [56] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [57] QApplication::notify(QObject*, QEvent*) at :0
+  [58] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [59] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [60] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [61]  at :0
+  [62]  at :0
+  [63] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [64] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [65] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [66] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [67] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [68]  at :0
+  [69] g_main_context_dispatch at :0
+  [70] g_main_context_iterate.isra.20 at :0
+  [71] g_main_context_iteration at :0
+  [72] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [73] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [74] QCoreApplication::exec() at :0
+  [75] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [76] __libc_start_main at :0
+  [77] _start at :0
+  [78]  at :0
+"
+2026-06-15T11:41:06.372Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] std::terminate() at :0
+  [10] __cxa_rethrow at :0
+  [11] main at ResInsight/ApplicationExeCode/RiaMain.cpp:232
+  [12] __libc_start_main at :0
+  [13] _start at :0
+  [14]  at :0
+"
+2026-06-15T10:58:55.67Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
+  [6] cvf::DrawableText::renderText(cvf::OpenGLContext*, cvf::ShaderProgram*, cvf::MatrixState const&) at ResInsight/Fwk/VizFwk/LibRender/cvfDrawableText.cpp:376
+  [7] cvf::RenderEngine::render(cvf::OpenGLContext*, cvf::RenderQueue*, unsigned long, cvf::Camera const&, cvf::UniformSet const*) at ResInsight/Fwk/VizFwk/LibViewing/cvfRenderEngine.cpp:288
+  [8] cvf::Rendering::render(cvf::OpenGLContext*) at ResInsight/Fwk/VizFwk/LibViewing/cvfRendering.cpp:271
+  [9] cvf::RenderSequence::render(cvf::OpenGLContext*) at ResInsight/Fwk/VizFwk/LibViewing/cvfRenderSequence.cpp:211
+  [10] caf::Viewer::paintGL() at ResInsight/Fwk/AppFwk/cafViewer/cafViewer.cpp:901
+  [11]  at :0
+  [12] QWidget::event(QEvent*) at :0
+  [13] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [14] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [15] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [16] QWidgetPrivate::sendPaintEvent(QRegion const&) at :0
+  [17] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [18] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [19] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [20] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [21] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [22] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [23] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [24] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [25] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [26] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [27] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [28] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [29] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [30] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [31] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [32] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [33] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [34] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [35] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [36] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [37] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [38] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [39] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [40] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [41] QWidgetRepaintManager::paintAndFlush() at :0
+  [42] QWidget::event(QEvent*) at :0
+  [43] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [44] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [45] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [46] QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*) at :0
+  [47]  at :0
+  [48] g_main_context_dispatch at :0
+  [49] g_main_context_iterate.isra.20 at :0
+  [50] g_main_context_iteration at :0
+  [51] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [52] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [53] RiaOpenTelemetryManager::reportCrash(int, std::basic_stacktrace<std::allocator<std::stacktrace_entry> > const&, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > const&) at ResInsight/ApplicationLibCode/Application/Tools/Telemetry/RiaOpenTelemetryManager.cpp:415
+  [54] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:174
+  [55] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [56]  at :0
+  [57] __GI_raise at :0
+  [58] __GI_abort at :0
+  [59] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
+  [60] cvf::DrawableText::renderText(cvf::OpenGLContext*, cvf::ShaderProgram*, cvf::MatrixState const&) at ResInsight/Fwk/VizFwk/LibRender/cvfDrawableText.cpp:376
+  [61] cvf::RenderEngine::render(cvf::OpenGLContext*, cvf::RenderQueue*, unsigned long, cvf::Camera const&, cvf::UniformSet const*) at ResInsight/Fwk/VizFwk/LibViewing/cvfRenderEngine.cpp:288
+  [62] cvf::Rendering::render(cvf::OpenGLContext*) at ResInsight/Fwk/VizFwk/LibViewing/cvfRendering.cpp:271
+  [63] cvf::RenderSequence::render(cvf::OpenGLContext*) at ResInsight/Fwk/VizFwk/LibViewing/cvfRenderSequence.cpp:211
+  [64] caf::Viewer::paintGL() at ResInsight/Fwk/AppFwk/cafViewer/cafViewer.cpp:901
+  [65]  at :0
+  [66] QWidget::event(QEvent*) at :0
+  [67] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [68] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [69] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [70] QWidgetPrivate::sendPaintEvent(QRegion const&) at :0
+  [71] QWidgetRepaintManager::paintAndFlush() at :0
+  [72] QWidget::event(QEvent*) at :0
+  [73] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [74] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [75] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [76] QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*) at :0
+  [77]  at :0
+  [78] g_main_context_dispatch at :0
+  [79] g_main_context_iterate.isra.20 at :0
+  [80] g_main_context_iteration at :0
+  [81] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [82] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [83] QCoreApplication::exec() at :0
+  [84] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [85] __libc_start_main at :0
+  [86] _start at :0
+  [87]  at :0
+"
+2026-06-15T10:58:55.594Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
+  [6] cvf::DrawableText::renderText(cvf::OpenGLContext*, cvf::ShaderProgram*, cvf::MatrixState const&) at ResInsight/Fwk/VizFwk/LibRender/cvfDrawableText.cpp:376
+  [7] cvf::RenderEngine::render(cvf::OpenGLContext*, cvf::RenderQueue*, unsigned long, cvf::Camera const&, cvf::UniformSet const*) at ResInsight/Fwk/VizFwk/LibViewing/cvfRenderEngine.cpp:288
+  [8] cvf::Rendering::render(cvf::OpenGLContext*) at ResInsight/Fwk/VizFwk/LibViewing/cvfRendering.cpp:271
+  [9] cvf::RenderSequence::render(cvf::OpenGLContext*) at ResInsight/Fwk/VizFwk/LibViewing/cvfRenderSequence.cpp:211
+  [10] caf::Viewer::paintGL() at ResInsight/Fwk/AppFwk/cafViewer/cafViewer.cpp:901
+  [11]  at :0
+  [12] QWidget::event(QEvent*) at :0
+  [13] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [14] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [15] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [16] QWidgetPrivate::sendPaintEvent(QRegion const&) at :0
+  [17] QWidgetRepaintManager::paintAndFlush() at :0
+  [18] QWidget::event(QEvent*) at :0
+  [19] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [20] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [21] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [22] QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*) at :0
+  [23]  at :0
+  [24] g_main_context_dispatch at :0
+  [25] g_main_context_iterate.isra.20 at :0
+  [26] g_main_context_iteration at :0
+  [27] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [28] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [29] QCoreApplication::exec() at :0
+  [30] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [31] __libc_start_main at :0
+  [32] _start at :0
+  [33]  at :0
+"
+2026-06-15T10:48:18.228Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] ecl_grid_alloc_EGRID__ at ResInsight/ThirdParty/Ert/lib/ecl/ecl_grid.cpp:3085
+  [4] ecl_grid_alloc_EGRID_all_grids at ResInsight/ThirdParty/Ert/lib/ecl/ecl_grid.cpp:3106
+  [5] RifReaderEclipseOutput::loadAllGrids() const at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp:1161
+  [6] RifReaderEclipseOutput::open(QString const&, RigEclipseCaseData*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp:389
+  [7] RimEclipseResultCase::importGridAndResultMetaData(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultCase.cpp:261
+  [8] RiaImportEclipseCaseTools::openEclipseCaseShowTimeStepFilterImpl(QString const&, bool, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:372
+  [9] RiaImportEclipseCaseTools::openEclipseCasesFromFile(QList<QString> const&, bool, std::map<QString, int, std::less<QString>, std::allocator<std::pair<QString const, int> > >*, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:107
+  [10] RicImportGeneralDataFeature::openEclipseCaseFromFileNames(QList<QString> const&, bool, std::vector<int, std::allocator<int> >&, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:362
+  [11] RicImportEclipseCaseFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/EclipseCommands/RicImportEclipseCaseFeature.cpp:72
+  [12] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+  [13]  at :0
+  [14] QAction::triggered(bool) at :0
+  [15] QAction::activate(QAction::ActionEvent) at :0
+  [16]  at :0
+  [17]  at :0
+  [18] QWidget::event(QEvent*) at :0
+  [19] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [20] QApplication::notify(QObject*, QEvent*) at :0
+  [21] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [22] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [23] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [24]  at :0
+  [25]  at :0
+  [26] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [27] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [28] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [29] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [30] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [31]  at :0
+  [32] g_main_context_dispatch at :0
+  [33] g_main_context_iterate.isra.20 at :0
+  [34] g_main_context_iteration at :0
+  [35] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [36] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [37] QCoreApplication::exec() at :0
+  [38] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [39] __libc_start_main at :0
+  [40] _start at :0
+  [41]  at :0
+"
+2026-06-15T10:41:23.874Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
+  [6] cvf::DrawableText::renderText(cvf::OpenGLContext*, cvf::ShaderProgram*, cvf::MatrixState const&) at ResInsight/Fwk/VizFwk/LibRender/cvfDrawableText.cpp:376
+  [7] cvf::RenderEngine::render(cvf::OpenGLContext*, cvf::RenderQueue*, unsigned long, cvf::Camera const&, cvf::UniformSet const*) at ResInsight/Fwk/VizFwk/LibViewing/cvfRenderEngine.cpp:288
+  [8] cvf::Rendering::render(cvf::OpenGLContext*) at ResInsight/Fwk/VizFwk/LibViewing/cvfRendering.cpp:271
+  [9] cvf::RenderSequence::render(cvf::OpenGLContext*) at ResInsight/Fwk/VizFwk/LibViewing/cvfRenderSequence.cpp:211
+  [10] caf::Viewer::paintGL() at ResInsight/Fwk/AppFwk/cafViewer/cafViewer.cpp:901
+  [11]  at :0
+  [12] QWidget::event(QEvent*) at :0
+  [13] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [14] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [15] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [16] QWidgetPrivate::sendPaintEvent(QRegion const&) at :0
+  [17] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [18] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [19] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [20] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [21] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [22] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [23] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [24] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [25] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [26] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [27] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [28] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [29] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [30] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [31] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [32] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [33] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [34] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [35] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [36] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [37] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [38] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [39] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [40] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [41] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [42] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [43] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [44] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [45] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [46] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [47] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [48] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [49] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [50] QWidgetRepaintManager::paintAndFlush() at :0
+  [51] QWidget::event(QEvent*) at :0
+  [52] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [53] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [54] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [55] QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*) at :0
+  [56]  at :0
+  [57] g_main_context_dispatch at :0
+  [58] g_main_context_iterate.isra.20 at :0
+  [59] g_main_context_iteration at :0
+  [60] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [61] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [62] QCoreApplication::exec() at :0
+  [63] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [64] __libc_start_main at :0
+  [65] _start at :0
+  [66]  at :0
+"
+2026-06-15T10:32:04.243Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] ecl_kw_get_data_type at ResInsight/ThirdParty/Ert/lib/ecl/ecl_kw.cpp:1776
+  [4] ecl_file_kw_assert_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_kw.cpp:211
+  [5] ecl_file_kw_load_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_kw.cpp:244
+  [6] ecl_file_view_get_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_view.cpp:149
+  [7] RifEclipseSummaryTools::getRestartRelativeFilePathResdata(QString const&) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseSummaryTools.cpp:336
+  [8] RifEclipseSummaryTools::getRestartFileNames(QString const&, bool, std::vector<QString, std::allocator<QString> >&) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseSummaryTools.cpp:225
+  [9] RifEclipseSummaryTools::getRestartFileNames(QString const&, std::vector<QString, std::allocator<QString> >&) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseSummaryTools.cpp:164
+  [10] operator() at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:190
+  [11] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:110
+  [12] RimFileSummaryCase::createSummaryReaderInterface() at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:129
+  [13] RimFileSummaryCase::summaryReader() at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:317
+  [14] RimSummaryEnsembleTools::caseWithMostDataObjects(std::vector<RimSummaryCase*, std::allocator<RimSummaryCase*> > const&) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryEnsembleTools.cpp:490
+  [15] RimSummaryEnsemble::ensembleSummaryAddresses() const at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryEnsemble.cpp:391
+  [16] RimSummaryPlot::handleSummaryAddressDrop(RimSummaryAddress*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryPlot.cpp:2355
+  [17] RimSummaryPlot::handleDroppedObjects(std::vector<caf::PdmObjectHandle*, std::allocator<caf::PdmObjectHandle*> > const&) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryPlot.cpp:2424
+  [18] RiuPlotWidget::handleDragDropEvent(QEvent*) at ResInsight/ApplicationLibCode/UserInterface/RiuPlotWidget.cpp:278
+  [19] RiuQwtPlotWidget::eventFilter(QObject*, QEvent*) at ResInsight/ApplicationLibCode/UserInterface/RiuQwtPlotWidget.cpp:552
+  [20] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [21] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [22] QApplication::notify(QObject*, QEvent*) at :0
+  [23] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [24] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [25]  at :0
+  [26]  at :0
+  [27] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [28] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [29] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [30] QGuiApplicationPrivate::processDrop(QWindow*, QMimeData const*, QPoint const&, QFlags<Qt::DropAction>, QFlags<Qt::MouseButton>, QFlags<Qt::KeyboardModifier>) at :0
+  [31] QWindowSystemInterface::handleDrop(QWindow*, QMimeData const*, QPoint const&, QFlags<Qt::DropAction>, QFlags<Qt::MouseButton>, QFlags<Qt::KeyboardModifier>) at :0
+  [32]  at :0
+  [33]  at :0
+  [34] QBasicDrag::eventFilter(QObject*, QEvent*) at :0
+  [35] QCoreApplicationPrivate::sendThroughApplicationEventFilters(QObject*, QEvent*) at :0
+  [36] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [37] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [38] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [39] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [40] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [41]  at :0
+  [42] g_main_context_dispatch at :0
+  [43] g_main_context_iterate.isra.20 at :0
+  [44] g_main_context_iteration at :0
+  [45] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [46] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [47] QBasicDrag::drag(QDrag*) at :0
+  [48] QDragManager::drag(QDrag*) at :0
+  [49] QDrag::exec(QFlags<Qt::DropAction>, Qt::DropAction) at :0
+  [50] QAbstractItemView::startDrag(QFlags<Qt::DropAction>) at :0
+  [51] QAbstractItemView::mouseMoveEvent(QMouseEvent*) at :0
+  [52] QWidget::event(QEvent*) at :0
+  [53] QFrame::event(QEvent*) at :0
+  [54] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [55] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [56] QApplication::notify(QObject*, QEvent*) at :0
+  [57] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [58] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [59] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [60]  at :0
+  [61]  at :0
+  [62] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [63] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [64] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [65] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [66] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [67]  at :0
+  [68] g_main_context_dispatch at :0
+  [69] g_main_context_iterate.isra.20 at :0
+  [70] g_main_context_iteration at :0
+  [71] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [72] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [73] QCoreApplication::exec() at :0
+  [74] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [75] __libc_start_main at :0
+  [76] _start at :0
+  [77]  at :0
+"
+2026-06-12T21:30:21.324Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] QWidgetPrivate::shouldPaintOnScreen() const at :0
+  [4] QWidgetRepaintManager::markNeedsFlush(QWidget*, QRegion const&, QPoint const&) at :0
+  [5] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [6] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [7] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [8] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [9] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [10] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [11] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [12] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [13] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [14] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [15] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [16] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [17] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [18] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [19] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [20] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [21] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [22] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [23] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [24] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [25] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [26] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [27] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [28] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [29] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [30] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [31] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [32] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [33] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [34] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [35] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [36] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [37] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [38] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [39] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [40] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [41] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [42] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [43] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [44] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [45] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [46] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [47] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [48] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [49] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [50] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [51] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [52] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [53] QWidgetRepaintManager::paintAndFlush() at :0
+  [54] QWidget::event(QEvent*) at :0
+  [55] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [56] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [57] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [58] QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*) at :0
+  [59]  at :0
+  [60] g_main_context_dispatch at :0
+  [61] g_main_context_iterate.isra.20 at :0
+  [62] g_main_context_iteration at :0
+  [63] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [64] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [65] QCoreApplication::exec() at :0
+  [66] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [67] __libc_start_main at :0
+  [68] _start at :0
+  [69]  at :0
+"
+2026-06-12T14:04:49.292Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] __cxa_call_terminate at :0
+  [10] __gxx_personality_v0 at :0
+  [11] _Unwind_RaiseException_Phase2 at :0
+  [12] _Unwind_Resume at :0
+  [13] Opm::EclIO::ESmry::dates() const at ResInsight/ThirdParty/custom-opm-common/opm-common/opm/io/eclipse/ESmry.cpp:1457
+  [14] RifHdf5SummaryExporter::writeGeneralSection(RifHdf5Exporter&, Opm::EclIO::ESmry&) at ResInsight/ApplicationLibCode/FileInterface/RifHdf5SummaryExporter.cpp:165
+  [15] RifHdf5SummaryExporter::ensureHdf5FileIsCreated(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool, unsigned long&) at ResInsight/ApplicationLibCode/FileInterface/RifHdf5SummaryExporter.cpp:141
+  [16] RifReaderEclipseSummary::open(QString const&, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseSummary.cpp:107
+  [17] RifSummaryReaderAggregator::createReadersAndImportMetaData(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/FileInterface/RifSummaryReaderAggregator.cpp:156
+  [18] RimFileSummaryCase::findRelatedFilesAndCreateReader(QString const&, bool, RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:221
+  [19] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:110
+  [20] RimFileSummaryCase::createSummaryReaderInterface() at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:129
+  [21] RiaSummaryTools::reloadSummaryCaseAndUpdateConnectedPlots(RimSummaryCase*) at ResInsight/ApplicationLibCode/Application/Tools/Summary/RiaSummaryTools.cpp:409
+  [22] RicReloadSummaryCaseFeature::reloadSelectedCasesAndUpdate() at ResInsight/ApplicationLibCode/Commands/RicReloadSummaryCaseFeature.cpp:148
+  [23] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+  [24]  at :0
+  [25] QAction::triggered(bool) at :0
+  [26] QAction::activate(QAction::ActionEvent) at :0
+  [27]  at :0
+  [28]  at :0
+  [29] QWidget::event(QEvent*) at :0
+  [30] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [31] QApplication::notify(QObject*, QEvent*) at :0
+  [32] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [33] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [34] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [35]  at :0
+  [36]  at :0
+  [37] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [38] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [39] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [40] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [41] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [42]  at :0
+  [43] g_main_context_dispatch at :0
+  [44] g_main_context_iterate.isra.20 at :0
+  [45] g_main_context_iteration at :0
+  [46] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [47] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [48]  at :0
+  [49] QMenu::exec(QPoint const&, QAction*) at :0
+  [50] RiuPlotMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp:1058
+  [51]  at :0
+  [52] QWidget::customContextMenuRequested(QPoint const&) at :0
+  [53] QWidget::event(QEvent*) at :0
+  [54] QFrame::event(QEvent*) at :0
+  [55] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [56] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [57] QApplication::notify(QObject*, QEvent*) at :0
+  [58] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [59] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [60]  at :0
+  [61]  at :0
+  [62] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [63] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [64] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [65] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [66] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [67]  at :0
+  [68] g_main_context_dispatch at :0
+  [69] g_main_context_iterate.isra.20 at :0
+  [70] g_main_context_iteration at :0
+  [71] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [72] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [73] QCoreApplication::exec() at :0
+  [74] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [75] __libc_start_main at :0
+  [76] _start at :0
+  [77]  at :0
+"
+2026-06-12T13:55:53.447Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] ecl_grid_alloc_EGRID__ at ResInsight/ThirdParty/Ert/lib/ecl/ecl_grid.cpp:3085
+  [4] ecl_grid_alloc_EGRID_all_grids at ResInsight/ThirdParty/Ert/lib/ecl/ecl_grid.cpp:3106
+  [5] RifReaderEclipseOutput::loadAllGrids() const at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp:1161
+  [6] RifReaderEclipseOutput::open(QString const&, RigEclipseCaseData*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp:389
+  [7] RimEclipseResultCase::importGridAndResultMetaData(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultCase.cpp:261
+  [8] RiaImportEclipseCaseTools::openEclipseCaseShowTimeStepFilterImpl(QString const&, bool, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:372
+  [9] RiaImportEclipseCaseTools::openEclipseCasesFromFile(QList<QString> const&, bool, std::map<QString, int, std::less<QString>, std::allocator<std::pair<QString const, int> > >*, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:107
+  [10] RiaImportEclipseCaseTools::openEclipseCasesFromFile(QList<QString> const&, bool, std::map<QString, int, std::less<QString>, std::allocator<std::pair<QString const, int> > >*, bool) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:77
+  [11] RicImportEclipseCasesFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/EclipseCommands/RicImportEclipseCasesFeature.cpp:67
+  [12] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+  [13]  at :0
+  [14] QAction::triggered(bool) at :0
+  [15] QAction::activate(QAction::ActionEvent) at :0
+  [16]  at :0
+  [17]  at :0
+  [18] QWidget::event(QEvent*) at :0
+  [19] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [20] QApplication::notify(QObject*, QEvent*) at :0
+  [21] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [22] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [23] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [24]  at :0
+  [25]  at :0
+  [26] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [27] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [28] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [29] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [30] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [31]  at :0
+  [32] g_main_context_dispatch at :0
+  [33] g_main_context_iterate.isra.20 at :0
+  [34] g_main_context_iteration at :0
+  [35] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [36] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [37] QCoreApplication::exec() at :0
+  [38] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [39] __libc_start_main at :0
+  [40] _start at :0
+  [41]  at :0
+"
+2026-06-12T13:30:59.853Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] Rim3dView::scaleZ() const at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:1242
+  [4] RimViewController::updateCameraLink() at ResInsight/ApplicationLibCode/ProjectDataModel/RimViewController.cpp:559
+  [5] RimViewController::setManagedView(Rim3dView*) at ResInsight/ApplicationLibCode/ProjectDataModel/RimViewController.cpp:443
+  [6] RimViewController::fieldChangedByUi(caf::PdmFieldHandle const*, QVariant const&, QVariant const&) at ResInsight/ApplicationLibCode/ProjectDataModel/RimViewController.cpp:226
+  [7] caf::PdmUiFieldHandle::notifyFieldChanged(QVariant const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiFieldHandle.cpp:74
+  [8] caf::PdmFieldUiCap<caf::PdmPtrField<Rim3dView*> >::setValueFromUiEditor(QVariant const&, bool) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafInternalPdmUiFieldCapability.inl:111
+  [9] caf::CmdFieldChangeExec::redo() at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFieldChangeExec.cpp:139
+  [10] QUndoStack::push(QUndoCommand*) at :0
+  [11] caf::CmdUiCommandSystemImpl::fieldChangedCommand(std::vector<caf::PdmFieldHandle*, std::allocator<caf::PdmFieldHandle*> > const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdUiCommandSystemImpl.cpp:146
+  [12] caf::PdmUiCommandSystemProxy::setUiValueToField(caf::PdmUiFieldHandle*, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiCommandSystemProxy.cpp:113
+  [13] caf::PdmUiComboBoxEditor::slotIndexActivated(int) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiComboBoxEditor.cpp:455
+  [14]  at :0
+  [15] QComboBox::activated(int) at :0
+  [16]  at :0
+  [17]  at :0
+  [18]  at :0
+  [19] QComboBoxPrivateContainer::itemSelected(QModelIndex const&) at :0
+  [20] QComboBoxPrivateContainer::eventFilter(QObject*, QEvent*) at :0
+  [21] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [22] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [23] QApplication::notify(QObject*, QEvent*) at :0
+  [24] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [25] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [26] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [27]  at :0
+  [28]  at :0
+  [29] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [30] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [31] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [32] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [33] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [34]  at :0
+  [35] g_main_context_dispatch at :0
+  [36] g_main_context_iterate.isra.20 at :0
+  [37] g_main_context_iteration at :0
+  [38] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [39] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [40] QCoreApplication::exec() at :0
+  [41] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [42] __libc_start_main at :0
+  [43] _start at :0
+  [44]  at :0
+"
+2026-06-11T18:04:58.278Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] std::terminate() at :0
+  [10] __cxa_rethrow at :0
+  [11] main at ResInsight/ApplicationExeCode/RiaMain.cpp:232
+  [12] __libc_start_main at :0
+  [13] _start at :0
+  [14]  at :0
+"
+2026-06-11T16:00:27.184Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] std::terminate() at :0
+  [10] __cxa_rethrow at :0
+  [11] main at ResInsight/ApplicationExeCode/RiaMain.cpp:232
+  [12] __libc_start_main at :0
+  [13] _start at :0
+  [14]  at :0
+"
+2026-06-11T13:04:29.981Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] __cxa_call_terminate at :0
+  [10] __gxx_personality_v0 at :0
+  [11] _Unwind_RaiseException_Phase2 at :0
+  [12] _Unwind_Resume at :0
+  [13] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:121
+  [14] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+  [15] gomp_thread_start at :0
+  [16] start_thread at :0
+  [17] __GI___clone at :0
+  [18]  at :0
+"
+2026-06-11T12:25:22.03Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] QArrayDataPointer<char16_t>::QArrayDataPointer(QArrayDataPointer<char16_t> const&) at /private/f_resinsight_build/resbuild/qt/6.6.3/gcc_64/include/QtCore/qarraydatapointer.h:38
+  [4] RimCase::gridFileName() const at ResInsight/ApplicationLibCode/ProjectDataModel/RimCase.cpp:136
+  [5] RimReloadCaseTools::findSummaryCaseFromEclipseResultCase(RimEclipseResultCase const*) at ResInsight/ApplicationLibCode/ProjectDataModel/RimReloadCaseTools.cpp:196
+  [6] RimReloadCaseTools::reloadEclipseData(RimEclipseCase*, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimReloadCaseTools.cpp:100
+  [7] RicReloadCaseFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/RicReloadCaseFeature.cpp:62
+  [8] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+  [9]  at :0
+  [10] QAction::triggered(bool) at :0
+  [11] QAction::activate(QAction::ActionEvent) at :0
+  [12]  at :0
+  [13]  at :0
+  [14] QWidget::event(QEvent*) at :0
+  [15] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [16] QApplication::notify(QObject*, QEvent*) at :0
+  [17] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [18] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [19] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [20]  at :0
+  [21]  at :0
+  [22] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [23] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [24] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [25] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [26] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [27]  at :0
+  [28] g_main_context_dispatch at :0
+  [29] g_main_context_iterate.isra.20 at :0
+  [30] g_main_context_iteration at :0
+  [31] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [32] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [33]  at :0
+  [34] QMenu::exec(QPoint const&, QAction*) at :0
+  [35] RiuMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:2056
+  [36]  at :0
+  [37] QWidget::customContextMenuRequested(QPoint const&) at :0
+  [38] QWidget::event(QEvent*) at :0
+  [39] QFrame::event(QEvent*) at :0
+  [40] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [41] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [42] QApplication::notify(QObject*, QEvent*) at :0
+  [43] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [44] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [45]  at :0
+  [46]  at :0
+  [47] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [48] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [49] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [50] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [51] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [52]  at :0
+  [53] g_main_context_dispatch at :0
+  [54] g_main_context_iterate.isra.20 at :0
+  [55] g_main_context_iteration at :0
+  [56] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [57] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [58] QCoreApplication::exec() at :0
+  [59] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [60] __libc_start_main at :0
+  [61] _start at :0
+  [62]  at :0
+"
+2026-06-11T12:11:13.925Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] QArrayDataPointer<char16_t>::QArrayDataPointer(QArrayDataPointer<char16_t> const&) at /private/f_resinsight_build/resbuild/qt/6.6.3/gcc_64/include/QtCore/qarraydatapointer.h:38
+  [4] RimCase::gridFileName() const at ResInsight/ApplicationLibCode/ProjectDataModel/RimCase.cpp:136
+  [5] RimReloadCaseTools::findSummaryCaseFromEclipseResultCase(RimEclipseResultCase const*) at ResInsight/ApplicationLibCode/ProjectDataModel/RimReloadCaseTools.cpp:196
+  [6] RimReloadCaseTools::reloadEclipseData(RimEclipseCase*, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimReloadCaseTools.cpp:100
+  [7] RicReloadCaseFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/RicReloadCaseFeature.cpp:62
+  [8] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+  [9]  at :0
+  [10] QAction::triggered(bool) at :0
+  [11] QAction::activate(QAction::ActionEvent) at :0
+  [12]  at :0
+  [13]  at :0
+  [14] QWidget::event(QEvent*) at :0
+  [15] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [16] QApplication::notify(QObject*, QEvent*) at :0
+  [17] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [18] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [19] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [20]  at :0
+  [21]  at :0
+  [22] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [23] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [24] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [25] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [26] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [27]  at :0
+  [28] g_main_context_dispatch at :0
+  [29] g_main_context_iterate.isra.20 at :0
+  [30] g_main_context_iteration at :0
+  [31] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [32] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [33]  at :0
+  [34] QMenu::exec(QPoint const&, QAction*) at :0
+  [35] RiuMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:2056
+  [36]  at :0
+  [37] QWidget::customContextMenuRequested(QPoint const&) at :0
+  [38] QWidget::event(QEvent*) at :0
+  [39] QFrame::event(QEvent*) at :0
+  [40] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [41] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [42] QApplication::notify(QObject*, QEvent*) at :0
+  [43] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [44] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [45]  at :0
+  [46]  at :0
+  [47] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [48] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [49] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [50] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [51] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [52]  at :0
+  [53] g_main_context_dispatch at :0
+  [54] g_main_context_iterate.isra.20 at :0
+  [55] g_main_context_iteration at :0
+  [56] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [57] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [58] QCoreApplication::exec() at :0
+  [59] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [60] __libc_start_main at :0
+  [61] _start at :0
+  [62]  at :0
+"
+2026-06-11T12:08:39.576Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] QArrayDataPointer<char16_t>::QArrayDataPointer(QArrayDataPointer<char16_t> const&) at /private/f_resinsight_build/resbuild/qt/6.6.3/gcc_64/include/QtCore/qarraydatapointer.h:38
+  [4] RimCase::gridFileName() const at ResInsight/ApplicationLibCode/ProjectDataModel/RimCase.cpp:136
+  [5] RimReloadCaseTools::findSummaryCaseFromEclipseResultCase(RimEclipseResultCase const*) at ResInsight/ApplicationLibCode/ProjectDataModel/RimReloadCaseTools.cpp:196
+  [6] RimReloadCaseTools::reloadEclipseData(RimEclipseCase*, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimReloadCaseTools.cpp:100
+  [7] RicReloadCaseFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/RicReloadCaseFeature.cpp:62
+  [8] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+  [9]  at :0
+  [10] QAction::triggered(bool) at :0
+  [11] QAction::activate(QAction::ActionEvent) at :0
+  [12]  at :0
+  [13]  at :0
+  [14] QWidget::event(QEvent*) at :0
+  [15] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [16] QApplication::notify(QObject*, QEvent*) at :0
+  [17] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [18] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [19] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [20]  at :0
+  [21]  at :0
+  [22] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [23] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [24] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [25] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [26] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [27]  at :0
+  [28] g_main_context_dispatch at :0
+  [29] g_main_context_iterate.isra.20 at :0
+  [30] g_main_context_iteration at :0
+  [31] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [32] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [33]  at :0
+  [34] QMenu::exec(QPoint const&, QAction*) at :0
+  [35] RiuMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:2056
+  [36]  at :0
+  [37] QWidget::customContextMenuRequested(QPoint const&) at :0
+  [38] QWidget::event(QEvent*) at :0
+  [39] QFrame::event(QEvent*) at :0
+  [40] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [41] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [42] QApplication::notify(QObject*, QEvent*) at :0
+  [43] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [44] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [45]  at :0
+  [46]  at :0
+  [47] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [48] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [49] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [50] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [51] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [52]  at :0
+  [53] g_main_context_dispatch at :0
+  [54] g_main_context_iterate.isra.20 at :0
+  [55] g_main_context_iteration at :0
+  [56] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [57] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [58] QCoreApplication::exec() at :0
+  [59] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [60] __libc_start_main at :0
+  [61] _start at :0
+  [62]  at :0
+"
+2026-06-11T12:06:52.69Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] QArrayDataPointer<char16_t>::QArrayDataPointer(QArrayDataPointer<char16_t> const&) at /private/f_resinsight_build/resbuild/qt/6.6.3/gcc_64/include/QtCore/qarraydatapointer.h:38
+  [4] RimCase::gridFileName() const at ResInsight/ApplicationLibCode/ProjectDataModel/RimCase.cpp:136
+  [5] RimReloadCaseTools::findSummaryCaseFromEclipseResultCase(RimEclipseResultCase const*) at ResInsight/ApplicationLibCode/ProjectDataModel/RimReloadCaseTools.cpp:196
+  [6] RimReloadCaseTools::reloadEclipseData(RimEclipseCase*, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimReloadCaseTools.cpp:100
+  [7] RicReloadCaseFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/RicReloadCaseFeature.cpp:62
+  [8] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+  [9]  at :0
+  [10] QAction::triggered(bool) at :0
+  [11] QAction::activate(QAction::ActionEvent) at :0
+  [12]  at :0
+  [13]  at :0
+  [14] QWidget::event(QEvent*) at :0
+  [15] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [16] QApplication::notify(QObject*, QEvent*) at :0
+  [17] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [18] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [19] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [20]  at :0
+  [21]  at :0
+  [22] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [23] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [24] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [25] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [26] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [27]  at :0
+  [28] g_main_context_dispatch at :0
+  [29] g_main_context_iterate.isra.20 at :0
+  [30] g_main_context_iteration at :0
+  [31] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [32] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [33]  at :0
+  [34] QMenu::exec(QPoint const&, QAction*) at :0
+  [35] RiuMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:2056
+  [36]  at :0
+  [37] QWidget::customContextMenuRequested(QPoint const&) at :0
+  [38] QWidget::event(QEvent*) at :0
+  [39] QFrame::event(QEvent*) at :0
+  [40] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [41] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [42] QApplication::notify(QObject*, QEvent*) at :0
+  [43] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [44] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [45]  at :0
+  [46]  at :0
+  [47] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [48] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [49] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [50] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [51] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [52]  at :0
+  [53] g_main_context_dispatch at :0
+  [54] g_main_context_iterate.isra.20 at :0
+  [55] g_main_context_iteration at :0
+  [56] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [57] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [58] QCoreApplication::exec() at :0
+  [59] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [60] __libc_start_main at :0
+  [61] _start at :0
+  [62]  at :0
+"
+2026-06-11T12:06:17.304Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] QArrayDataPointer<char16_t>::QArrayDataPointer(QArrayDataPointer<char16_t> const&) at /private/f_resinsight_build/resbuild/qt/6.6.3/gcc_64/include/QtCore/qarraydatapointer.h:38
+  [4] RimCase::gridFileName() const at ResInsight/ApplicationLibCode/ProjectDataModel/RimCase.cpp:136
+  [5] RimReloadCaseTools::findSummaryCaseFromEclipseResultCase(RimEclipseResultCase const*) at ResInsight/ApplicationLibCode/ProjectDataModel/RimReloadCaseTools.cpp:196
+  [6] RimReloadCaseTools::reloadEclipseData(RimEclipseCase*, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimReloadCaseTools.cpp:100
+  [7] RicReloadCaseFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/RicReloadCaseFeature.cpp:62
+  [8] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+  [9]  at :0
+  [10] QAction::triggered(bool) at :0
+  [11] QAction::activate(QAction::ActionEvent) at :0
+  [12]  at :0
+  [13]  at :0
+  [14] QWidget::event(QEvent*) at :0
+  [15] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [16] QApplication::notify(QObject*, QEvent*) at :0
+  [17] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [18] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [19] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [20]  at :0
+  [21]  at :0
+  [22] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [23] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [24] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [25] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [26] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [27]  at :0
+  [28] g_main_context_dispatch at :0
+  [29] g_main_context_iterate.isra.20 at :0
+  [30] g_main_context_iteration at :0
+  [31] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [32] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [33]  at :0
+  [34] QMenu::exec(QPoint const&, QAction*) at :0
+  [35] RiuMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:2056
+  [36]  at :0
+  [37] QWidget::customContextMenuRequested(QPoint const&) at :0
+  [38] QWidget::event(QEvent*) at :0
+  [39] QFrame::event(QEvent*) at :0
+  [40] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [41] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [42] QApplication::notify(QObject*, QEvent*) at :0
+  [43] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [44] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [45]  at :0
+  [46]  at :0
+  [47] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [48] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [49] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [50] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [51] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [52]  at :0
+  [53] g_main_context_dispatch at :0
+  [54] g_main_context_iterate.isra.20 at :0
+  [55] g_main_context_iteration at :0
+  [56] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [57] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [58] QCoreApplication::exec() at :0
+  [59] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [60] __libc_start_main at :0
+  [61] _start at :0
+  [62]  at :0
+"
+2026-06-11T11:44:57.648Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] __cxa_call_terminate at :0
+  [10] __gxx_personality_v0 at :0
+  [11] _Unwind_RaiseException_Phase2 at :0
+  [12] _Unwind_Resume at :0
+  [13] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:121
+  [14] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+  [15] gomp_thread_start at :0
+  [16] start_thread at :0
+  [17] __GI___clone at :0
+  [18]  at :0
+"
+2026-06-11T10:55:17.861Z,2026.06.0-RC_3,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:167
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:263
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] caf::PdmFieldUiCap<caf::PdmField<QString> >::setValueFromUiEditor(QVariant const&, bool) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafInternalPdmUiFieldCapability.inl:30
+  [6] caf::PdmUiCommandSystemProxy::setUiValueToField(caf::PdmUiFieldHandle*, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiCommandSystemProxy.cpp:122
+  [7] caf::PdmUiTreeSelectionQModel::setData(QModelIndex const&, QVariant const&, int) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionQModel.cpp:482
+  [8] QSortFilterProxyModel::setData(QModelIndex const&, QVariant const&, int) at :0
+  [9] caf::PdmUiTreeSelectionEditor::currentChanged(QModelIndex const&) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionEditor.cpp:829
+  [10] caf::PdmUiTreeSelectionEditor::slotClicked(QModelIndex const&) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionEditor.cpp:776
+  [11]  at :0
+  [12] QAbstractItemView::clicked(QModelIndex const&) at :0
+  [13] QAbstractItemView::mouseReleaseEvent(QMouseEvent*) at :0
+  [14] QWidget::event(QEvent*) at :0
+  [15] QFrame::event(QEvent*) at :0
+  [16] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [17] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [18] QApplication::notify(QObject*, QEvent*) at :0
+  [19] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1828
+  [20] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [21] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [22]  at :0
+  [23]  at :0
+  [24] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [25] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1828
+  [26] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [27] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [28] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [29]  at :0
+  [30] g_main_context_dispatch at :0
+  [31] g_main_context_iterate.isra.20 at :0
+  [32] g_main_context_iteration at :0
+  [33] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [34] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [35] QCoreApplication::exec() at :0
+  [36] main at ResInsight/ApplicationExeCode/RiaMain.cpp:258
+  [37] __libc_start_main at :0
+  [38] _start at :0
+  [39]  at :0
+"
+2026-06-11T08:43:10.483Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] std::vector<double, std::allocator<double> >::size() const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/stl_vector.h:993
+  [4] RigFlowDiagResults::calculateDerivedResult(RigFlowDiagResultAddress const&, unsigned long) at ResInsight/ApplicationLibCode/ReservoirDataModel/RigFlowDiagResults.cpp:208
+  [5] RigFlowDiagResults::findOrCalculateResult(RigFlowDiagResultAddress const&, unsigned long) at ResInsight/ApplicationLibCode/ReservoirDataModel/RigFlowDiagResults.cpp:92
+  [6] RigFlowDiagStatCalc::minMaxCellScalarValues(unsigned long, double&, double&) at ResInsight/ApplicationLibCode/ReservoirDataModel/RigFlowDiagStatCalc.cpp:49
+  [7] RigStatisticsDataCache::minMaxCellScalarValues(unsigned long, double&, double&) at ResInsight/ApplicationLibCode/ResultStatisticsCache/RigStatisticsDataCache.cpp:119
+  [8] RimEclipseResultDefinitionTools::updateLegendForFlowDiagnostics(RimEclipseResultDefinition const*, RimRegularLegendConfig*, int) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinitionTools.cpp:422
+  [9] RimEclipseResultDefinition::updateRangesForExplicitLegends(RimRegularLegendConfig*, RimTernaryLegendConfig*, int, RimEclipseView*) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:1695
+  [10] RimEclipseView::updateLegendRangesTextAndVisibility(RimRegularLegendConfig*, RimTernaryLegendConfig*, QString, RimEclipseResultDefinition*, int) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp:1620
+  [11] RimEclipseView::onUpdateLegends() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp:1489
+  [12] RimEclipseView::onCreateDisplayModel() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp:796
+  [13] Rim3dView::createDisplayModelAndRedraw() at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:718
+  [14] RiaViewRedrawScheduler::updateAndRedrawScheduledViews() at ResInsight/ApplicationLibCode/Application/RiaViewRedrawScheduler.cpp:93
+  [15]  at :0
+  [16] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [17] QObject::event(QEvent*) at :0
+  [18] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [19] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [20] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [21] QTimerInfoList::activateTimers() at :0
+  [22]  at :0
+  [23] g_main_context_dispatch at :0
+  [24] g_main_context_iterate.isra.20 at :0
+  [25] g_main_context_iteration at :0
+  [26] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [27] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [28] QCoreApplication::exec() at :0
+  [29] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [30] __libc_start_main at :0
+  [31] _start at :0
+  [32]  at :0
+"
+2026-06-11T07:55:16.572Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] QWidgetPrivate::shouldPaintOnScreen() const at :0
+  [4] QWidgetRepaintManager::markNeedsFlush(QWidget*, QRegion const&, QPoint const&) at :0
+  [5] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [6] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [7] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [8] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [9] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [10] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [11] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [12] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [13] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [14] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [15] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [16] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [17] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [18] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [19] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [20] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [21] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [22] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [23] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [24] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [25] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [26] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [27] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [28] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [29] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [30] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [31] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [32] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [33] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [34] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [35] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [36] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [37] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [38] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [39] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [40] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [41] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [42] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [43] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [44] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [45] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [46] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [47] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [48] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [49] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [50] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [51] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [52] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [53] QWidgetRepaintManager::paintAndFlush() at :0
+  [54] QWidget::event(QEvent*) at :0
+  [55] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [56] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [57] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [58] QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*) at :0
+  [59]  at :0
+  [60] g_main_context_dispatch at :0
+  [61] g_main_context_iterate.isra.20 at :0
+  [62] g_main_context_iteration at :0
+  [63] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [64] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [65] QCoreApplication::exec() at :0
+  [66] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [67] __libc_start_main at :0
+  [68] _start at :0
+  [69]  at :0
+"
+2026-06-11T06:21:46.27Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] ecl_kw_get_data_type at ResInsight/ThirdParty/Ert/lib/ecl/ecl_kw.cpp:1776
+  [4] ecl_file_kw_assert_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_kw.cpp:211
+  [5] ecl_file_kw_load_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_kw.cpp:244
+  [6] ecl_file_view_get_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_view.cpp:149
+  [7] RifEclipseOutputFileTools::keywordData(ecl_file_struct const*, QString const&, unsigned long, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseOutputFileTools.cpp:305
+  [8] RifEclipseUnifiedRestartFileAccess::results(QString const&, unsigned long, unsigned long, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseUnifiedRestartFileAccess.cpp:248
+  [9] RifReaderEclipseOutput::dynamicResult(QString const&, RiaDefines::PorosityModelType, unsigned long, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp:1070
+  [10] RigCaseCellResultsData::findOrLoadKnownScalarResult(RigEclipseResultAddress const&) at ResInsight/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp:1538
+  [11] RigCaseCellResultsData::ensureKnownResultLoaded(RigEclipseResultAddress const&) at ResInsight/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp:1264
+  [12] RimEclipseResultDefinition::loadResult() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:1134
+  [13] RimWellLogExtractionCurve::extractEclipseData(RimEclipseCase*, bool*) at ResInsight/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogExtractionCurve.cpp:546
+  [14] RimWellLogExtractionCurve::extractData(bool*, std::optional<double> const&, std::optional<double> const&) at ResInsight/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogExtractionCurve.cpp:457
+  [15] RimWellLogExtractionCurve::performDataExtraction(bool*) at ResInsight/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogExtractionCurve.cpp:433
+  [16] RimWellLogExtractionCurve::onLoadDataAndUpdate(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogExtractionCurve.cpp:342
+  [17] RimPlotCurve::loadDataAndUpdate(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimPlotCurve.cpp:587
+  [18] RimWellLogTrack::onLoadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogTrack.cpp:1213
+  [19] RimDepthTrackPlot::updateDepthAxisVisibility() at ResInsight/ApplicationLibCode/ProjectDataModel/RimDepthTrackPlot.cpp:979
+  [20] RimDepthTrackPlot::updatePlots() at ResInsight/ApplicationLibCode/ProjectDataModel/RimDepthTrackPlot.cpp:1244
+  [21] RimDepthTrackPlot::onLoadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimDepthTrackPlot.cpp:1233
+  [22] RimWellRftPlot::updateCurvesInPlot(std::set<RiaRftPltCurveDefinition, std::less<RiaRftPltCurveDefinition>, std::allocator<RiaRftPltCurveDefinition> > const&, std::set<RiaRftPltCurveDefinition, std::less<RiaRftPltCurveDefinition>, std::allocator<RiaRftPltCurveDefinition> > const&, std::set<RimWellLogCurve*, std::less<RimWellLogCurve*>, std::allocator<RimWellLogCurve*> > const&) at ResInsight/ApplicationLibCode/ProjectDataModel/Flow/RimWellRftPlot.cpp:790
+  [23] RimWellRftPlot::syncCurvesFromUiSelection() at ResInsight/ApplicationLibCode/ProjectDataModel/Flow/RimWellRftPlot.cpp:482
+  [24] RimWellRftPlot::setOrInitializeDataSources(std::vector<RifDataSourceForRftPlt, std::allocator<RifDataSourceForRftPlt> > const&) at ResInsight/ApplicationLibCode/ProjectDataModel/Flow/RimWellRftPlot.cpp:344
+  [25] RimWellRftPlot::initializeDataSources(RimWellRftPlot*) at ResInsight/ApplicationLibCode/ProjectDataModel/Flow/RimWellRftPlot.cpp:1763
+  [26] RicCreateRftPlotsFeature::appendRftPlotForWell(QString const&, RimRftPlotCollection*) at ResInsight/ApplicationLibCode/Commands/WellLogCommands/RicCreateRftPlotsFeature.cpp:145
+  [27] RicNewRftPlotFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/WellLogCommands/RicNewRftPlotFeature.cpp:62
+  [28] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+  [29]  at :0
+  [30] QAction::triggered(bool) at :0
+  [31] QAction::activate(QAction::ActionEvent) at :0
+  [32]  at :0
+  [33]  at :0
+  [34] QWidget::event(QEvent*) at :0
+  [35] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [36] QApplication::notify(QObject*, QEvent*) at :0
+  [37] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [38] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [39] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [40]  at :0
+  [41]  at :0
+  [42] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [43] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [44] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [45] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [46] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [47]  at :0
+  [48] g_main_context_dispatch at :0
+  [49] g_main_context_iterate.isra.20 at :0
+  [50] g_main_context_iteration at :0
+  [51] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [52] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [53]  at :0
+  [54] QMenu::exec(QPoint const&, QAction*) at :0
+  [55] RiuPlotMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp:1058
+  [56]  at :0
+  [57] QWidget::customContextMenuRequested(QPoint const&) at :0
+  [58] QWidget::event(QEvent*) at :0
+  [59] QFrame::event(QEvent*) at :0
+  [60] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [61] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [62] QApplication::notify(QObject*, QEvent*) at :0
+  [63] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [64] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [65]  at :0
+  [66]  at :0
+  [67] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [68] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [69] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [70] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [71] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [72]  at :0
+  [73] g_main_context_dispatch at :0
+  [74] g_main_context_iterate.isra.20 at :0
+  [75] g_main_context_iteration at :0
+  [76] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [77] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [78] QCoreApplication::exec() at :0
+  [79] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [80] __libc_start_main at :0
+  [81] _start at :0
+  [82]  at :0
+"
+2026-06-10T22:21:19.311Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] std::__atomic_base<int>::fetch_sub(int, std::memory_order) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/atomic_base.h:645
+  [4] __run_exit_handlers at :0
+  [5] exit at :0
+  [6] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:228
+  [7]  at :0
+  [8] __GI_raise at :0
+  [9] __GI_abort at :0
+  [10] __libc_message at :0
+  [11] malloc_printerr at :0
+  [12] _int_free at :0
+  [13] std::__new_allocator<double>::deallocate(double*, unsigned long) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/new_allocator.h:172
+  [14] RigStimPlanFractureDefinition::~RigStimPlanFractureDefinition() at ResInsight/ApplicationLibCode/ReservoirDataModel/RigStimPlanFractureDefinition.cpp:67
+  [15] cvf::Object::release() const at ResInsight/Fwk/VizFwk/LibCore/cvfObject.inl:90
+  [16] RimStimPlanFractureTemplate::~RimStimPlanFractureTemplate() at ResInsight/ApplicationLibCode/ProjectDataModel/Completions/RimStimPlanFractureTemplate.cpp:95
+  [17] caf::PdmChildArrayField<RimFractureTemplate*>::deleteChildren() at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmChildArrayField.inl:181
+  [18] caf::PdmChildArrayField<RimFractureTemplate*>::~PdmChildArrayField() at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmChildArrayField.inl:17
+  [19] RimFractureTemplateCollection::~RimFractureTemplateCollection() at ResInsight/ApplicationLibCode/ProjectDataModel/Completions/RimFractureTemplateCollection.h:34
+  [20] caf::PdmChildField<RimFractureTemplateCollection*>::~PdmChildField() at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmChildField.inl:80
+  [21] RimCompletionTemplateCollection::~RimCompletionTemplateCollection() at ResInsight/ApplicationLibCode/ProjectDataModel/Completions/RimCompletionTemplateCollection.cpp:60
+  [22] caf::PdmChildField<RimCompletionTemplateCollection*>::~PdmChildField() at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmChildField.inl:80
+  [23] RimOilField::~RimOilField() at ResInsight/ApplicationLibCode/ProjectDataModel/RimOilField.cpp:113
+  [24] caf::PdmChildArrayField<RimOilField*>::deleteChildren() at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmChildArrayField.inl:181
+  [25] RimProject::close() at ResInsight/ApplicationLibCode/ProjectDataModel/RimProject.cpp:257
+  [26] RiaApplication::closeProject() at ResInsight/ApplicationLibCode/Application/RiaApplication.cpp:1021
+  [27] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:36
+  [28]  at :0
+  [29] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [30] QObject::event(QEvent*) at :0
+  [31] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [32] QTimerInfoList::activateTimers() at :0
+  [33]  at :0
+  [34] g_main_context_dispatch at :0
+  [35] g_main_context_iterate.isra.20 at :0
+  [36] g_main_context_iteration at :0
+  [37] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [38] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [39] QCoreApplication::exec() at :0
+  [40] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [41] __libc_start_main at :0
+  [42] _start at :0
+  [43]  at :0
+"
+2026-06-10T22:21:19.134Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __libc_message at :0
+  [6] malloc_printerr at :0
+  [7] _int_free at :0
+  [8] std::__new_allocator<double>::deallocate(double*, unsigned long) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/new_allocator.h:172
+  [9] RigStimPlanFractureDefinition::~RigStimPlanFractureDefinition() at ResInsight/ApplicationLibCode/ReservoirDataModel/RigStimPlanFractureDefinition.cpp:67
+  [10] cvf::Object::release() const at ResInsight/Fwk/VizFwk/LibCore/cvfObject.inl:90
+  [11] RimStimPlanFractureTemplate::~RimStimPlanFractureTemplate() at ResInsight/ApplicationLibCode/ProjectDataModel/Completions/RimStimPlanFractureTemplate.cpp:95
+  [12] caf::PdmChildArrayField<RimFractureTemplate*>::deleteChildren() at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmChildArrayField.inl:181
+  [13] caf::PdmChildArrayField<RimFractureTemplate*>::~PdmChildArrayField() at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmChildArrayField.inl:17
+  [14] RimFractureTemplateCollection::~RimFractureTemplateCollection() at ResInsight/ApplicationLibCode/ProjectDataModel/Completions/RimFractureTemplateCollection.h:34
+  [15] caf::PdmChildField<RimFractureTemplateCollection*>::~PdmChildField() at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmChildField.inl:80
+  [16] RimCompletionTemplateCollection::~RimCompletionTemplateCollection() at ResInsight/ApplicationLibCode/ProjectDataModel/Completions/RimCompletionTemplateCollection.cpp:60
+  [17] caf::PdmChildField<RimCompletionTemplateCollection*>::~PdmChildField() at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmChildField.inl:80
+  [18] RimOilField::~RimOilField() at ResInsight/ApplicationLibCode/ProjectDataModel/RimOilField.cpp:113
+  [19] caf::PdmChildArrayField<RimOilField*>::deleteChildren() at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmChildArrayField.inl:181
+  [20] RimProject::close() at ResInsight/ApplicationLibCode/ProjectDataModel/RimProject.cpp:257
+  [21] RiaApplication::closeProject() at ResInsight/ApplicationLibCode/Application/RiaApplication.cpp:1021
+  [22] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:36
+  [23]  at :0
+  [24] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [25] QObject::event(QEvent*) at :0
+  [26] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [27] QTimerInfoList::activateTimers() at :0
+  [28]  at :0
+  [29] g_main_context_dispatch at :0
+  [30] g_main_context_iterate.isra.20 at :0
+  [31] g_main_context_iteration at :0
+  [32] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [33] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [34] QCoreApplication::exec() at :0
+  [35] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [36] __libc_start_main at :0
+  [37] _start at :0
+  [38]  at :0
+"
+2026-06-10T21:56:05.631Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] QString::size() const at /private/f_resinsight_build/resbuild/qt/6.6.3/gcc_64/include/QtCore/qstring.h:182
+  [4] std::map<QString, QString, std::less<QString>, std::allocator<std::pair<QString const, QString> > >::contains(QString const&) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/stl_map.h:1285
+  [5] RigCaseCellResultsData::hasResultEntry(RigEclipseResultAddress const&) const at ResInsight/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp:1287
+  [6] RigEclipseContourMapProjection::generateResults(RigEclipseContourMapProjection const&, RigContourMapGrid const&, RigCaseCellResultsData&, RigEclipseResultAddress const&, RigContourMapCalculator::ResultAggregationType, int, RigFloodingSettings&) at ResInsight/ApplicationLibCode/ReservoirDataModel/ContourMap/RigEclipseContourMapProjection.cpp:103
+  [7] RigEclipseContourMapProjection::generateAndSaveResults(RigEclipseResultAddress const&, RigContourMapCalculator::ResultAggregationType, int, RigFloodingSettings&) at ResInsight/ApplicationLibCode/ReservoirDataModel/ContourMap/RigEclipseContourMapProjection.cpp:71
+  [8] RimEclipseContourMapProjection::generateAndSaveResults(int) at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapProjection.cpp:213
+  [9] RimContourMapProjection::generateResultsIfNecessary(int) at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimContourMapProjection.cpp:164
+  [10] RimEclipseContourMapView::updateGeometry() at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapView.cpp:282
+  [11] Rim3dView::updateDisplayModelForCurrentTimeStepAndRedraw() at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:673
+  [12] RiuViewer::setCurrentFrame(int) at ResInsight/ApplicationLibCode/UserInterface/RiuViewer.cpp:1008
+  [13] RimEclipseView::onCreateDisplayModel() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp:791
+  [14] RimEclipseContourMapView::onCreateDisplayModel() at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapView.cpp:205
+  [15] Rim3dView::createDisplayModelAndRedraw() at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:718
+  [16] RiaViewRedrawScheduler::updateAndRedrawScheduledViews() at ResInsight/ApplicationLibCode/Application/RiaViewRedrawScheduler.cpp:93
+  [17]  at :0
+  [18] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [19] QObject::event(QEvent*) at :0
+  [20] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [21] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [22] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [23] QTimerInfoList::activateTimers() at :0
+  [24]  at :0
+  [25] g_main_context_dispatch at :0
+  [26] g_main_context_iterate.isra.20 at :0
+  [27] g_main_context_iteration at :0
+  [28] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [29] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [30] QCoreApplication::exec() at :0
+  [31] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [32] __libc_start_main at :0
+  [33] _start at :0
+  [34]  at :0
+"
+2026-06-10T13:17:05.526Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] ecl_kw_get_data_type at ResInsight/ThirdParty/Ert/lib/ecl/ecl_kw.cpp:1776
+  [4] ecl_file_kw_assert_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_kw.cpp:211
+  [5] ecl_file_kw_load_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_kw.cpp:244
+  [6] ecl_file_view_get_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_view.cpp:149
+  [7] RifEclipseOutputFileTools::keywordData(ecl_file_struct const*, QString const&, unsigned long, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseOutputFileTools.cpp:305
+  [8] RifEclipseUnifiedRestartFileAccess::results(QString const&, unsigned long, unsigned long, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseUnifiedRestartFileAccess.cpp:248
+  [9] RifReaderEclipseOutput::dynamicResult(QString const&, RiaDefines::PorosityModelType, unsigned long, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp:1070
+  [10] RigCaseCellResultsData::findOrLoadKnownScalarResult(RigEclipseResultAddress const&) at ResInsight/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp:1538
+  [11] RigCaseCellResultsData::ensureKnownResultLoaded(RigEclipseResultAddress const&) at ResInsight/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp:1264
+  [12] RimEclipseResultDefinition::loadResult() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:1134
+  [13] RimEclipseCellColors::loadResult() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCellColors.cpp:260
+  [14] RimEclipseResultDefinition::loadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:533
+  [15] RimEclipseResultDefinition::fieldChangedByUi(caf::PdmFieldHandle const*, QVariant const&, QVariant const&) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:305
+  [16] RimEclipseCellColors::fieldChangedByUi(caf::PdmFieldHandle const*, QVariant const&, QVariant const&) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCellColors.cpp:90
+  [17] caf::PdmUiFieldHandle::notifyFieldChanged(QVariant const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiFieldHandle.cpp:74
+  [18] caf::PdmFieldUiCap<caf::PdmField<QString> >::setValueFromUiEditor(QVariant const&, bool) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafInternalPdmUiFieldCapability.inl:110
+  [19] caf::PdmUiCommandSystemProxy::setUiValueToField(caf::PdmUiFieldHandle*, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiCommandSystemProxy.cpp:122
+  [20] caf::PdmUiTreeSelectionQModel::setData(QModelIndex const&, QVariant const&, int) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionQModel.cpp:482
+  [21] QSortFilterProxyModel::setData(QModelIndex const&, QVariant const&, int) at :0
+  [22] caf::PdmUiTreeSelectionEditor::currentChanged(QModelIndex const&) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionEditor.cpp:812
+  [23] caf::PdmUiTreeSelectionEditor::slotClicked(QModelIndex const&) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionEditor.cpp:759
+  [24]  at :0
+  [25] QAbstractItemView::clicked(QModelIndex const&) at :0
+  [26] QAbstractItemView::mouseReleaseEvent(QMouseEvent*) at :0
+  [27] QWidget::event(QEvent*) at :0
+  [28] QFrame::event(QEvent*) at :0
+  [29] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [30] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [31] QApplication::notify(QObject*, QEvent*) at :0
+  [32] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [33] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [34] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [35]  at :0
+  [36]  at :0
+  [37] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [38] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [39] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [40] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [41] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [42]  at :0
+  [43] g_main_context_dispatch at :0
+  [44] g_main_context_iterate.isra.20 at :0
+  [45] g_main_context_iteration at :0
+  [46] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [47] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [48] QCoreApplication::exec() at :0
+  [49] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [50] __libc_start_main at :0
+  [51] _start at :0
+  [52]  at :0
+"
+2026-06-09T19:33:37.704Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] QWidgetPrivate::shouldPaintOnScreen() const at :0
+  [4] QWidgetRepaintManager::markNeedsFlush(QWidget*, QRegion const&, QPoint const&) at :0
+  [5] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [6] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [7] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [8] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [9] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [10] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [11] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [12] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [13] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [14] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [15] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [16] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [17] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [18] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [19] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [20] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [21] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [22] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [23] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [24] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [25] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [26] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [27] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [28] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [29] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [30] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [31] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [32] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [33] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [34] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [35] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [36] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [37] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [38] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [39] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [40] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [41] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [42] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [43] QWidgetRepaintManager::paintAndFlush() at :0
+  [44] QWidget::event(QEvent*) at :0
+  [45] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [46] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [47] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [48] QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*) at :0
+  [49]  at :0
+  [50] g_main_context_dispatch at :0
+  [51] g_main_context_iterate.isra.20 at :0
+  [52] g_main_context_iteration at :0
+  [53] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [54] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [55] QCoreApplication::exec() at :0
+  [56] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [57] __libc_start_main at :0
+  [58] _start at :0
+  [59]  at :0
+"
+2026-06-09T16:14:29.739Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __libc_poll at :0
+  [4] g_main_context_iterate.isra.20 at :0
+  [5] g_main_context_iteration at :0
+  [6] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [7] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [8] QCoreApplication::exec() at :0
+  [9] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [10] __libc_start_main at :0
+  [11] _start at :0
+  [12]  at :0
+"
+2026-06-09T15:09:35.656Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] ecl_kw_get_data_type at ResInsight/ThirdParty/Ert/lib/ecl/ecl_kw.cpp:1776
+  [4] ecl_file_kw_assert_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_kw.cpp:211
+  [5] ecl_file_kw_load_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_kw.cpp:244
+  [6] ecl_file_view_get_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_view.cpp:149
+  [7] RifEclipseOutputFileTools::keywordData(ecl_file_struct const*, QString const&, unsigned long, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseOutputFileTools.cpp:305
+  [8] RifEclipseUnifiedRestartFileAccess::results(QString const&, unsigned long, unsigned long, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseUnifiedRestartFileAccess.cpp:248
+  [9] RifReaderEclipseOutput::dynamicResult(QString const&, RiaDefines::PorosityModelType, unsigned long, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp:1070
+  [10] RigCaseCellResultsData::findOrLoadKnownScalarResult(RigEclipseResultAddress const&) at ResInsight/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp:1538
+  [11] RigCaseCellResultsData::ensureKnownResultLoaded(RigEclipseResultAddress const&) at ResInsight/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp:1264
+  [12] RimEclipseResultDefinition::loadResult() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:1134
+  [13] RimEclipseCellColors::loadResult() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCellColors.cpp:260
+  [14] RimEclipseResultDefinition::loadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:533
+  [15] RimEclipseResultDefinition::fieldChangedByUi(caf::PdmFieldHandle const*, QVariant const&, QVariant const&) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:305
+  [16] RimEclipseCellColors::fieldChangedByUi(caf::PdmFieldHandle const*, QVariant const&, QVariant const&) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCellColors.cpp:90
+  [17] caf::PdmUiFieldHandle::notifyFieldChanged(QVariant const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiFieldHandle.cpp:74
+  [18] caf::PdmFieldUiCap<caf::PdmField<QString> >::setValueFromUiEditor(QVariant const&, bool) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafInternalPdmUiFieldCapability.inl:110
+  [19] caf::PdmUiCommandSystemProxy::setUiValueToField(caf::PdmUiFieldHandle*, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiCommandSystemProxy.cpp:122
+  [20] caf::PdmUiTreeSelectionQModel::setData(QModelIndex const&, QVariant const&, int) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionQModel.cpp:482
+  [21] QSortFilterProxyModel::setData(QModelIndex const&, QVariant const&, int) at :0
+  [22] caf::PdmUiTreeSelectionEditor::currentChanged(QModelIndex const&) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionEditor.cpp:812
+  [23] caf::PdmUiTreeSelectionEditor::slotClicked(QModelIndex const&) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionEditor.cpp:759
+  [24]  at :0
+  [25] QAbstractItemView::clicked(QModelIndex const&) at :0
+  [26] QAbstractItemView::mouseReleaseEvent(QMouseEvent*) at :0
+  [27] QWidget::event(QEvent*) at :0
+  [28] QFrame::event(QEvent*) at :0
+  [29] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [30] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [31] QApplication::notify(QObject*, QEvent*) at :0
+  [32] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [33] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [34] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [35]  at :0
+  [36]  at :0
+  [37] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [38] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [39] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [40] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [41] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [42]  at :0
+  [43] g_main_context_dispatch at :0
+  [44] g_main_context_iterate.isra.20 at :0
+  [45] g_main_context_iteration at :0
+  [46] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [47] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [48] QCoreApplication::exec() at :0
+  [49] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [50] __libc_start_main at :0
+  [51] _start at :0
+  [52]  at :0
+"
+2026-06-09T12:48:39.467Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] __cxa_call_terminate at :0
+  [10] __gxx_personality_v0 at :0
+  [11] _Unwind_RaiseException_Phase2 at :0
+  [12] _Unwind_Resume at :0
+  [13] Opm::EclIO::ESmry::dates() const at ResInsight/ThirdParty/custom-opm-common/opm-common/opm/io/eclipse/ESmry.cpp:1457
+  [14] RifHdf5SummaryExporter::writeGeneralSection(RifHdf5Exporter&, Opm::EclIO::ESmry&) at ResInsight/ApplicationLibCode/FileInterface/RifHdf5SummaryExporter.cpp:165
+  [15] RifHdf5SummaryExporter::ensureHdf5FileIsCreated(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool, unsigned long&) at ResInsight/ApplicationLibCode/FileInterface/RifHdf5SummaryExporter.cpp:141
+  [16] RifReaderEclipseSummary::open(QString const&, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseSummary.cpp:107
+  [17] RimFileSummaryCase::findRelatedFilesAndCreateReader(QString const&, bool, RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:238
+  [18] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:110
+  [19] RimFileSummaryCase::createSummaryReaderInterface() at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:129
+  [20] RiaSummaryTools::reloadSummaryCaseAndUpdateConnectedPlots(RimSummaryCase*) at ResInsight/ApplicationLibCode/Application/Tools/Summary/RiaSummaryTools.cpp:409
+  [21] RicReloadSummaryCaseFeature::reloadSelectedCasesAndUpdate() at ResInsight/ApplicationLibCode/Commands/RicReloadSummaryCaseFeature.cpp:148
+  [22] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+  [23]  at :0
+  [24] QAction::triggered(bool) at :0
+  [25] QAction::activate(QAction::ActionEvent) at :0
+  [26]  at :0
+  [27]  at :0
+  [28] QWidget::event(QEvent*) at :0
+  [29] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [30] QApplication::notify(QObject*, QEvent*) at :0
+  [31] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [32] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [33] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [34]  at :0
+  [35]  at :0
+  [36] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [37] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [38] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [39] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [40] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [41]  at :0
+  [42] g_main_context_dispatch at :0
+  [43] g_main_context_iterate.isra.20 at :0
+  [44] g_main_context_iteration at :0
+  [45] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [46] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [47]  at :0
+  [48] QMenu::exec(QPoint const&, QAction*) at :0
+  [49] RiuPlotMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp:1058
+  [50]  at :0
+  [51] QWidget::customContextMenuRequested(QPoint const&) at :0
+  [52] QWidget::event(QEvent*) at :0
+  [53] QFrame::event(QEvent*) at :0
+  [54] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [55] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [56] QApplication::notify(QObject*, QEvent*) at :0
+  [57] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [58] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [59]  at :0
+  [60]  at :0
+  [61] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [62] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [63] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [64] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [65] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [66]  at :0
+  [67] g_main_context_dispatch at :0
+  [68] g_main_context_iterate.isra.20 at :0
+  [69] g_main_context_iteration at :0
+  [70] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [71] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [72] QCoreApplication::exec() at :0
+  [73] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [74] __libc_start_main at :0
+  [75] _start at :0
+  [76]  at :0
+"
+2026-06-08T21:46:56.086Z,2026.06.0-RC_1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:167
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:263
+  [2]  at :0
+  [3] ecl_kw_get_data_type at ResInsight/ThirdParty/Ert/lib/ecl/ecl_kw.cpp:1776
+  [4] ecl_file_kw_assert_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_kw.cpp:211
+  [5] ecl_file_kw_load_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_kw.cpp:244
+  [6] ecl_file_view_get_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_view.cpp:149
+  [7] RifEclipseOutputFileTools::keywordData(ecl_file_struct const*, QString const&, unsigned long, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseOutputFileTools.cpp:305
+  [8] RifEclipseUnifiedRestartFileAccess::results(QString const&, unsigned long, unsigned long, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseUnifiedRestartFileAccess.cpp:249
+  [9] RifReaderEclipseOutput::dynamicResult(QString const&, RiaDefines::PorosityModelType, unsigned long, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp:1074
+  [10] RigCaseCellResultsData::findOrLoadKnownScalarResult(RigEclipseResultAddress const&) at ResInsight/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp:1553
+  [11] RigCaseCellResultsData::ensureKnownResultLoaded(RigEclipseResultAddress const&) at ResInsight/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp:1265
+  [12] RimEclipseResultDefinition::loadResult() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:1140
+  [13] RimEclipseCellColors::loadResult() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCellColors.cpp:259
+  [14] RimEclipseResultDefinition::loadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:533
+  [15] RimEclipseResultDefinition::fieldChangedByUi(caf::PdmFieldHandle const*, QVariant const&, QVariant const&) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:305
+  [16] RimEclipseCellColors::fieldChangedByUi(caf::PdmFieldHandle const*, QVariant const&, QVariant const&) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCellColors.cpp:90
+  [17] caf::PdmUiFieldHandle::notifyFieldChanged(QVariant const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiFieldHandle.cpp:75
+  [18] caf::PdmFieldUiCap<caf::PdmField<QString> >::setValueFromUiEditor(QVariant const&, bool) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafInternalPdmUiFieldCapability.inl:110
+  [19] caf::PdmUiCommandSystemProxy::setUiValueToField(caf::PdmUiFieldHandle*, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiCommandSystemProxy.cpp:122
+  [20] caf::PdmUiTreeSelectionQModel::setData(QModelIndex const&, QVariant const&, int) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionQModel.cpp:482
+  [21] QSortFilterProxyModel::setData(QModelIndex const&, QVariant const&, int) at :0
+  [22] caf::PdmUiTreeSelectionEditor::currentChanged(QModelIndex const&) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionEditor.cpp:829
+  [23] caf::PdmUiTreeSelectionEditor::slotClicked(QModelIndex const&) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionEditor.cpp:776
+  [24]  at :0
+  [25] QAbstractItemView::clicked(QModelIndex const&) at :0
+  [26] QAbstractItemView::mouseReleaseEvent(QMouseEvent*) at :0
+  [27] QWidget::event(QEvent*) at :0
+  [28] QFrame::event(QEvent*) at :0
+  [29] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [30] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [31] QApplication::notify(QObject*, QEvent*) at :0
+  [32] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1828
+  [33] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [34] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [35]  at :0
+  [36]  at :0
+  [37] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [38] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1828
+  [39] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [40] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [41] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [42]  at :0
+  [43] g_main_context_dispatch at :0
+  [44] g_main_context_iterate.isra.20 at :0
+  [45] g_main_context_iteration at :0
+  [46] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [47] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [48] QCoreApplication::exec() at :0
+  [49] main at ResInsight/ApplicationExeCode/RiaMain.cpp:258
+  [50] __libc_start_main at :0
+  [51] _start at :0
+  [52]  at :0
+"
+2026-06-08T21:16:36.133Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
+  [6] cvf::Frustum::isOutside(cvf::BoundingBox const&) const at ResInsight/Fwk/VizFwk/LibGeometry/cvfFrustum.cpp:203
+  [7] cvf::ModelBasicList::partVisible(cvf::Part*, cvf::Camera const*, cvf::CullSettings const*, unsigned int, double*) at ResInsight/Fwk/VizFwk/LibViewing/cvfModelBasicList.cpp:215
+  [8] cvf::ModelBasicList::findVisibleParts(cvf::PartRenderHintCollection*, cvf::Camera const&, cvf::CullSettings const&, unsigned int) at ResInsight/Fwk/VizFwk/LibViewing/cvfModelBasicList.cpp:181
+  [9] cvf::Scene::findVisibleParts(cvf::PartRenderHintCollection*, cvf::Camera const&, cvf::CullSettings const&, unsigned int) at ResInsight/Fwk/VizFwk/LibViewing/cvfScene.cpp:87
+  [10] cvf::Rendering::render(cvf::OpenGLContext*) at ResInsight/Fwk/VizFwk/LibViewing/cvfRendering.cpp:182
+  [11] cvf::RenderSequence::render(cvf::OpenGLContext*) at ResInsight/Fwk/VizFwk/LibViewing/cvfRenderSequence.cpp:211
+  [12] caf::Viewer::paintGL() at ResInsight/Fwk/AppFwk/cafViewer/cafViewer.cpp:901
+  [13]  at :0
+  [14] QWidget::event(QEvent*) at :0
+  [15] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [16] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [17] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [18] QWidgetPrivate::sendPaintEvent(QRegion const&) at :0
+  [19] QWidgetRepaintManager::paintAndFlush() at :0
+  [20] QWidget::event(QEvent*) at :0
+  [21] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [22] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [23] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [24] QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*) at :0
+  [25]  at :0
+  [26] g_main_context_dispatch at :0
+  [27] g_main_context_iterate.isra.20 at :0
+  [28] g_main_context_iteration at :0
+  [29] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [30] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [31] QCoreApplication::exec() at :0
+  [32] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [33] __libc_start_main at :0
+  [34] _start at :0
+  [35]  at :0
+"
+2026-06-08T12:09:14.349Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] ecl_kw_get_data_type at ResInsight/ThirdParty/Ert/lib/ecl/ecl_kw.cpp:1776
+  [4] ecl_file_kw_assert_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_kw.cpp:211
+  [5] ecl_file_kw_load_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_kw.cpp:244
+  [6] ecl_file_view_get_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_view.cpp:149
+  [7] RifEclipseOutputFileTools::keywordData(ecl_file_struct const*, QString const&, unsigned long, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseOutputFileTools.cpp:305
+  [8] RifReaderEclipseOutput::staticResult(QString const&, RiaDefines::PorosityModelType, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp:999
+  [9] RigCaseCellResultsData::findOrLoadKnownScalarResult(RigEclipseResultAddress const&) at ResInsight/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp:1558
+  [10] RigCaseCellResultsData::ensureKnownResultLoaded(RigEclipseResultAddress const&) at ResInsight/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp:1264
+  [11] RimEclipseResultDefinition::loadResult() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:1134
+  [12] RimEclipseCellColors::loadResult() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCellColors.cpp:260
+  [13] RimEclipseResultDefinition::loadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:533
+  [14] RimEclipseResultDefinition::fieldChangedByUi(caf::PdmFieldHandle const*, QVariant const&, QVariant const&) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:305
+  [15] RimEclipseCellColors::fieldChangedByUi(caf::PdmFieldHandle const*, QVariant const&, QVariant const&) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCellColors.cpp:90
+  [16] caf::PdmUiFieldHandle::notifyFieldChanged(QVariant const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiFieldHandle.cpp:74
+  [17] caf::PdmFieldUiCap<caf::PdmField<QString> >::setValueFromUiEditor(QVariant const&, bool) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafInternalPdmUiFieldCapability.inl:110
+  [18] caf::PdmUiCommandSystemProxy::setUiValueToField(caf::PdmUiFieldHandle*, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiCommandSystemProxy.cpp:122
+  [19] caf::PdmUiTreeSelectionQModel::setData(QModelIndex const&, QVariant const&, int) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionQModel.cpp:482
+  [20] QSortFilterProxyModel::setData(QModelIndex const&, QVariant const&, int) at :0
+  [21] caf::PdmUiTreeSelectionEditor::currentChanged(QModelIndex const&) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionEditor.cpp:812
+  [22] caf::PdmUiTreeSelectionEditor::slotClicked(QModelIndex const&) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionEditor.cpp:759
+  [23]  at :0
+  [24] QAbstractItemView::clicked(QModelIndex const&) at :0
+  [25] QAbstractItemView::mouseReleaseEvent(QMouseEvent*) at :0
+  [26] QWidget::event(QEvent*) at :0
+  [27] QFrame::event(QEvent*) at :0
+  [28] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [29] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [30] QApplication::notify(QObject*, QEvent*) at :0
+  [31] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [32] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [33] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [34]  at :0
+  [35]  at :0
+  [36] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [37] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [38] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [39] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [40] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [41]  at :0
+  [42] g_main_context_dispatch at :0
+  [43] g_main_context_iterate.isra.20 at :0
+  [44] g_main_context_iteration at :0
+  [45] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [46] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [47] QCoreApplication::exec() at :0
+  [48] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [49] __libc_start_main at :0
+  [50] _start at :0
+  [51]  at :0
+"
+2026-06-08T11:26:22.295Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
+  [6] cvf::StructGridInterface::oppositeFace(cvf::StructGridInterface::FaceType) at ResInsight/Fwk/AppFwk/CommonCode/cvfStructGrid.cpp:199
+  [7] RigCombMultResultAccessor::cellFaceScalar(unsigned long, cvf::StructGridInterface::FaceType) const at ResInsight/ApplicationLibCode/ReservoirDataModel/ResultAccessors/RigCombMultResultAccessor.cpp:77
+  [8] RiuResultTextBuilder::cellResultTextAndValueText(RimEclipseResultDefinition*) at ResInsight/ApplicationLibCode/UserInterface/RiuResultTextBuilder.cpp:1106
+  [9] RiuResultTextBuilder::cellResultText(std::vector<RimEclipseResultDefinition*, std::allocator<RimEclipseResultDefinition*> > const&, bool) at ResInsight/ApplicationLibCode/UserInterface/RiuResultTextBuilder.cpp:998
+  [10] RiuResultTextBuilder::gridResultText() at ResInsight/ApplicationLibCode/UserInterface/RiuResultTextBuilder.cpp:490
+  [11] RiuResultTextBuilder::resultTextFromLinkedViews() const at ResInsight/ApplicationLibCode/UserInterface/RiuResultTextBuilder.cpp:829
+  [12] RiuResultTextBuilder::gridResultDetails() at ResInsight/ApplicationLibCode/UserInterface/RiuResultTextBuilder.cpp:377
+  [13] RiuResultTextBuilder::mainResultText() at ResInsight/ApplicationLibCode/UserInterface/RiuResultTextBuilder.cpp:189
+  [14] RiuSelectionChangedHandler::updateResultInfo(RiuSelectionItem const*) const at ResInsight/ApplicationLibCode/UserInterface/RiuSelectionChangedHandler.cpp:389
+  [15] RiuSelectionChangedHandler::handleItemAppended(RiuSelectionItem const*) const at ResInsight/ApplicationLibCode/UserInterface/RiuSelectionChangedHandler.cpp:132
+  [16] RiuCellAndNncPickEventHandler::handle3dPickEvent(Ric3dPickEvent const&) at ResInsight/ApplicationLibCode/UserInterface/RiuCellAndNncPickEventHandler.cpp:459
+  [17] RiuViewerCommands::handlePickAction(int, int, QFlags<Qt::KeyboardModifier>) at ResInsight/ApplicationLibCode/UserInterface/RiuViewerCommands.cpp:702
+  [18] QWidget::event(QEvent*) at :0
+  [19] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [20] QApplication::notify(QObject*, QEvent*) at :0
+  [21] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [22] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [23] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [24]  at :0
+  [25]  at :0
+  [26] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [27] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [28] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [29] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [30] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [31]  at :0
+  [32] g_main_context_dispatch at :0
+  [33] g_main_context_iterate.isra.20 at :0
+  [34] g_main_context_iteration at :0
+  [35] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [36] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [37] QCoreApplication::exec() at :0
+  [38] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [39] __libc_start_main at :0
+  [40] _start at :0
+  [41]  at :0
+"
+2026-06-08T09:08:34.773Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] std::terminate() at :0
+  [10] __cxa_rethrow at :0
+  [11] main at ResInsight/ApplicationExeCode/RiaMain.cpp:232
+  [12] __libc_start_main at :0
+  [13] _start at :0
+  [14]  at :0
+"
+2026-06-08T07:25:54.722Z,2026.02.2,"  [0]  at :0
+  [1]  at :0
+  [2]  at :0
+  [3]  at :0
+  [4]  at :0
+  [5]  at :0
+  [6]  at :0
+  [7]  at :0
+  [8]  at :0
+  [9]  at :0
+  [10]  at :0
+  [11]  at :0
+  [12]  at :0
+  [13]  at :0
+  [14]  at :0
+  [15]  at :0
+  [16]  at :0
+  [17]  at :0
+  [18]  at :0
+  [19]  at :0
+  [20]  at :0
+  [21]  at :0
+  [22]  at :0
+  [23]  at :0
+  [24]  at :0
+  [25]  at :0
+  [26]  at :0
+  [27]  at :0
+  [28]  at :0
+  [29]  at :0
+  [30]  at :0
+  [31]  at :0
+  [32]  at :0
+  [33]  at :0
+  [34]  at :0
+  [35]  at :0
+  [36]  at :0
+  [37]  at :0
+  [38]  at :0
+  [39]  at :0
+  [40]  at :0
+  [41]  at :0
+  [42]  at :0
+  [43]  at :0
+  [44]  at :0
+  [45]  at :0
+  [46]  at :0
+  [47]  at :0
+  [48]  at :0
+  [49]  at :0
+  [50]  at :0
+  [51]  at :0
+  [52]  at :0
+  [53]  at :0
+  [54]  at :0
+  [55]  at :0
+  [56]  at :0
+  [57]  at :0
+"
+2026-06-08T07:20:50.661Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] QArrayDataPointer<char16_t>::QArrayDataPointer(QArrayDataPointer<char16_t> const&) at /private/f_resinsight_build/resbuild/qt/6.6.3/gcc_64/include/QtCore/qarraydatapointer.h:38
+  [4] RimStimPlanModelCalculator::calculateFormation() const at ResInsight/ApplicationLibCode/ProjectDataModel/StimPlanModel/RimStimPlanModelCalculator.cpp:740
+  [5] RifStimPlanModelGeologicalFrkExporter::writeToFile(RimStimPlanModel*, bool, QString const&) at ResInsight/ApplicationLibCode/FileInterface/RifStimPlanModelGeologicalFrkExporter.cpp:149
+  [6] RifStimPlanModelExporter::writeToDirectory(RimStimPlanModel*, bool, QString const&) at ResInsight/ApplicationLibCode/FileInterface/RifStimPlanModelExporter.cpp:33
+  [7] RimcStimPlanModel_exportToFile::execute() at ResInsight/ApplicationLibCode/ProjectDataModelCommands/RimcStimPlanModel.cpp:47
+  [8] RiaGrpcPdmObjectService::CallPdmObjectMethod(grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*) at ResInsight/GrpcInterface/RiaGrpcPdmObjectService.cpp:578
+  [9] grpc::Status std::__invoke_impl<grpc::Status, grpc::Status (RiaGrpcPdmObjectService::*&)(grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*), RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*>(std::__invoke_memfun_ref, grpc::Status (RiaGrpcPdmObjectService::*&)(grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*), RiaGrpcPdmObjectService&, grpc::ServerContext*&&, rips::PdmObjectMethodRequest const*&&, rips::PdmObject*&&) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/invoke.h:67
+  [10] std::function<grpc::Status (RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*)>::operator()(RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:591
+  [11] RiaGrpcServerImpl::processAllQueuedRequests() at ResInsight/GrpcInterface/RiaGrpcServer.cpp:197
+  [12] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:115
+  [13] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:33
+  [14]  at :0
+  [15] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [16] QObject::event(QEvent*) at :0
+  [17] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [18] QTimerInfoList::activateTimers() at :0
+  [19]  at :0
+  [20] g_main_context_dispatch at :0
+  [21] g_main_context_iterate.isra.20 at :0
+  [22] g_main_context_iteration at :0
+  [23] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [24] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [25] QCoreApplication::exec() at :0
+  [26] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [27] __libc_start_main at :0
+  [28] _start at :0
+  [29]  at :0
+"
+2026-06-08T07:20:23.769Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] QArrayDataPointer<char16_t>::QArrayDataPointer(QArrayDataPointer<char16_t> const&) at /private/f_resinsight_build/resbuild/qt/6.6.3/gcc_64/include/QtCore/qarraydatapointer.h:38
+  [4] RimStimPlanModelCalculator::calculateFormation() const at ResInsight/ApplicationLibCode/ProjectDataModel/StimPlanModel/RimStimPlanModelCalculator.cpp:740
+  [5] RifStimPlanModelGeologicalFrkExporter::writeToFile(RimStimPlanModel*, bool, QString const&) at ResInsight/ApplicationLibCode/FileInterface/RifStimPlanModelGeologicalFrkExporter.cpp:149
+  [6] RifStimPlanModelExporter::writeToDirectory(RimStimPlanModel*, bool, QString const&) at ResInsight/ApplicationLibCode/FileInterface/RifStimPlanModelExporter.cpp:33
+  [7] RimcStimPlanModel_exportToFile::execute() at ResInsight/ApplicationLibCode/ProjectDataModelCommands/RimcStimPlanModel.cpp:47
+  [8] RiaGrpcPdmObjectService::CallPdmObjectMethod(grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*) at ResInsight/GrpcInterface/RiaGrpcPdmObjectService.cpp:578
+  [9] grpc::Status std::__invoke_impl<grpc::Status, grpc::Status (RiaGrpcPdmObjectService::*&)(grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*), RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*>(std::__invoke_memfun_ref, grpc::Status (RiaGrpcPdmObjectService::*&)(grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*), RiaGrpcPdmObjectService&, grpc::ServerContext*&&, rips::PdmObjectMethodRequest const*&&, rips::PdmObject*&&) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/invoke.h:67
+  [10] std::function<grpc::Status (RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*)>::operator()(RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:591
+  [11] RiaGrpcServerImpl::processAllQueuedRequests() at ResInsight/GrpcInterface/RiaGrpcServer.cpp:197
+  [12] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:115
+  [13] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:33
+  [14]  at :0
+  [15] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [16] QObject::event(QEvent*) at :0
+  [17] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [18] QTimerInfoList::activateTimers() at :0
+  [19]  at :0
+  [20] g_main_context_dispatch at :0
+  [21] g_main_context_iterate.isra.20 at :0
+  [22] g_main_context_iteration at :0
+  [23] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [24] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [25] QCoreApplication::exec() at :0
+  [26] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [27] __libc_start_main at :0
+  [28] _start at :0
+  [29]  at :0
+"
+2026-06-08T06:30:26.385Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
+  [6] cvf::StructGridInterface::oppositeFace(cvf::StructGridInterface::FaceType) at ResInsight/Fwk/AppFwk/CommonCode/cvfStructGrid.cpp:199
+  [7] RigCombMultResultAccessor::cellFaceScalar(unsigned long, cvf::StructGridInterface::FaceType) const at ResInsight/ApplicationLibCode/ReservoirDataModel/ResultAccessors/RigCombMultResultAccessor.cpp:77
+  [8] RiuResultTextBuilder::cellResultTextAndValueText(RimEclipseResultDefinition*) at ResInsight/ApplicationLibCode/UserInterface/RiuResultTextBuilder.cpp:1106
+  [9] RiuResultTextBuilder::cellResultText(std::vector<RimEclipseResultDefinition*, std::allocator<RimEclipseResultDefinition*> > const&, bool) at ResInsight/ApplicationLibCode/UserInterface/RiuResultTextBuilder.cpp:998
+  [10] RiuResultTextBuilder::gridResultText() at ResInsight/ApplicationLibCode/UserInterface/RiuResultTextBuilder.cpp:490
+  [11] RiuResultTextBuilder::resultTextFromLinkedViews() const at ResInsight/ApplicationLibCode/UserInterface/RiuResultTextBuilder.cpp:829
+  [12] RiuResultTextBuilder::gridResultDetails() at ResInsight/ApplicationLibCode/UserInterface/RiuResultTextBuilder.cpp:377
+  [13] RiuResultTextBuilder::mainResultText() at ResInsight/ApplicationLibCode/UserInterface/RiuResultTextBuilder.cpp:189
+  [14] RiuSelectionChangedHandler::updateResultInfo(RiuSelectionItem const*) const at ResInsight/ApplicationLibCode/UserInterface/RiuSelectionChangedHandler.cpp:389
+  [15] RiuSelectionChangedHandler::handleItemAppended(RiuSelectionItem const*) const at ResInsight/ApplicationLibCode/UserInterface/RiuSelectionChangedHandler.cpp:132
+  [16] RiuCellAndNncPickEventHandler::handle3dPickEvent(Ric3dPickEvent const&) at ResInsight/ApplicationLibCode/UserInterface/RiuCellAndNncPickEventHandler.cpp:459
+  [17] RiuViewerCommands::handlePickAction(int, int, QFlags<Qt::KeyboardModifier>) at ResInsight/ApplicationLibCode/UserInterface/RiuViewerCommands.cpp:702
+  [18] QWidget::event(QEvent*) at :0
+  [19] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [20] QApplication::notify(QObject*, QEvent*) at :0
+  [21] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [22] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [23] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [24]  at :0
+  [25]  at :0
+  [26] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [27] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [28] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [29] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [30] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [31]  at :0
+  [32] g_main_context_dispatch at :0
+  [33] g_main_context_iterate.isra.20 at :0
+  [34] g_main_context_iteration at :0
+  [35] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [36] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [37] QCoreApplication::exec() at :0
+  [38] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [39] __libc_start_main at :0
+  [40] _start at :0
+  [41]  at :0
+"
+2026-06-08T06:19:04.114Z,2026.02.2,"  [0]  at :0
+  [1]  at :0
+  [2]  at :0
+  [3]  at :0
+  [4]  at :0
+  [5]  at :0
+  [6]  at :0
+  [7]  at :0
+  [8]  at :0
+  [9]  at :0
+  [10]  at :0
+  [11]  at :0
+  [12]  at :0
+  [13]  at :0
+  [14]  at :0
+  [15]  at :0
+  [16]  at :0
+  [17]  at :0
+  [18]  at :0
+  [19]  at :0
+  [20]  at :0
+  [21]  at :0
+  [22]  at :0
+  [23]  at :0
+  [24]  at :0
+  [25]  at :0
+  [26]  at :0
+  [27]  at :0
+  [28]  at :0
+  [29]  at :0
+  [30]  at :0
+  [31]  at :0
+  [32]  at :0
+  [33]  at :0
+  [34]  at :0
+  [35]  at :0
+  [36]  at :0
+  [37]  at :0
+  [38]  at :0
+  [39]  at :0
+  [40]  at :0
+  [41]  at :0
+  [42]  at :0
+  [43]  at :0
+  [44]  at :0
+  [45]  at :0
+  [46]  at :0
+  [47]  at :0
+  [48]  at :0
+  [49]  at :0
+  [50]  at :0
+  [51]  at :0
+  [52]  at :0
+  [53]  at :0
+  [54]  at :0
+  [55]  at :0
+  [56]  at :0
+  [57]  at :0
+  [58]  at :0
+  [59]  at :0
+  [60]  at :0
+"
+2026-06-08T05:51:18.931Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] Rim3dView::scaleZ() const at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:1242
+  [4] RimViewController::updateCameraLink() at ResInsight/ApplicationLibCode/ProjectDataModel/RimViewController.cpp:559
+  [5] RimViewController::setManagedView(Rim3dView*) at ResInsight/ApplicationLibCode/ProjectDataModel/RimViewController.cpp:443
+  [6] RimViewController::fieldChangedByUi(caf::PdmFieldHandle const*, QVariant const&, QVariant const&) at ResInsight/ApplicationLibCode/ProjectDataModel/RimViewController.cpp:226
+  [7] caf::PdmUiFieldHandle::notifyFieldChanged(QVariant const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiFieldHandle.cpp:74
+  [8] caf::PdmFieldUiCap<caf::PdmPtrField<Rim3dView*> >::setValueFromUiEditor(QVariant const&, bool) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafInternalPdmUiFieldCapability.inl:111
+  [9] caf::CmdFieldChangeExec::redo() at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFieldChangeExec.cpp:139
+  [10] QUndoStack::push(QUndoCommand*) at :0
+  [11] caf::CmdUiCommandSystemImpl::fieldChangedCommand(std::vector<caf::PdmFieldHandle*, std::allocator<caf::PdmFieldHandle*> > const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdUiCommandSystemImpl.cpp:146
+  [12] caf::PdmUiCommandSystemProxy::setUiValueToField(caf::PdmUiFieldHandle*, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiCommandSystemProxy.cpp:113
+  [13] caf::PdmUiComboBoxEditor::slotIndexActivated(int) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiComboBoxEditor.cpp:455
+  [14]  at :0
+  [15] QComboBox::activated(int) at :0
+  [16]  at :0
+  [17]  at :0
+  [18]  at :0
+  [19] QComboBoxPrivateContainer::itemSelected(QModelIndex const&) at :0
+  [20] QComboBoxPrivateContainer::eventFilter(QObject*, QEvent*) at :0
+  [21] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [22] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [23] QApplication::notify(QObject*, QEvent*) at :0
+  [24] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [25] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [26] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [27]  at :0
+  [28]  at :0
+  [29] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [30] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [31] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [32] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [33] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [34]  at :0
+  [35] g_main_context_dispatch at :0
+  [36] g_main_context_iterate.isra.20 at :0
+  [37] g_main_context_iteration at :0
+  [38] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [39] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [40] QCoreApplication::exec() at :0
+  [41] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [42] __libc_start_main at :0
+  [43] _start at :0
+  [44]  at :0
+"
+2026-06-08T04:01:22.172Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] __cxa_call_terminate at :0
+  [10] __gxx_personality_v0 at :0
+  [11] _Unwind_RaiseException_Phase2 at :0
+  [12] _Unwind_RaiseException at :0
+  [13] __cxa_throw at :0
+  [14] operator new(unsigned long) at :0
+  [15] void std::vector<double, std::allocator<double> >::_M_range_insert<__gnu_cxx::__normal_iterator<double*, std::vector<double, std::allocator<double> > > >(__gnu_cxx::__normal_iterator<double*, std::vector<double, std::allocator<double> > >, __gnu_cxx::__normal_iterator<double*, std::vector<double, std::allocator<double> > >, __gnu_cxx::__normal_iterator<double*, std::vector<double, std::allocator<double> > >, std::forward_iterator_tag) [clone .isra.0] at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/new_allocator.h:151
+  [16] RifEclipseOutputFileTools::keywordData(ecl_file_struct const*, QString const&, unsigned long, std::vector<double, std::allocator<double> >*) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/stl_vector.h:1486
+  [17] RifEclipseUnifiedRestartFileAccess::results(QString const&, unsigned long, unsigned long, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseUnifiedRestartFileAccess.cpp:248
+  [18] RifReaderEclipseOutput::dynamicResult(QString const&, RiaDefines::PorosityModelType, unsigned long, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp:1070
+  [19] RigCaseCellResultsData::findOrLoadKnownScalarResult(RigEclipseResultAddress const&) [clone .localalias] at :0
+  [20] RigCaseCellResultsData::ensureKnownResultLoaded(RigEclipseResultAddress const&) at :0
+  [21] RimEclipseResultDefinition::loadResult() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:1134
+  [22] RimEclipseCellColors::loadResult() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCellColors.cpp:260
+  [23] RimEclipseResultDefinition::loadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:533
+  [24] RimEclipseResultDefinition::fieldChangedByUi(caf::PdmFieldHandle const*, QVariant const&, QVariant const&) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:305
+  [25] RimEclipseCellColors::fieldChangedByUi(caf::PdmFieldHandle const*, QVariant const&, QVariant const&) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCellColors.cpp:90
+  [26] caf::PdmUiFieldHandle::notifyFieldChanged(QVariant const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiFieldHandle.cpp:74
+  [27] caf::PdmFieldUiCap<caf::PdmField<QString> >::setValueFromUiEditor(QVariant const&, bool) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafInternalPdmUiFieldCapability.inl:110
+  [28] caf::PdmUiCommandSystemProxy::setUiValueToField(caf::PdmUiFieldHandle*, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiCommandSystemProxy.cpp:122
+  [29] caf::PdmUiTreeSelectionQModel::setData(QModelIndex const&, QVariant const&, int) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionQModel.cpp:482
+  [30] QSortFilterProxyModel::setData(QModelIndex const&, QVariant const&, int) at :0
+  [31] QStyledItemDelegate::editorEvent(QEvent*, QAbstractItemModel*, QStyleOptionViewItem const&, QModelIndex const&) at :0
+  [32]  at :0
+  [33] QAbstractItemView::edit(QModelIndex const&, QAbstractItemView::EditTrigger, QEvent*) at :0
+  [34] QAbstractItemView::mouseReleaseEvent(QMouseEvent*) at :0
+  [35] QWidget::event(QEvent*) at :0
+  [36] QFrame::event(QEvent*) at :0
+  [37] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [38] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [39] QApplication::notify(QObject*, QEvent*) at :0
+  [40] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [41] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [42] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [43]  at :0
+  [44]  at :0
+  [45] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [46] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [47] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [48] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [49] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [50]  at :0
+  [51] g_main_context_dispatch at :0
+  [52] g_main_context_iterate.isra.20 at :0
+  [53] g_main_context_iteration at :0
+  [54] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [55] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [56] QCoreApplication::exec() at :0
+  [57] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [58] __libc_start_main at :0
+  [59] _start at :0
+  [60]  at :0
+"
+2026-06-08T03:28:53.232Z,2026.02.2,"  [0]  at :0
+  [1]  at :0
+  [2]  at :0
+  [3]  at :0
+  [4]  at :0
+  [5]  at :0
+  [6]  at :0
+  [7]  at :0
+  [8]  at :0
+  [9]  at :0
+  [10]  at :0
+  [11]  at :0
+  [12]  at :0
+  [13]  at :0
+  [14]  at :0
+  [15]  at :0
+  [16]  at :0
+  [17]  at :0
+  [18]  at :0
+  [19]  at :0
+  [20]  at :0
+  [21]  at :0
+  [22]  at :0
+  [23]  at :0
+  [24]  at :0
+  [25]  at :0
+  [26]  at :0
+  [27]  at :0
+  [28]  at :0
+  [29]  at :0
+  [30]  at :0
+  [31]  at :0
+  [32]  at :0
+  [33]  at :0
+  [34]  at :0
+  [35]  at :0
+  [36]  at :0
+  [37]  at :0
+  [38]  at :0
+  [39]  at :0
+  [40]  at :0
+  [41]  at :0
+  [42]  at :0
+  [43]  at :0
+  [44]  at :0
+  [45]  at :0
+  [46]  at :0
+  [47]  at :0
+  [48]  at :0
+  [49]  at :0
+  [50]  at :0
+  [51]  at :0
+  [52]  at :0
+  [53]  at :0
+  [54]  at :0
+  [55]  at :0
+  [56]  at :0
+  [57]  at :0
+  [58]  at :0
+  [59]  at :0
+"
+2026-06-07T17:56:40.141Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] RimEclipseResultDefinition::eclipseCase() const at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:223
+  [4] RimEclipseGeometrySelectionItem::setFromSelectionItem(RiuEclipseSelectionItem const*) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseGeometrySelectionItem.cpp:67
+  [5] RimGridTimeHistoryCurve::setFromSelectionItem(RiuSelectionItem const*, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimGridTimeHistoryCurve.cpp:104
+  [6] RiuSelectionChangedHandler::updateGridCellCurvesFromSelection() at ResInsight/ApplicationLibCode/UserInterface/RiuSelectionChangedHandler.cpp:480
+  [7] RiuSelectionChangedHandler::handleItemAppended(RiuSelectionItem const*) const at ResInsight/ApplicationLibCode/UserInterface/RiuSelectionChangedHandler.cpp:133
+  [8] Riu3dSelectionManager::updateSelectedItems() at ResInsight/ApplicationLibCode/UserInterface/Riu3dSelectionManager.cpp:114
+  [9] RiuTimeStepChangedHandler::handleTimeStepChanged(Rim3dView*) const at ResInsight/ApplicationLibCode/UserInterface/RiuTimeStepChangedHandler.cpp:101
+  [10] Rim3dView::setCurrentTimeStep(int) at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:650
+  [11] non-virtual thunk to Rim3dView::setCurrentTimeStepAndUpdate(int) at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.h:156
+  [12] RiuViewer::setCurrentFrame(int) at ResInsight/ApplicationLibCode/UserInterface/RiuViewer.cpp:1008
+  [13] RiuViewer::slotSetCurrentFrame(int) at ResInsight/ApplicationLibCode/UserInterface/RiuViewer.cpp:348
+  [14] RiuMainWindow::slotAnimationSliderMoved(int) at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:1961
+  [15]  at :0
+  [16] QAbstractSlider::valueChanged(int) at :0
+  [17] QAbstractSlider::setValue(int) at :0
+  [18] QSlider::mousePressEvent(QMouseEvent*) at :0
+  [19] QWidget::event(QEvent*) at :0
+  [20] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [21] QApplication::notify(QObject*, QEvent*) at :0
+  [22] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [23] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [24] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [25]  at :0
+  [26]  at :0
+  [27] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [28] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [29] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [30] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [31] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [32]  at :0
+  [33] g_main_context_dispatch at :0
+  [34] g_main_context_iterate.isra.20 at :0
+  [35] g_main_context_iteration at :0
+  [36] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [37] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [38] QCoreApplication::exec() at :0
+  [39] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [40] __libc_start_main at :0
+  [41] _start at :0
+  [42]  at :0
+"
+2026-06-07T16:59:38.294Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3]  at :0
+  [4] QComboBox::textActivated(QString const&) at :0
+  [5]  at :0
+  [6]  at :0
+  [7]  at :0
+  [8] QComboBoxPrivateContainer::itemSelected(QModelIndex const&) at :0
+  [9] QComboBoxPrivateContainer::eventFilter(QObject*, QEvent*) at :0
+  [10] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [11] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [12] QApplication::notify(QObject*, QEvent*) at :0
+  [13] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [14] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [15] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [16]  at :0
+  [17]  at :0
+  [18] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [19] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [20] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [21] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [22] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [23]  at :0
+  [24] g_main_context_dispatch at :0
+  [25] g_main_context_iterate.isra.20 at :0
+  [26] g_main_context_iteration at :0
+  [27] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [28] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [29] QCoreApplication::exec() at :0
+  [30] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [31] __libc_start_main at :0
+  [32] _start at :0
+  [33]  at :0
+"
+2026-06-07T14:41:21.307Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __libc_poll at :0
+  [4] g_main_context_iterate.isra.20 at :0
+  [5] g_main_context_iteration at :0
+  [6] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [7] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [8] QCoreApplication::exec() at :0
+  [9] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [10] __libc_start_main at :0
+  [11] _start at :0
+  [12]  at :0
+"
+2026-06-06T09:41:16.188Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] ecl_kw_get_data_type at ResInsight/ThirdParty/Ert/lib/ecl/ecl_kw.cpp:1776
+  [4] ecl_file_kw_assert_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_kw.cpp:211
+  [5] ecl_file_kw_load_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_kw.cpp:244
+  [6] ecl_file_view_get_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_view.cpp:149
+  [7] RifEclipseOutputFileTools::keywordData(ecl_file_struct const*, QString const&, unsigned long, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseOutputFileTools.cpp:305
+  [8] RifEclipseUnifiedRestartFileAccess::results(QString const&, unsigned long, unsigned long, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseUnifiedRestartFileAccess.cpp:248
+  [9] RifReaderEclipseOutput::dynamicResult(QString const&, RiaDefines::PorosityModelType, unsigned long, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp:1070
+  [10] RigCaseCellResultsData::findOrLoadKnownScalarResult(RigEclipseResultAddress const&) at ResInsight/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp:1538
+  [11] RigCaseCellResultsData::ensureKnownResultLoaded(RigEclipseResultAddress const&) at ResInsight/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp:1264
+  [12] RimEclipseResultDefinition::loadResult() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:1134
+  [13] RimEclipseCellColors::loadResult() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCellColors.cpp:260
+  [14] RimEclipseResultDefinition::loadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:533
+  [15] RimEclipseResultDefinition::fieldChangedByUi(caf::PdmFieldHandle const*, QVariant const&, QVariant const&) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:305
+  [16] RimEclipseCellColors::fieldChangedByUi(caf::PdmFieldHandle const*, QVariant const&, QVariant const&) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCellColors.cpp:90
+  [17] caf::PdmUiFieldHandle::notifyFieldChanged(QVariant const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiFieldHandle.cpp:74
+  [18] caf::PdmFieldUiCap<caf::PdmField<QString> >::setValueFromUiEditor(QVariant const&, bool) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafInternalPdmUiFieldCapability.inl:110
+  [19] caf::PdmUiCommandSystemProxy::setUiValueToField(caf::PdmUiFieldHandle*, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiCommandSystemProxy.cpp:122
+  [20] caf::PdmUiTreeSelectionQModel::setData(QModelIndex const&, QVariant const&, int) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionQModel.cpp:482
+  [21] QSortFilterProxyModel::setData(QModelIndex const&, QVariant const&, int) at :0
+  [22] caf::PdmUiTreeSelectionEditor::currentChanged(QModelIndex const&) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionEditor.cpp:812
+  [23] caf::PdmUiTreeSelectionEditor::slotClicked(QModelIndex const&) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionEditor.cpp:759
+  [24]  at :0
+  [25] QAbstractItemView::clicked(QModelIndex const&) at :0
+  [26] QAbstractItemView::mouseReleaseEvent(QMouseEvent*) at :0
+  [27] QWidget::event(QEvent*) at :0
+  [28] QFrame::event(QEvent*) at :0
+  [29] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [30] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [31] QApplication::notify(QObject*, QEvent*) at :0
+  [32] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [33] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [34] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [35]  at :0
+  [36]  at :0
+  [37] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [38] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [39] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [40] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [41] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [42]  at :0
+  [43] g_main_context_dispatch at :0
+  [44] g_main_context_iterate.isra.20 at :0
+  [45] g_main_context_iteration at :0
+  [46] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [47] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [48] QCoreApplication::exec() at :0
+  [49] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [50] __libc_start_main at :0
+  [51] _start at :0
+  [52]  at :0
+"
+2026-06-05T19:35:27.414Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] ecl_grid_alloc_EGRID__ at ResInsight/ThirdParty/Ert/lib/ecl/ecl_grid.cpp:3085
+  [4] ecl_grid_alloc_EGRID_all_grids at ResInsight/ThirdParty/Ert/lib/ecl/ecl_grid.cpp:3106
+  [5] RifReaderEclipseOutput::loadAllGrids() const at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp:1161
+  [6] RifReaderEclipseOutput::open(QString const&, RigEclipseCaseData*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp:389
+  [7] RimEclipseResultCase::importGridAndResultMetaData(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultCase.cpp:261
+  [8] RiaImportEclipseCaseTools::openEclipseCaseShowTimeStepFilterImpl(QString const&, bool, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:372
+  [9] RiaImportEclipseCaseTools::openEclipseCasesFromFile(QList<QString> const&, bool, std::map<QString, int, std::less<QString>, std::allocator<std::pair<QString const, int> > >*, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:107
+  [10] RicImportGeneralDataFeature::openEclipseCaseFromFileNames(QList<QString> const&, bool, std::vector<int, std::allocator<int> >&, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:362
+  [11] RicImportEclipseCaseFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/EclipseCommands/RicImportEclipseCaseFeature.cpp:72
+  [12] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+  [13]  at :0
+  [14] QAction::triggered(bool) at :0
+  [15] QAction::activate(QAction::ActionEvent) at :0
+  [16]  at :0
+  [17]  at :0
+  [18] QWidget::event(QEvent*) at :0
+  [19] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [20] QApplication::notify(QObject*, QEvent*) at :0
+  [21] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [22] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [23] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [24]  at :0
+  [25]  at :0
+  [26] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [27] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [28] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [29] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [30] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [31]  at :0
+  [32] g_main_context_dispatch at :0
+  [33] g_main_context_iterate.isra.20 at :0
+  [34] g_main_context_iteration at :0
+  [35] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [36] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [37] QCoreApplication::exec() at :0
+  [38] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [39] __libc_start_main at :0
+  [40] _start at :0
+  [41]  at :0
+"
+2026-06-05T12:19:36.531Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigCaseCellResultsData::statistics(RigEclipseResultAddress const&) at ResInsight/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp:3063
+  [6] RigCaseCellResultsData::setStatisticsDataCacheNumBins(RigEclipseResultAddress const&, unsigned long) at ResInsight/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp:3204
+  [7] RimHistogramCalculator::histogramData(RimEclipseView*, RimEclipseResultDefinition*, RimHistogramCalculator::StatisticsCellRangeType, RimHistogramCalculator::StatisticsTimeRangeType, int) at ResInsight/ApplicationLibCode/ProjectDataModel/RimHistogramCalculator.cpp:259
+  [8] RimGridStatisticsHistogramDataSource::createStatisticsData() const at ResInsight/ApplicationLibCode/ProjectDataModel/Histogram/RimGridStatisticsHistogramDataSource.cpp:209
+  [9] RimGridStatisticsHistogramDataSource::compute(RimHistogramPlot::GraphType, RimHistogramPlot::FrequencyType) const at ResInsight/ApplicationLibCode/ProjectDataModel/Histogram/RimGridStatisticsHistogramDataSource.cpp:165
+  [10] RimHistogramCurve::onLoadDataAndUpdate(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Histogram/RimHistogramCurve.cpp:278
+  [11] RimPlotCurve::loadDataAndUpdate(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimPlotCurve.cpp:587
+  [12] RimHistogramCurve::loadAndUpdateDataAndPlot() at ResInsight/ApplicationLibCode/ProjectDataModel/Histogram/RimHistogramCurve.cpp:440
+  [13] std::function<void (caf::SignalEmitter const*)>::operator()(caf::SignalEmitter const*) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:591
+  [14] RicCreateGridStatisticsPlotFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/RicCreateGridStatisticsPlotFeature.cpp:45
+  [15] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+  [16]  at :0
+  [17] QAction::triggered(bool) at :0
+  [18] QAction::activate(QAction::ActionEvent) at :0
+  [19]  at :0
+  [20]  at :0
+  [21] QWidget::event(QEvent*) at :0
+  [22] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [23] QApplication::notify(QObject*, QEvent*) at :0
+  [24] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [25] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [26] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [27]  at :0
+  [28]  at :0
+  [29] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [30] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [31] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [32] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [33] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [34]  at :0
+  [35] g_main_context_dispatch at :0
+  [36] g_main_context_iterate.isra.20 at :0
+  [37] g_main_context_iteration at :0
+  [38] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [39] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [40]  at :0
+  [41] QMenu::exec(QPoint const&, QAction*) at :0
+  [42] RiuViewerCommands::displayContextMenu(QMouseEvent*) at ResInsight/ApplicationLibCode/UserInterface/RiuViewerCommands.cpp:648
+  [43] QWidget::event(QEvent*) at :0
+  [44] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [45] QApplication::notify(QObject*, QEvent*) at :0
+  [46] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [47] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [48] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [49]  at :0
+  [50]  at :0
+  [51] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [52] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [53] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [54] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [55] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [56]  at :0
+  [57] g_main_context_dispatch at :0
+  [58] g_main_context_iterate.isra.20 at :0
+  [59] g_main_context_iteration at :0
+  [60] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [61] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [62] QCoreApplication::exec() at :0
+  [63] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [64] __libc_start_main at :0
+  [65] _start at :0
+  [66]  at :0
+"
+2026-06-05T10:08:05.555Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] QString::size() const at /private/f_resinsight_build/resbuild/qt/6.6.3/gcc_64/include/QtCore/qstring.h:182
+  [4] std::map<QString, QString, std::less<QString>, std::allocator<std::pair<QString const, QString> > >::contains(QString const&) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/stl_map.h:1285
+  [5] RigCaseCellResultsData::hasResultEntry(RigEclipseResultAddress const&) const at ResInsight/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp:1287
+  [6] RigEclipseContourMapProjection::generateResults(RigEclipseContourMapProjection const&, RigContourMapGrid const&, RigCaseCellResultsData&, RigEclipseResultAddress const&, RigContourMapCalculator::ResultAggregationType, int, RigFloodingSettings&) at ResInsight/ApplicationLibCode/ReservoirDataModel/ContourMap/RigEclipseContourMapProjection.cpp:103
+  [7] RigEclipseContourMapProjection::generateAndSaveResults(RigEclipseResultAddress const&, RigContourMapCalculator::ResultAggregationType, int, RigFloodingSettings&) at ResInsight/ApplicationLibCode/ReservoirDataModel/ContourMap/RigEclipseContourMapProjection.cpp:71
+  [8] RimEclipseContourMapProjection::generateAndSaveResults(int) at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapProjection.cpp:213
+  [9] RimContourMapProjection::generateResultsIfNecessary(int) at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimContourMapProjection.cpp:164
+  [10] RimEclipseContourMapView::updateGeometry() at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapView.cpp:282
+  [11] Rim3dView::updateDisplayModelForCurrentTimeStepAndRedraw() at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:673
+  [12] RiuViewer::setCurrentFrame(int) at ResInsight/ApplicationLibCode/UserInterface/RiuViewer.cpp:1008
+  [13] RiuViewer::slotSetCurrentFrame(int) at ResInsight/ApplicationLibCode/UserInterface/RiuViewer.cpp:348
+  [14]  at :0
+  [15] caf::FrameAnimationControl::changeFrame(int) at ResInsight/cmakebuild/Fwk/AppFwk/cafAnimControl/cafAnimControl_autogen/EWIEGA46WW/moc_cafFrameAnimationControl.cpp:321
+  [16]  at :0
+  [17] QAction::triggered(bool) at :0
+  [18] QAction::activate(QAction::ActionEvent) at :0
+  [19]  at :0
+  [20] QAbstractButton::mouseReleaseEvent(QMouseEvent*) at :0
+  [21] QToolButton::mouseReleaseEvent(QMouseEvent*) at :0
+  [22] QWidget::event(QEvent*) at :0
+  [23] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [24] QApplication::notify(QObject*, QEvent*) at :0
+  [25] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [26] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [27] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [28]  at :0
+  [29]  at :0
+  [30] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [31] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [32] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [33] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [34] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [35]  at :0
+  [36] g_main_context_dispatch at :0
+  [37] g_main_context_iterate.isra.20 at :0
+  [38] g_main_context_iteration at :0
+  [39] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [40] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [41] QCoreApplication::exec() at :0
+  [42] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [43] __libc_start_main at :0
+  [44] _start at :0
+  [45]  at :0
+"
+2026-06-05T08:48:40.24Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] ecl_kw_get_data_type at ResInsight/ThirdParty/Ert/lib/ecl/ecl_kw.cpp:1776
+  [4] ecl_file_kw_assert_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_kw.cpp:211
+  [5] ecl_file_kw_load_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_kw.cpp:244
+  [6] ecl_file_view_get_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_view.cpp:149
+  [7] ecl_smspec_fread_header at ResInsight/ThirdParty/Ert/lib/ecl/ecl_smspec.cpp:1098
+  [8] ecl_sum_fread at ResInsight/ThirdParty/Ert/lib/ecl/ecl_sum.cpp:213
+  [9] ecl_sum_fread_alloc at ResInsight/ThirdParty/Ert/lib/ecl/ecl_sum.cpp:271
+  [10] RifEclipseSummaryTools::openEclSum(QString const&, bool) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseSummaryTools.cpp:519
+  [11] RifEclipseSummaryTools::getFileInfoAndTimeSteps(QString const&) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseSummaryTools.cpp:280
+  [12] RicSummaryCaseRestartDialog::openDialog(QString const&, QString const&, bool, bool, bool, RicSummaryCaseRestartDialog::ImportOptions, RicSummaryCaseRestartDialog::ImportOptions, bool, RicSummaryCaseRestartDialogResult*, QWidget*) at ResInsight/ApplicationLibCode/Commands/RicSummaryCaseRestartDialog.cpp:237
+  [13] RifSummaryCaseRestartSelector::determineFilesToImportByAskingUser(std::vector<RifSummaryCaseFileImportInfo, std::allocator<RifSummaryCaseFileImportInfo> > const&, bool) at ResInsight/ApplicationLibCode/FileInterface/RifSummaryCaseRestartSelector.cpp:189
+  [14] RifSummaryCaseRestartSelector::determineFilesToImportFromSummaryFiles(QList<QString> const&) at ResInsight/ApplicationLibCode/FileInterface/RifSummaryCaseRestartSelector.cpp:96
+  [15] RiaEnsembleImportTools::createSummaryCasesFromFiles(QList<QString> const&, RiaEnsembleImportTools::CreateConfig) at ResInsight/ApplicationLibCode/Application/Tools/Ensemble/RiaEnsembleImportTools.cpp:60
+  [16] RicImportSummaryCasesFeature::createAndAddSummaryCasesFromFiles(QList<QString> const&, bool) at ResInsight/ApplicationLibCode/Commands/RicImportSummaryCasesFeature.cpp:126
+  [17] RicImportGeneralDataFeature::openSummaryCaseFromFileNames(QList<QString> const&, bool) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:378
+  [18] RicImportGeneralDataFeature::openEclipseFilesFromFileNames(QList<QString> const&, bool, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:122
+  [19] RicImportGeneralDataFeature::openEclipseFilesFromFileNames(QList<QString> const&, bool, bool) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:55
+  [20] RicImportGeneralDataFeature::openFileDialog(RiaDefines::ImportFileType) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:339
+  [21] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+  [22]  at :0
+  [23] QAction::triggered(bool) at :0
+  [24] QAction::activate(QAction::ActionEvent) at :0
+  [25]  at :0
+  [26] QAbstractButton::mouseReleaseEvent(QMouseEvent*) at :0
+  [27] QToolButton::mouseReleaseEvent(QMouseEvent*) at :0
+  [28] QWidget::event(QEvent*) at :0
+  [29] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [30] QApplication::notify(QObject*, QEvent*) at :0
+  [31] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [32] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [33] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [34]  at :0
+  [35]  at :0
+  [36] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [37] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [38] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [39] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [40] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [41]  at :0
+  [42] g_main_context_dispatch at :0
+  [43] g_main_context_iterate.isra.20 at :0
+  [44] g_main_context_iteration at :0
+  [45] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [46] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [47] QCoreApplication::exec() at :0
+  [48] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [49] __libc_start_main at :0
+  [50] _start at :0
+  [51]  at :0
+"
+2026-06-05T08:44:15.848Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3]  at :0
+  [4]  at :0
+  [5]  at :0
+  [6] cvf::PrimitiveSetIndexedUInt::render(cvf::OpenGLContext*) const at ResInsight/Fwk/VizFwk/LibRender/cvfPrimitiveSetIndexedUInt.cpp:125
+  [7] cvf::DrawableGeo::render(cvf::OpenGLContext*, cvf::ShaderProgram*, cvf::MatrixState const&) at ResInsight/Fwk/VizFwk/LibRender/cvfDrawableGeo.cpp:141
+  [8] cvf::RenderEngine::render(cvf::OpenGLContext*, cvf::RenderQueue*, unsigned long, cvf::Camera const&, cvf::UniformSet const*) at ResInsight/Fwk/VizFwk/LibViewing/cvfRenderEngine.cpp:284
+  [9] cvf::Rendering::render(cvf::OpenGLContext*) at ResInsight/Fwk/VizFwk/LibViewing/cvfRendering.cpp:271
+  [10] cvf::RenderSequence::render(cvf::OpenGLContext*) at ResInsight/Fwk/VizFwk/LibViewing/cvfRenderSequence.cpp:211
+  [11] caf::Viewer::paintGL() at ResInsight/Fwk/AppFwk/cafViewer/cafViewer.cpp:901
+  [12]  at :0
+  [13] QWidget::event(QEvent*) at :0
+  [14] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [15] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [16] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [17] QWidgetPrivate::sendPaintEvent(QRegion const&) at :0
+  [18] QWidgetRepaintManager::paintAndFlush() at :0
+  [19] QWidget::event(QEvent*) at :0
+  [20] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [21] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [22] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [23] QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*) at :0
+  [24]  at :0
+  [25] g_main_context_dispatch at :0
+  [26] g_main_context_iterate.isra.20 at :0
+  [27] g_main_context_iteration at :0
+  [28] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [29] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [30] QCoreApplication::exec() at :0
+  [31] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [32] __libc_start_main at :0
+  [33] _start at :0
+  [34]  at :0
+"
+2026-06-05T06:25:00.48Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] QWidgetPrivate::shouldPaintOnScreen() const at :0
+  [4] QWidgetRepaintManager::markNeedsFlush(QWidget*, QRegion const&, QPoint const&) at :0
+  [5] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [6] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [7] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [8] QWidgetRepaintManager::paintAndFlush() at :0
+  [9] QWidget::event(QEvent*) at :0
+  [10] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [11] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [12] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [13] QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*) at :0
+  [14]  at :0
+  [15] g_main_context_dispatch at :0
+  [16] g_main_context_iterate.isra.20 at :0
+  [17] g_main_context_iteration at :0
+  [18] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [19] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [20] QCoreApplication::exec() at :0
+  [21] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [22] __libc_start_main at :0
+  [23] _start at :0
+  [24]  at :0
+"
+2026-06-04T15:00:13.919Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] ecl_grid_alloc_EGRID__ at ResInsight/ThirdParty/Ert/lib/ecl/ecl_grid.cpp:3085
+  [4] ecl_grid_alloc_EGRID_all_grids at ResInsight/ThirdParty/Ert/lib/ecl/ecl_grid.cpp:3106
+  [5] RifReaderEclipseOutput::loadAllGrids() const at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp:1161
+  [6] RifReaderEclipseOutput::open(QString const&, RigEclipseCaseData*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp:389
+  [7] RimEclipseResultCase::importGridAndResultMetaData(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultCase.cpp:261
+  [8] RiaImportEclipseCaseTools::openEclipseCaseShowTimeStepFilterImpl(QString const&, bool, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:372
+  [9] RiaImportEclipseCaseTools::openEclipseCasesFromFile(QList<QString> const&, bool, std::map<QString, int, std::less<QString>, std::allocator<std::pair<QString const, int> > >*, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:107
+  [10] RicImportGeneralDataFeature::openEclipseCaseFromFileNames(QList<QString> const&, bool, std::vector<int, std::allocator<int> >&, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:362
+  [11] RicImportEclipseCaseFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/EclipseCommands/RicImportEclipseCaseFeature.cpp:72
+  [12] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+  [13]  at :0
+  [14] QAction::triggered(bool) at :0
+  [15] QAction::activate(QAction::ActionEvent) at :0
+  [16]  at :0
+  [17] QAbstractButton::mouseReleaseEvent(QMouseEvent*) at :0
+  [18] QToolButton::mouseReleaseEvent(QMouseEvent*) at :0
+  [19] QWidget::event(QEvent*) at :0
+  [20] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [21] QApplication::notify(QObject*, QEvent*) at :0
+  [22] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [23] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [24] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [25]  at :0
+  [26]  at :0
+  [27] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [28] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [29] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [30] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [31] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [32]  at :0
+  [33] g_main_context_dispatch at :0
+  [34] g_main_context_iterate.isra.20 at :0
+  [35] g_main_context_iteration at :0
+  [36] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [37] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [38] QCoreApplication::exec() at :0
+  [39] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [40] __libc_start_main at :0
+  [41] _start at :0
+  [42]  at :0
+"
+2026-06-04T13:39:55.03Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
+  [6] RicWellPathExportMswTableData::generateCellSegments(RimEclipseCase const*, RimWellPath const*) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswTableData.cpp:649
+  [7] RicWellPathExportMswTableData::extractSingleWellMswData[abi:cxx11](RimEclipseCase*, RimWellPath*, bool, RicWellPathExportMswTableData::CompletionType, std::optional<QDateTime> const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswTableData.cpp:83
+  [8] RimMswSegmentCollection::updateSegments(RimWellPath*, RimEclipseCase*) at ResInsight/ApplicationLibCode/ProjectDataModel/Completions/RimMswSegmentCollection.cpp:168
+  [9] RimWellPathCollection::updateMswSegments() at ResInsight/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPathCollection.cpp:624
+  [10]  at :0
+  [11] QAbstractButton::clicked(bool) at :0
+  [12]  at :0
+  [13]  at :0
+  [14] QAbstractButton::mouseReleaseEvent(QMouseEvent*) at :0
+  [15] QWidget::event(QEvent*) at :0
+  [16] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [17] QApplication::notify(QObject*, QEvent*) at :0
+  [18] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [19] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [20] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [21]  at :0
+  [22]  at :0
+  [23] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [24] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [25] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [26] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [27] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [28]  at :0
+  [29] g_main_context_dispatch at :0
+  [30] g_main_context_iterate.isra.20 at :0
+  [31] g_main_context_iteration at :0
+  [32] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [33] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [34] QCoreApplication::exec() at :0
+  [35] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [36] __libc_start_main at :0
+  [37] _start at :0
+  [38]  at :0
+"
+2026-06-04T13:25:41.152Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
+  [6] RicWellPathExportMswTableData::generateCellSegments(RimEclipseCase const*, RimWellPath const*) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswTableData.cpp:649
+  [7] RicWellPathExportMswTableData::extractSingleWellMswData[abi:cxx11](RimEclipseCase*, RimWellPath*, bool, RicWellPathExportMswTableData::CompletionType, std::optional<QDateTime> const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswTableData.cpp:83
+  [8] RimMswSegmentCollection::updateSegments(RimWellPath*, RimEclipseCase*) at ResInsight/ApplicationLibCode/ProjectDataModel/Completions/RimMswSegmentCollection.cpp:168
+  [9] RimWellPathCollection::updateMswSegments() at ResInsight/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPathCollection.cpp:624
+  [10]  at :0
+  [11] QAbstractButton::clicked(bool) at :0
+  [12]  at :0
+  [13]  at :0
+  [14] QAbstractButton::mouseReleaseEvent(QMouseEvent*) at :0
+  [15] QWidget::event(QEvent*) at :0
+  [16] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [17] QApplication::notify(QObject*, QEvent*) at :0
+  [18] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [19] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [20] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [21]  at :0
+  [22]  at :0
+  [23] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [24] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [25] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [26] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [27] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [28]  at :0
+  [29] g_main_context_dispatch at :0
+  [30] g_main_context_iterate.isra.20 at :0
+  [31] g_main_context_iteration at :0
+  [32] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [33] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [34] RiaOpenTelemetryManager::reportCrash(int, std::basic_stacktrace<std::allocator<std::stacktrace_entry> > const&, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > const&) at ResInsight/ApplicationLibCode/Application/Tools/Telemetry/RiaOpenTelemetryManager.cpp:415
+  [35] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:174
+  [36] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [37]  at :0
+  [38] __GI_raise at :0
+  [39] __GI_abort at :0
+  [40] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
+  [41] RicWellPathExportMswTableData::generateCellSegments(RimEclipseCase const*, RimWellPath const*) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswTableData.cpp:649
+  [42] RicWellPathExportMswTableData::extractSingleWellMswData[abi:cxx11](RimEclipseCase*, RimWellPath*, bool, RicWellPathExportMswTableData::CompletionType, std::optional<QDateTime> const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswTableData.cpp:83
+  [43] RimMswSegmentCollection::updateSegments(RimWellPath*, RimEclipseCase*) at ResInsight/ApplicationLibCode/ProjectDataModel/Completions/RimMswSegmentCollection.cpp:168
+  [44] RimWellPathCollection::updateMswSegments() at ResInsight/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPathCollection.cpp:624
+  [45]  at :0
+  [46] QAbstractButton::clicked(bool) at :0
+  [47]  at :0
+  [48]  at :0
+  [49] QAbstractButton::mouseReleaseEvent(QMouseEvent*) at :0
+  [50] QWidget::event(QEvent*) at :0
+  [51] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [52] QApplication::notify(QObject*, QEvent*) at :0
+  [53] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [54] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [55] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [56]  at :0
+  [57]  at :0
+  [58] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [59] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [60] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [61] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [62] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [63]  at :0
+  [64] g_main_context_dispatch at :0
+  [65] g_main_context_iterate.isra.20 at :0
+  [66] g_main_context_iteration at :0
+  [67] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [68] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [69] QCoreApplication::exec() at :0
+  [70] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [71] __libc_start_main at :0
+  [72] _start at :0
+  [73]  at :0
+"
+2026-06-04T13:25:41.101Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
+  [6] RicWellPathExportMswTableData::generateCellSegments(RimEclipseCase const*, RimWellPath const*) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswTableData.cpp:649
+  [7] RicWellPathExportMswTableData::extractSingleWellMswData[abi:cxx11](RimEclipseCase*, RimWellPath*, bool, RicWellPathExportMswTableData::CompletionType, std::optional<QDateTime> const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswTableData.cpp:83
+  [8] RimMswSegmentCollection::updateSegments(RimWellPath*, RimEclipseCase*) at ResInsight/ApplicationLibCode/ProjectDataModel/Completions/RimMswSegmentCollection.cpp:168
+  [9] RimWellPathCollection::updateMswSegments() at ResInsight/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPathCollection.cpp:624
+  [10]  at :0
+  [11] QAbstractButton::clicked(bool) at :0
+  [12]  at :0
+  [13]  at :0
+  [14] QAbstractButton::mouseReleaseEvent(QMouseEvent*) at :0
+  [15] QWidget::event(QEvent*) at :0
+  [16] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [17] QApplication::notify(QObject*, QEvent*) at :0
+  [18] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [19] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [20] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [21]  at :0
+  [22]  at :0
+  [23] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [24] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [25] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [26] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [27] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [28]  at :0
+  [29] g_main_context_dispatch at :0
+  [30] g_main_context_iterate.isra.20 at :0
+  [31] g_main_context_iteration at :0
+  [32] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [33] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [34] QCoreApplication::exec() at :0
+  [35] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [36] __libc_start_main at :0
+  [37] _start at :0
+  [38]  at :0
+"
+2026-06-04T11:15:23.138Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __libc_message at :0
+  [6] malloc_printerr at :0
+  [7] _int_free at :0
+  [8] std::__new_allocator<std::_Rb_tree_node<caf::PdmUiEditorHandle*> >::deallocate(std::_Rb_tree_node<caf::PdmUiEditorHandle*>*, unsigned long) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/new_allocator.h:172
+  [9] std::_Rb_tree<caf::PdmUiEditorHandle*, caf::PdmUiEditorHandle*, std::_Identity<caf::PdmUiEditorHandle*>, std::less<caf::PdmUiEditorHandle*>, std::allocator<caf::PdmUiEditorHandle*> >::erase(caf::PdmUiEditorHandle* const&) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/stl_tree.h:1255
+  [10] caf::PdmUiEditorHandle::~PdmUiEditorHandle() at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiEditorHandle.cpp:55
+  [11] caf::PdmUiTreeItemEditor::~PdmUiTreeItemEditor() at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeItemEditor.h:53
+  [12] caf::PdmUiTreeOrdering::~PdmUiTreeOrdering() at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiTreeOrdering.cpp:233
+  [13] void qDeleteAll<QList<caf::PdmUiTreeOrdering*>::const_iterator>(QList<caf::PdmUiTreeOrdering*>::const_iterator, QList<caf::PdmUiTreeOrdering*>::const_iterator) at /private/f_resinsight_build/resbuild/qt/6.6.3/gcc_64/include/QtCore/qalgorithms.h:27
+  [14] void qDeleteAll<QList<caf::PdmUiTreeOrdering*>::const_iterator>(QList<caf::PdmUiTreeOrdering*>::const_iterator, QList<caf::PdmUiTreeOrdering*>::const_iterator) at /private/f_resinsight_build/resbuild/qt/6.6.3/gcc_64/include/QtCore/qalgorithms.h:27
+  [15] void qDeleteAll<QList<caf::PdmUiTreeOrdering*>::const_iterator>(QList<caf::PdmUiTreeOrdering*>::const_iterator, QList<caf::PdmUiTreeOrdering*>::const_iterator) at /private/f_resinsight_build/resbuild/qt/6.6.3/gcc_64/include/QtCore/qalgorithms.h:27
+  [16] void qDeleteAll<QList<caf::PdmUiTreeOrdering*>::const_iterator>(QList<caf::PdmUiTreeOrdering*>::const_iterator, QList<caf::PdmUiTreeOrdering*>::const_iterator) at /private/f_resinsight_build/resbuild/qt/6.6.3/gcc_64/include/QtCore/qalgorithms.h:27
+  [17] caf::PdmUiTreeOrdering::removeChildren(int, int) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiTreeOrdering.cpp:390
+  [18] caf::PdmUiTreeViewQModel::updateSubTreeRecursive(QModelIndex const&, caf::PdmUiTreeOrdering*, caf::PdmUiTreeOrdering*, bool) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeViewQModel.cpp:269
+  [19] caf::PdmUiTreeViewQModel::updateSubTree(caf::PdmUiItem*, bool) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeViewQModel.cpp:202
+  [20] caf::PdmUiTreeViewEditor::updateMySubTree(caf::PdmUiItem*, bool) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeViewEditor.cpp:332
+  [21] caf::PdmUiEditorHandle::updateUi() at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiEditorHandle.cpp:82
+  [22] caf::PdmUiItem::updateConnectedEditors() const at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiItem.cpp:491
+  [23] RicDeleteSummaryCaseCollectionFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/RicDeleteSummaryCaseCollectionFeature.cpp:130
+  [24] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+  [25] RiuTreeViewEventFilter::activateFirstEnabledFeature(std::vector<caf::CmdFeature*, std::allocator<caf::CmdFeature*> > const&) at ResInsight/ApplicationLibCode/UserInterface/RiuTreeViewEventFilter.cpp:95
+  [26] RiuTreeViewEventFilter::eventFilter(QObject*, QEvent*) at ResInsight/ApplicationLibCode/UserInterface/RiuTreeViewEventFilter.cpp:143
+  [27] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [28] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [29] QApplication::notify(QObject*, QEvent*) at :0
+  [30] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [31] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [32]  at :0
+  [33] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [34] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [35] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [36] QGuiApplicationPrivate::processKeyEvent(QWindowSystemInterfacePrivate::KeyEvent*) at :0
+  [37] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [38]  at :0
+  [39] g_main_context_dispatch at :0
+  [40] g_main_context_iterate.isra.20 at :0
+  [41] g_main_context_iteration at :0
+  [42] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [43] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [44] QCoreApplication::exec() at :0
+  [45] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [46] __libc_start_main at :0
+  [47] _start at :0
+  [48]  at :0
+"
+2026-06-04T10:43:28.121Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] QAbstractSpinBox::lineEdit() const at :0
+  [4] QAbstractSpinBox::text() const at :0
+  [5] caf::PdmUiSliderEditor::writeValueToField() at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiSliderEditor.cpp:190
+  [6]  at :0
+  [7] QSpinBox::valueChanged(int) at :0
+  [8]  at :0
+  [9] QAbstractSpinBox::stepBy(int) at :0
+  [10]  at :0
+  [11] QWidget::event(QEvent*) at :0
+  [12] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [13] QApplication::notify(QObject*, QEvent*) at :0
+  [14] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [15] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [16] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [17]  at :0
+  [18]  at :0
+  [19] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [20] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [21] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [22] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [23] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [24]  at :0
+  [25] g_main_context_dispatch at :0
+  [26] g_main_context_iterate.isra.20 at :0
+  [27] g_main_context_iteration at :0
+  [28] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [29] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [30] QCoreApplication::exec() at :0
+  [31] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [32] __libc_start_main at :0
+  [33] _start at :0
+  [34]  at :0
+"
+2026-06-04T10:38:47.12Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] std::vector<cvf::Vector3<double>, std::allocator<cvf::Vector3<double> > >::size() const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/stl_vector.h:993
+  [4] caf::PdmUiEditorHandle::updateUi() at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiEditorHandle.cpp:82
+  [5] RicWellPathGeometry3dEditor::configureAndUpdateUi(QString const&) at ResInsight/ApplicationLibCode/Commands/WellPathCommands/PointTangentManipulator/RicWellPathGeometry3dEditor.cpp:78
+  [6] caf::PdmUiEditorHandle::updateUi() at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiEditorHandle.cpp:82
+  [7] caf::PdmUiItem::updateConnectedEditors() const at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiItem.cpp:491
+  [8] RicCreateWellTargetsPickEventHandler::handle3dPickEvent(Ric3dPickEvent const&) at ResInsight/ApplicationLibCode/Commands/WellPathCommands/RicCreateWellTargetsPickEventHandler.cpp:183
+  [9] RiuViewerCommands::handlePickAction(int, int, QFlags<Qt::KeyboardModifier>) at ResInsight/ApplicationLibCode/UserInterface/RiuViewerCommands.cpp:695
+  [10] QWidget::event(QEvent*) at :0
+  [11] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [12] QApplication::notify(QObject*, QEvent*) at :0
+  [13] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [14] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [15] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [16]  at :0
+  [17]  at :0
+  [18] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [19] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [20] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [21] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [22] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [23]  at :0
+  [24] g_main_context_dispatch at :0
+  [25] g_main_context_iterate.isra.20 at :0
+  [26] g_main_context_iteration at :0
+  [27] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [28] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [29] QCoreApplication::exec() at :0
+  [30] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [31] __libc_start_main at :0
+  [32] _start at :0
+  [33]  at :0
+"
+2026-06-04T10:32:37.552Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3]  at :0
+  [4] QComboBox::textActivated(QString const&) at :0
+  [5]  at :0
+  [6]  at :0
+  [7]  at :0
+  [8] QComboBoxPrivateContainer::itemSelected(QModelIndex const&) at :0
+  [9] QComboBoxPrivateContainer::eventFilter(QObject*, QEvent*) at :0
+  [10] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [11] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [12] QApplication::notify(QObject*, QEvent*) at :0
+  [13] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [14] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [15] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [16]  at :0
+  [17]  at :0
+  [18] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [19] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [20] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [21] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [22] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [23]  at :0
+  [24] g_main_context_dispatch at :0
+  [25] g_main_context_iterate.isra.20 at :0
+  [26] g_main_context_iteration at :0
+  [27] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [28] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [29] QCoreApplication::exec() at :0
+  [30] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [31] __libc_start_main at :0
+  [32] _start at :0
+  [33]  at :0
+"
+2026-06-04T10:23:43.078Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] std::__atomic_base<int>::load(std::memory_order) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/atomic_base.h:505
+  [4]  at :0
+  [5] QSpinBox::valueChanged(int) at :0
+  [6]  at :0
+  [7] QAbstractSpinBox::stepBy(int) at :0
+  [8]  at :0
+  [9] QWidget::event(QEvent*) at :0
+  [10] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [11] QApplication::notify(QObject*, QEvent*) at :0
+  [12] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [13] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [14] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [15]  at :0
+  [16]  at :0
+  [17] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [18] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [19] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [20] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [21] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [22]  at :0
+  [23] g_main_context_dispatch at :0
+  [24] g_main_context_iterate.isra.20 at :0
+  [25] g_main_context_iteration at :0
+  [26] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [27] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [28] QCoreApplication::exec() at :0
+  [29] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [30] __libc_start_main at :0
+  [31] _start at :0
+  [32]  at :0
+"
+2026-06-04T09:07:54.727Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] QArrayDataPointer<char16_t>::QArrayDataPointer(QArrayDataPointer<char16_t> const&) at /private/f_resinsight_build/resbuild/qt/6.6.3/gcc_64/include/QtCore/qarraydatapointer.h:38
+  [4] RimStimPlanModelCalculator::calculateFormation() const at ResInsight/ApplicationLibCode/ProjectDataModel/StimPlanModel/RimStimPlanModelCalculator.cpp:740
+  [5] RifStimPlanModelGeologicalFrkExporter::writeToFile(RimStimPlanModel*, bool, QString const&) at ResInsight/ApplicationLibCode/FileInterface/RifStimPlanModelGeologicalFrkExporter.cpp:149
+  [6] RifStimPlanModelExporter::writeToDirectory(RimStimPlanModel*, bool, QString const&) at ResInsight/ApplicationLibCode/FileInterface/RifStimPlanModelExporter.cpp:33
+  [7] RimcStimPlanModel_exportToFile::execute() at ResInsight/ApplicationLibCode/ProjectDataModelCommands/RimcStimPlanModel.cpp:47
+  [8] RiaGrpcPdmObjectService::CallPdmObjectMethod(grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*) at ResInsight/GrpcInterface/RiaGrpcPdmObjectService.cpp:578
+  [9] grpc::Status std::__invoke_impl<grpc::Status, grpc::Status (RiaGrpcPdmObjectService::*&)(grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*), RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*>(std::__invoke_memfun_ref, grpc::Status (RiaGrpcPdmObjectService::*&)(grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*), RiaGrpcPdmObjectService&, grpc::ServerContext*&&, rips::PdmObjectMethodRequest const*&&, rips::PdmObject*&&) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/invoke.h:67
+  [10] std::function<grpc::Status (RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*)>::operator()(RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:591
+  [11] RiaGrpcServerImpl::processAllQueuedRequests() at ResInsight/GrpcInterface/RiaGrpcServer.cpp:197
+  [12] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:115
+  [13] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:33
+  [14]  at :0
+  [15] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [16] QObject::event(QEvent*) at :0
+  [17] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [18] QTimerInfoList::activateTimers() at :0
+  [19]  at :0
+  [20] g_main_context_dispatch at :0
+  [21] g_main_context_iterate.isra.20 at :0
+  [22] g_main_context_iteration at :0
+  [23] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [24] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [25] QCoreApplication::exec() at :0
+  [26] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [27] __libc_start_main at :0
+  [28] _start at :0
+  [29]  at :0
+"
+2026-06-04T09:07:54.572Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] QArrayDataPointer<char16_t>::QArrayDataPointer(QArrayDataPointer<char16_t> const&) at /private/f_resinsight_build/resbuild/qt/6.6.3/gcc_64/include/QtCore/qarraydatapointer.h:38
+  [4] RimStimPlanModelCalculator::calculateFormation() const at ResInsight/ApplicationLibCode/ProjectDataModel/StimPlanModel/RimStimPlanModelCalculator.cpp:740
+  [5] RifStimPlanModelGeologicalFrkExporter::writeToFile(RimStimPlanModel*, bool, QString const&) at ResInsight/ApplicationLibCode/FileInterface/RifStimPlanModelGeologicalFrkExporter.cpp:149
+  [6] RifStimPlanModelExporter::writeToDirectory(RimStimPlanModel*, bool, QString const&) at ResInsight/ApplicationLibCode/FileInterface/RifStimPlanModelExporter.cpp:33
+  [7] RimcStimPlanModel_exportToFile::execute() at ResInsight/ApplicationLibCode/ProjectDataModelCommands/RimcStimPlanModel.cpp:47
+  [8] RiaGrpcPdmObjectService::CallPdmObjectMethod(grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*) at ResInsight/GrpcInterface/RiaGrpcPdmObjectService.cpp:578
+  [9] grpc::Status std::__invoke_impl<grpc::Status, grpc::Status (RiaGrpcPdmObjectService::*&)(grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*), RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*>(std::__invoke_memfun_ref, grpc::Status (RiaGrpcPdmObjectService::*&)(grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*), RiaGrpcPdmObjectService&, grpc::ServerContext*&&, rips::PdmObjectMethodRequest const*&&, rips::PdmObject*&&) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/invoke.h:67
+  [10] std::function<grpc::Status (RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*)>::operator()(RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:591
+  [11] RiaGrpcServerImpl::processAllQueuedRequests() at ResInsight/GrpcInterface/RiaGrpcServer.cpp:197
+  [12] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:115
+  [13] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:33
+  [14]  at :0
+  [15] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [16] QObject::event(QEvent*) at :0
+  [17] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [18] QTimerInfoList::activateTimers() at :0
+  [19]  at :0
+  [20] g_main_context_dispatch at :0
+  [21] g_main_context_iterate.isra.20 at :0
+  [22] g_main_context_iteration at :0
+  [23] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [24] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [25] QCoreApplication::exec() at :0
+  [26] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [27] __libc_start_main at :0
+  [28] _start at :0
+  [29]  at :0
+"
+2026-06-04T09:07:18.742Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] QArrayDataPointer<char16_t>::QArrayDataPointer(QArrayDataPointer<char16_t> const&) at /private/f_resinsight_build/resbuild/qt/6.6.3/gcc_64/include/QtCore/qarraydatapointer.h:38
+  [4] RimStimPlanModelCalculator::calculateFormation() const at ResInsight/ApplicationLibCode/ProjectDataModel/StimPlanModel/RimStimPlanModelCalculator.cpp:740
+  [5] RifStimPlanModelGeologicalFrkExporter::writeToFile(RimStimPlanModel*, bool, QString const&) at ResInsight/ApplicationLibCode/FileInterface/RifStimPlanModelGeologicalFrkExporter.cpp:149
+  [6] RifStimPlanModelExporter::writeToDirectory(RimStimPlanModel*, bool, QString const&) at ResInsight/ApplicationLibCode/FileInterface/RifStimPlanModelExporter.cpp:33
+  [7] RimcStimPlanModel_exportToFile::execute() at ResInsight/ApplicationLibCode/ProjectDataModelCommands/RimcStimPlanModel.cpp:47
+  [8] RiaGrpcPdmObjectService::CallPdmObjectMethod(grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*) at ResInsight/GrpcInterface/RiaGrpcPdmObjectService.cpp:578
+  [9] grpc::Status std::__invoke_impl<grpc::Status, grpc::Status (RiaGrpcPdmObjectService::*&)(grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*), RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*>(std::__invoke_memfun_ref, grpc::Status (RiaGrpcPdmObjectService::*&)(grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*), RiaGrpcPdmObjectService&, grpc::ServerContext*&&, rips::PdmObjectMethodRequest const*&&, rips::PdmObject*&&) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/invoke.h:67
+  [10] std::function<grpc::Status (RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*)>::operator()(RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:591
+  [11] RiaGrpcServerImpl::processAllQueuedRequests() at ResInsight/GrpcInterface/RiaGrpcServer.cpp:197
+  [12] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:115
+  [13] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:33
+  [14]  at :0
+  [15] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [16] QObject::event(QEvent*) at :0
+  [17] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [18] QTimerInfoList::activateTimers() at :0
+  [19]  at :0
+  [20] g_main_context_dispatch at :0
+  [21] g_main_context_iterate.isra.20 at :0
+  [22] g_main_context_iteration at :0
+  [23] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [24] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [25] QCoreApplication::exec() at :0
+  [26] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [27] __libc_start_main at :0
+  [28] _start at :0
+  [29]  at :0
+"
+2026-06-04T09:07:05.988Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] QArrayDataPointer<char16_t>::QArrayDataPointer(QArrayDataPointer<char16_t> const&) at /private/f_resinsight_build/resbuild/qt/6.6.3/gcc_64/include/QtCore/qarraydatapointer.h:38
+  [4] RimStimPlanModelCalculator::calculateFormation() const at ResInsight/ApplicationLibCode/ProjectDataModel/StimPlanModel/RimStimPlanModelCalculator.cpp:740
+  [5] RifStimPlanModelGeologicalFrkExporter::writeToFile(RimStimPlanModel*, bool, QString const&) at ResInsight/ApplicationLibCode/FileInterface/RifStimPlanModelGeologicalFrkExporter.cpp:149
+  [6] RifStimPlanModelExporter::writeToDirectory(RimStimPlanModel*, bool, QString const&) at ResInsight/ApplicationLibCode/FileInterface/RifStimPlanModelExporter.cpp:33
+  [7] RimcStimPlanModel_exportToFile::execute() at ResInsight/ApplicationLibCode/ProjectDataModelCommands/RimcStimPlanModel.cpp:47
+  [8] RiaGrpcPdmObjectService::CallPdmObjectMethod(grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*) at ResInsight/GrpcInterface/RiaGrpcPdmObjectService.cpp:578
+  [9] grpc::Status std::__invoke_impl<grpc::Status, grpc::Status (RiaGrpcPdmObjectService::*&)(grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*), RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*>(std::__invoke_memfun_ref, grpc::Status (RiaGrpcPdmObjectService::*&)(grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*), RiaGrpcPdmObjectService&, grpc::ServerContext*&&, rips::PdmObjectMethodRequest const*&&, rips::PdmObject*&&) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/invoke.h:67
+  [10] std::function<grpc::Status (RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*)>::operator()(RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:591
+  [11] RiaGrpcServerImpl::processAllQueuedRequests() at ResInsight/GrpcInterface/RiaGrpcServer.cpp:197
+  [12] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:115
+  [13] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:33
+  [14]  at :0
+  [15] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [16] QObject::event(QEvent*) at :0
+  [17] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [18] QTimerInfoList::activateTimers() at :0
+  [19]  at :0
+  [20] g_main_context_dispatch at :0
+  [21] g_main_context_iterate.isra.20 at :0
+  [22] g_main_context_iteration at :0
+  [23] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [24] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [25] QCoreApplication::exec() at :0
+  [26] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [27] __libc_start_main at :0
+  [28] _start at :0
+  [29]  at :0
+"
+2026-06-04T09:06:06.259Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] QArrayDataPointer<char16_t>::QArrayDataPointer(QArrayDataPointer<char16_t> const&) at /private/f_resinsight_build/resbuild/qt/6.6.3/gcc_64/include/QtCore/qarraydatapointer.h:38
+  [4] RimStimPlanModelCalculator::calculateFormation() const at ResInsight/ApplicationLibCode/ProjectDataModel/StimPlanModel/RimStimPlanModelCalculator.cpp:740
+  [5] RifStimPlanModelGeologicalFrkExporter::writeToFile(RimStimPlanModel*, bool, QString const&) at ResInsight/ApplicationLibCode/FileInterface/RifStimPlanModelGeologicalFrkExporter.cpp:149
+  [6] RifStimPlanModelExporter::writeToDirectory(RimStimPlanModel*, bool, QString const&) at ResInsight/ApplicationLibCode/FileInterface/RifStimPlanModelExporter.cpp:33
+  [7] RimcStimPlanModel_exportToFile::execute() at ResInsight/ApplicationLibCode/ProjectDataModelCommands/RimcStimPlanModel.cpp:47
+  [8] RiaGrpcPdmObjectService::CallPdmObjectMethod(grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*) at ResInsight/GrpcInterface/RiaGrpcPdmObjectService.cpp:578
+  [9] grpc::Status std::__invoke_impl<grpc::Status, grpc::Status (RiaGrpcPdmObjectService::*&)(grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*), RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*>(std::__invoke_memfun_ref, grpc::Status (RiaGrpcPdmObjectService::*&)(grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*), RiaGrpcPdmObjectService&, grpc::ServerContext*&&, rips::PdmObjectMethodRequest const*&&, rips::PdmObject*&&) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/invoke.h:67
+  [10] std::function<grpc::Status (RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*)>::operator()(RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:591
+  [11] RiaGrpcServerImpl::processAllQueuedRequests() at ResInsight/GrpcInterface/RiaGrpcServer.cpp:197
+  [12] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:115
+  [13] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:33
+  [14]  at :0
+  [15] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [16] QObject::event(QEvent*) at :0
+  [17] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [18] QTimerInfoList::activateTimers() at :0
+  [19]  at :0
+  [20] g_main_context_dispatch at :0
+  [21] g_main_context_iterate.isra.20 at :0
+  [22] g_main_context_iteration at :0
+  [23] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [24] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [25] QCoreApplication::exec() at :0
+  [26] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [27] __libc_start_main at :0
+  [28] _start at :0
+  [29]  at :0
+"
+2026-06-04T09:05:42.824Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] QArrayDataPointer<char16_t>::QArrayDataPointer(QArrayDataPointer<char16_t> const&) at /private/f_resinsight_build/resbuild/qt/6.6.3/gcc_64/include/QtCore/qarraydatapointer.h:38
+  [4] RimStimPlanModelCalculator::calculateFormation() const at ResInsight/ApplicationLibCode/ProjectDataModel/StimPlanModel/RimStimPlanModelCalculator.cpp:740
+  [5] RifStimPlanModelGeologicalFrkExporter::writeToFile(RimStimPlanModel*, bool, QString const&) at ResInsight/ApplicationLibCode/FileInterface/RifStimPlanModelGeologicalFrkExporter.cpp:149
+  [6] RifStimPlanModelExporter::writeToDirectory(RimStimPlanModel*, bool, QString const&) at ResInsight/ApplicationLibCode/FileInterface/RifStimPlanModelExporter.cpp:33
+  [7] RimcStimPlanModel_exportToFile::execute() at ResInsight/ApplicationLibCode/ProjectDataModelCommands/RimcStimPlanModel.cpp:47
+  [8] RiaGrpcPdmObjectService::CallPdmObjectMethod(grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*) at ResInsight/GrpcInterface/RiaGrpcPdmObjectService.cpp:578
+  [9] grpc::Status std::__invoke_impl<grpc::Status, grpc::Status (RiaGrpcPdmObjectService::*&)(grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*), RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*>(std::__invoke_memfun_ref, grpc::Status (RiaGrpcPdmObjectService::*&)(grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*), RiaGrpcPdmObjectService&, grpc::ServerContext*&&, rips::PdmObjectMethodRequest const*&&, rips::PdmObject*&&) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/invoke.h:67
+  [10] std::function<grpc::Status (RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*)>::operator()(RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:591
+  [11] RiaGrpcServerImpl::processAllQueuedRequests() at ResInsight/GrpcInterface/RiaGrpcServer.cpp:197
+  [12] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:115
+  [13] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:33
+  [14]  at :0
+  [15] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [16] QObject::event(QEvent*) at :0
+  [17] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [18] QTimerInfoList::activateTimers() at :0
+  [19]  at :0
+  [20] g_main_context_dispatch at :0
+  [21] g_main_context_iterate.isra.20 at :0
+  [22] g_main_context_iteration at :0
+  [23] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [24] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [25] QCoreApplication::exec() at :0
+  [26] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [27] __libc_start_main at :0
+  [28] _start at :0
+  [29]  at :0
+"
+2026-06-04T09:05:13.542Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] QArrayDataPointer<char16_t>::QArrayDataPointer(QArrayDataPointer<char16_t> const&) at /private/f_resinsight_build/resbuild/qt/6.6.3/gcc_64/include/QtCore/qarraydatapointer.h:38
+  [4] RimStimPlanModelCalculator::calculateFormation() const at ResInsight/ApplicationLibCode/ProjectDataModel/StimPlanModel/RimStimPlanModelCalculator.cpp:740
+  [5] RifStimPlanModelGeologicalFrkExporter::writeToFile(RimStimPlanModel*, bool, QString const&) at ResInsight/ApplicationLibCode/FileInterface/RifStimPlanModelGeologicalFrkExporter.cpp:149
+  [6] RifStimPlanModelExporter::writeToDirectory(RimStimPlanModel*, bool, QString const&) at ResInsight/ApplicationLibCode/FileInterface/RifStimPlanModelExporter.cpp:33
+  [7] RimcStimPlanModel_exportToFile::execute() at ResInsight/ApplicationLibCode/ProjectDataModelCommands/RimcStimPlanModel.cpp:47
+  [8] RiaGrpcPdmObjectService::CallPdmObjectMethod(grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*) at ResInsight/GrpcInterface/RiaGrpcPdmObjectService.cpp:578
+  [9] grpc::Status std::__invoke_impl<grpc::Status, grpc::Status (RiaGrpcPdmObjectService::*&)(grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*), RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*>(std::__invoke_memfun_ref, grpc::Status (RiaGrpcPdmObjectService::*&)(grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*), RiaGrpcPdmObjectService&, grpc::ServerContext*&&, rips::PdmObjectMethodRequest const*&&, rips::PdmObject*&&) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/invoke.h:67
+  [10] std::function<grpc::Status (RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*)>::operator()(RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:591
+  [11] RiaGrpcServerImpl::processAllQueuedRequests() at ResInsight/GrpcInterface/RiaGrpcServer.cpp:197
+  [12] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:115
+  [13] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:33
+  [14]  at :0
+  [15] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [16] QObject::event(QEvent*) at :0
+  [17] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [18] QTimerInfoList::activateTimers() at :0
+  [19]  at :0
+  [20] g_main_context_dispatch at :0
+  [21] g_main_context_iterate.isra.20 at :0
+  [22] g_main_context_iteration at :0
+  [23] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [24] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [25] QCoreApplication::exec() at :0
+  [26] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [27] __libc_start_main at :0
+  [28] _start at :0
+  [29]  at :0
+"
+2026-06-04T07:16:01.097Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] QArrayDataPointer<char16_t>::QArrayDataPointer(QArrayDataPointer<char16_t> const&) at /private/f_resinsight_build/resbuild/qt/6.6.3/gcc_64/include/QtCore/qarraydatapointer.h:38
+  [4] RimStimPlanModelCalculator::calculateFormation() const at ResInsight/ApplicationLibCode/ProjectDataModel/StimPlanModel/RimStimPlanModelCalculator.cpp:740
+  [5] RifStimPlanModelGeologicalFrkExporter::writeToFile(RimStimPlanModel*, bool, QString const&) at ResInsight/ApplicationLibCode/FileInterface/RifStimPlanModelGeologicalFrkExporter.cpp:149
+  [6] RifStimPlanModelExporter::writeToDirectory(RimStimPlanModel*, bool, QString const&) at ResInsight/ApplicationLibCode/FileInterface/RifStimPlanModelExporter.cpp:33
+  [7] RimcStimPlanModel_exportToFile::execute() at ResInsight/ApplicationLibCode/ProjectDataModelCommands/RimcStimPlanModel.cpp:47
+  [8] RiaGrpcPdmObjectService::CallPdmObjectMethod(grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*) at ResInsight/GrpcInterface/RiaGrpcPdmObjectService.cpp:578
+  [9] grpc::Status std::__invoke_impl<grpc::Status, grpc::Status (RiaGrpcPdmObjectService::*&)(grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*), RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*>(std::__invoke_memfun_ref, grpc::Status (RiaGrpcPdmObjectService::*&)(grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*), RiaGrpcPdmObjectService&, grpc::ServerContext*&&, rips::PdmObjectMethodRequest const*&&, rips::PdmObject*&&) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/invoke.h:67
+  [10] std::function<grpc::Status (RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*)>::operator()(RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::PdmObjectMethodRequest const*, rips::PdmObject*) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:591
+  [11] RiaGrpcServerImpl::processAllQueuedRequests() at ResInsight/GrpcInterface/RiaGrpcServer.cpp:197
+  [12] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:115
+  [13] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:33
+  [14]  at :0
+  [15] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [16] QObject::event(QEvent*) at :0
+  [17] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [18] QTimerInfoList::activateTimers() at :0
+  [19]  at :0
+  [20] g_main_context_dispatch at :0
+  [21] g_main_context_iterate.isra.20 at :0
+  [22] g_main_context_iteration at :0
+  [23] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [24] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [25] QCoreApplication::exec() at :0
+  [26] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [27] __libc_start_main at :0
+  [28] _start at :0
+  [29]  at :0
+"
+2026-06-03T20:29:37.764Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] std::terminate() at :0
+  [10] __cxa_rethrow at :0
+  [11] main at ResInsight/ApplicationExeCode/RiaMain.cpp:232
+  [12] __libc_start_main at :0
+  [13] _start at :0
+  [14]  at :0
+"
+2026-06-03T20:20:41.003Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] std::terminate() at :0
+  [10] __cxa_rethrow at :0
+  [11] main at ResInsight/ApplicationExeCode/RiaMain.cpp:232
+  [12] __libc_start_main at :0
+  [13] _start at :0
+  [14]  at :0
+"
+2026-06-03T15:59:29.719Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
+  [6] cvf::StructGridInterface::oppositeFace(cvf::StructGridInterface::FaceType) at ResInsight/Fwk/AppFwk/CommonCode/cvfStructGrid.cpp:199
+  [7] RigCombMultResultAccessor::cellFaceScalar(unsigned long, cvf::StructGridInterface::FaceType) const at ResInsight/ApplicationLibCode/ReservoirDataModel/ResultAccessors/RigCombMultResultAccessor.cpp:77
+  [8] RiuResultTextBuilder::cellResultTextAndValueText(RimEclipseResultDefinition*) at ResInsight/ApplicationLibCode/UserInterface/RiuResultTextBuilder.cpp:1106
+  [9] RiuResultTextBuilder::cellResultText(std::vector<RimEclipseResultDefinition*, std::allocator<RimEclipseResultDefinition*> > const&, bool) at ResInsight/ApplicationLibCode/UserInterface/RiuResultTextBuilder.cpp:998
+  [10] RiuResultTextBuilder::gridResultText() at ResInsight/ApplicationLibCode/UserInterface/RiuResultTextBuilder.cpp:490
+  [11] RiuResultTextBuilder::resultTextFromLinkedViews() const at ResInsight/ApplicationLibCode/UserInterface/RiuResultTextBuilder.cpp:829
+  [12] RiuResultTextBuilder::gridResultDetails() at ResInsight/ApplicationLibCode/UserInterface/RiuResultTextBuilder.cpp:377
+  [13] RiuResultTextBuilder::mainResultText() at ResInsight/ApplicationLibCode/UserInterface/RiuResultTextBuilder.cpp:189
+  [14] RiuSelectionChangedHandler::updateResultInfo(RiuSelectionItem const*) const at ResInsight/ApplicationLibCode/UserInterface/RiuSelectionChangedHandler.cpp:389
+  [15] RiuSelectionChangedHandler::handleItemAppended(RiuSelectionItem const*) const at ResInsight/ApplicationLibCode/UserInterface/RiuSelectionChangedHandler.cpp:132
+  [16] RiuCellAndNncPickEventHandler::handle3dPickEvent(Ric3dPickEvent const&) at ResInsight/ApplicationLibCode/UserInterface/RiuCellAndNncPickEventHandler.cpp:459
+  [17] RiuViewerCommands::handlePickAction(int, int, QFlags<Qt::KeyboardModifier>) at ResInsight/ApplicationLibCode/UserInterface/RiuViewerCommands.cpp:702
+  [18] QWidget::event(QEvent*) at :0
+  [19] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [20] QApplication::notify(QObject*, QEvent*) at :0
+  [21] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [22] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [23] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [24]  at :0
+  [25]  at :0
+  [26] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [27] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [28] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [29] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [30] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [31]  at :0
+  [32] g_main_context_dispatch at :0
+  [33] g_main_context_iterate.isra.20 at :0
+  [34] g_main_context_iteration at :0
+  [35] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [36] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [37] QCoreApplication::exec() at :0
+  [38] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [39] __libc_start_main at :0
+  [40] _start at :0
+  [41]  at :0
+"
+2026-06-03T15:55:39.169Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
+  [6] cvf::StructGridInterface::oppositeFace(cvf::StructGridInterface::FaceType) at ResInsight/Fwk/AppFwk/CommonCode/cvfStructGrid.cpp:199
+  [7] RigCombMultResultAccessor::cellFaceScalar(unsigned long, cvf::StructGridInterface::FaceType) const at ResInsight/ApplicationLibCode/ReservoirDataModel/ResultAccessors/RigCombMultResultAccessor.cpp:77
+  [8] RiuResultTextBuilder::cellResultTextAndValueText(RimEclipseResultDefinition*) at ResInsight/ApplicationLibCode/UserInterface/RiuResultTextBuilder.cpp:1106
+  [9] RiuResultTextBuilder::cellResultText(std::vector<RimEclipseResultDefinition*, std::allocator<RimEclipseResultDefinition*> > const&, bool) at ResInsight/ApplicationLibCode/UserInterface/RiuResultTextBuilder.cpp:998
+  [10] RiuResultTextBuilder::gridResultText() at ResInsight/ApplicationLibCode/UserInterface/RiuResultTextBuilder.cpp:490
+  [11] RiuResultTextBuilder::resultTextFromLinkedViews() const at ResInsight/ApplicationLibCode/UserInterface/RiuResultTextBuilder.cpp:829
+  [12] RiuResultTextBuilder::gridResultDetails() at ResInsight/ApplicationLibCode/UserInterface/RiuResultTextBuilder.cpp:377
+  [13] RiuResultTextBuilder::mainResultText() at ResInsight/ApplicationLibCode/UserInterface/RiuResultTextBuilder.cpp:189
+  [14] RiuSelectionChangedHandler::updateResultInfo(RiuSelectionItem const*) const at ResInsight/ApplicationLibCode/UserInterface/RiuSelectionChangedHandler.cpp:389
+  [15] RiuSelectionChangedHandler::handleItemAppended(RiuSelectionItem const*) const at ResInsight/ApplicationLibCode/UserInterface/RiuSelectionChangedHandler.cpp:132
+  [16] RiuCellAndNncPickEventHandler::handle3dPickEvent(Ric3dPickEvent const&) at ResInsight/ApplicationLibCode/UserInterface/RiuCellAndNncPickEventHandler.cpp:459
+  [17] RiuViewerCommands::handlePickAction(int, int, QFlags<Qt::KeyboardModifier>) at ResInsight/ApplicationLibCode/UserInterface/RiuViewerCommands.cpp:702
+  [18] QWidget::event(QEvent*) at :0
+  [19] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [20] QApplication::notify(QObject*, QEvent*) at :0
+  [21] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [22] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [23] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [24]  at :0
+  [25]  at :0
+  [26] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [27] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [28] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [29] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [30] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [31]  at :0
+  [32] g_main_context_dispatch at :0
+  [33] g_main_context_iterate.isra.20 at :0
+  [34] g_main_context_iteration at :0
+  [35] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [36] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [37] RiaOpenTelemetryManager::reportCrash(int, std::basic_stacktrace<std::allocator<std::stacktrace_entry> > const&, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > const&) at ResInsight/ApplicationLibCode/Application/Tools/Telemetry/RiaOpenTelemetryManager.cpp:415
+  [38] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:174
+  [39] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [40]  at :0
+  [41] __GI_raise at :0
+  [42] __GI_abort at :0
+  [43] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
+  [44] cvf::StructGridInterface::oppositeFace(cvf::StructGridInterface::FaceType) at ResInsight/Fwk/AppFwk/CommonCode/cvfStructGrid.cpp:199
+  [45] RigCombMultResultAccessor::cellFaceScalar(unsigned long, cvf::StructGridInterface::FaceType) const at ResInsight/ApplicationLibCode/ReservoirDataModel/ResultAccessors/RigCombMultResultAccessor.cpp:77
+  [46] RiuResultTextBuilder::cellResultTextAndValueText(RimEclipseResultDefinition*) at ResInsight/ApplicationLibCode/UserInterface/RiuResultTextBuilder.cpp:1106
+  [47] RiuResultTextBuilder::cellResultText(std::vector<RimEclipseResultDefinition*, std::allocator<RimEclipseResultDefinition*> > const&, bool) at ResInsight/ApplicationLibCode/UserInterface/RiuResultTextBuilder.cpp:998
+  [48] RiuResultTextBuilder::gridResultText() at ResInsight/ApplicationLibCode/UserInterface/RiuResultTextBuilder.cpp:490
+  [49] RiuResultTextBuilder::resultTextFromLinkedViews() const at ResInsight/ApplicationLibCode/UserInterface/RiuResultTextBuilder.cpp:829
+  [50] RiuResultTextBuilder::gridResultDetails() at ResInsight/ApplicationLibCode/UserInterface/RiuResultTextBuilder.cpp:377
+  [51] RiuResultTextBuilder::mainResultText() at ResInsight/ApplicationLibCode/UserInterface/RiuResultTextBuilder.cpp:189
+  [52] RiuSelectionChangedHandler::updateResultInfo(RiuSelectionItem const*) const at ResInsight/ApplicationLibCode/UserInterface/RiuSelectionChangedHandler.cpp:389
+  [53] RiuSelectionChangedHandler::handleItemAppended(RiuSelectionItem const*) const at ResInsight/ApplicationLibCode/UserInterface/RiuSelectionChangedHandler.cpp:132
+  [54] RiuCellAndNncPickEventHandler::handle3dPickEvent(Ric3dPickEvent const&) at ResInsight/ApplicationLibCode/UserInterface/RiuCellAndNncPickEventHandler.cpp:459
+  [55] RiuViewerCommands::handlePickAction(int, int, QFlags<Qt::KeyboardModifier>) at ResInsight/ApplicationLibCode/UserInterface/RiuViewerCommands.cpp:702
+  [56] QWidget::event(QEvent*) at :0
+  [57] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [58] QApplication::notify(QObject*, QEvent*) at :0
+  [59] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [60] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [61] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [62]  at :0
+  [63]  at :0
+  [64] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [65] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [66] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [67] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [68] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [69]  at :0
+  [70] g_main_context_dispatch at :0
+  [71] g_main_context_iterate.isra.20 at :0
+  [72] g_main_context_iteration at :0
+  [73] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [74] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [75] QCoreApplication::exec() at :0
+  [76] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [77] __libc_start_main at :0
+  [78] _start at :0
+  [79]  at :0
+"
+2026-06-03T15:55:39.121Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
+  [6] cvf::StructGridInterface::oppositeFace(cvf::StructGridInterface::FaceType) at ResInsight/Fwk/AppFwk/CommonCode/cvfStructGrid.cpp:199
+  [7] RigCombMultResultAccessor::cellFaceScalar(unsigned long, cvf::StructGridInterface::FaceType) const at ResInsight/ApplicationLibCode/ReservoirDataModel/ResultAccessors/RigCombMultResultAccessor.cpp:77
+  [8] RiuResultTextBuilder::cellResultTextAndValueText(RimEclipseResultDefinition*) at ResInsight/ApplicationLibCode/UserInterface/RiuResultTextBuilder.cpp:1106
+  [9] RiuResultTextBuilder::cellResultText(std::vector<RimEclipseResultDefinition*, std::allocator<RimEclipseResultDefinition*> > const&, bool) at ResInsight/ApplicationLibCode/UserInterface/RiuResultTextBuilder.cpp:998
+  [10] RiuResultTextBuilder::gridResultText() at ResInsight/ApplicationLibCode/UserInterface/RiuResultTextBuilder.cpp:490
+  [11] RiuResultTextBuilder::resultTextFromLinkedViews() const at ResInsight/ApplicationLibCode/UserInterface/RiuResultTextBuilder.cpp:829
+  [12] RiuResultTextBuilder::gridResultDetails() at ResInsight/ApplicationLibCode/UserInterface/RiuResultTextBuilder.cpp:377
+  [13] RiuResultTextBuilder::mainResultText() at ResInsight/ApplicationLibCode/UserInterface/RiuResultTextBuilder.cpp:189
+  [14] RiuSelectionChangedHandler::updateResultInfo(RiuSelectionItem const*) const at ResInsight/ApplicationLibCode/UserInterface/RiuSelectionChangedHandler.cpp:389
+  [15] RiuSelectionChangedHandler::handleItemAppended(RiuSelectionItem const*) const at ResInsight/ApplicationLibCode/UserInterface/RiuSelectionChangedHandler.cpp:132
+  [16] RiuCellAndNncPickEventHandler::handle3dPickEvent(Ric3dPickEvent const&) at ResInsight/ApplicationLibCode/UserInterface/RiuCellAndNncPickEventHandler.cpp:459
+  [17] RiuViewerCommands::handlePickAction(int, int, QFlags<Qt::KeyboardModifier>) at ResInsight/ApplicationLibCode/UserInterface/RiuViewerCommands.cpp:702
+  [18] QWidget::event(QEvent*) at :0
+  [19] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [20] QApplication::notify(QObject*, QEvent*) at :0
+  [21] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [22] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [23] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [24]  at :0
+  [25]  at :0
+  [26] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [27] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [28] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [29] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [30] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [31]  at :0
+  [32] g_main_context_dispatch at :0
+  [33] g_main_context_iterate.isra.20 at :0
+  [34] g_main_context_iteration at :0
+  [35] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [36] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [37] QCoreApplication::exec() at :0
+  [38] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [39] __libc_start_main at :0
+  [40] _start at :0
+  [41]  at :0
+"
+2026-06-03T14:03:14.26Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] QWidgetPrivate::shouldPaintOnScreen() const at :0
+  [4] QWidgetRepaintManager::markNeedsFlush(QWidget*, QRegion const&, QPoint const&) at :0
+  [5] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [6] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [7] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [8] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [9] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [10] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [11] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [12] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [13] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [14] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [15] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [16] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [17] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [18] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [19] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [20] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [21] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [22] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [23] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [24] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [25] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [26] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [27] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [28] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [29] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [30] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [31] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [32] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [33] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [34] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [35] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [36] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [37] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [38] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [39] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [40] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [41] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [42] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [43] QWidgetRepaintManager::paintAndFlush() at :0
+  [44] QWidget::event(QEvent*) at :0
+  [45] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [46] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [47] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [48] QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*) at :0
+  [49]  at :0
+  [50] g_main_context_dispatch at :0
+  [51] g_main_context_iterate.isra.20 at :0
+  [52] g_main_context_iteration at :0
+  [53] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [54] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [55] QCoreApplication::exec() at :0
+  [56] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [57] __libc_start_main at :0
+  [58] _start at :0
+  [59]  at :0
+"
+2026-06-03T13:27:53.25Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] caf::PdmUiObjectHandle::uiOrdering(QString const&, caf::PdmUiOrdering&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiObjectHandle.cpp:40
+  [4] RimContourMapProjection::defineUiOrdering(QString, caf::PdmUiOrdering&) at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimContourMapProjection.cpp:616
+  [5] RimEclipseContourMapProjection::defineUiOrdering(QString, caf::PdmUiOrdering&) at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapProjection.cpp:333
+  [6] caf::PdmUiObjectHandle::uiOrdering(QString const&, caf::PdmUiOrdering&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiObjectHandle.cpp:40
+  [7] caf::PdmUiFormLayoutObjectEditor::configureAndUpdateUi(QString const&) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiFormLayoutObjectEditor.cpp:670
+  [8] caf::PdmUiEditorHandle::updateUi(QString const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiEditorHandle.cpp:66
+  [9] caf::PdmUiPropertyView::showProperties(caf::PdmObjectHandle*) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiPropertyView.cpp:213
+  [10] RiuMainWindow::selectedObjectsChanged() at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:1530
+  [11]  at :0
+  [12] caf::PdmUiTreeView::slotOnSelectionChanged() at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeView.cpp:154
+  [13]  at :0
+  [14]  at :0
+  [15] QItemSelectionModel::selectionChanged(QItemSelection const&, QItemSelection const&) at :0
+  [16] QItemSelectionModel::emitSelectionChanged(QItemSelection const&, QItemSelection const&) at :0
+  [17] QItemSelectionModel::select(QItemSelection const&, QFlags<QItemSelectionModel::SelectionFlag>) at :0
+  [18] QTreeViewPrivate::select(QModelIndex const&, QModelIndex const&, QFlags<QItemSelectionModel::SelectionFlag>) at :0
+  [19] QTreeView::setSelection(QRect const&, QFlags<QItemSelectionModel::SelectionFlag>) at :0
+  [20] QAbstractItemView::mousePressEvent(QMouseEvent*) at :0
+  [21] QWidget::event(QEvent*) at :0
+  [22] QFrame::event(QEvent*) at :0
+  [23] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [24] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [25] QApplication::notify(QObject*, QEvent*) at :0
+  [26] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [27] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [28] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [29]  at :0
+  [30]  at :0
+  [31] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [32] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [33] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [34] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [35] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [36]  at :0
+  [37] g_main_context_dispatch at :0
+  [38] g_main_context_iterate.isra.20 at :0
+  [39] g_main_context_iteration at :0
+  [40] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [41] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [42] QCoreApplication::exec() at :0
+  [43] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [44] __libc_start_main at :0
+  [45] _start at :0
+  [46]  at :0
+"
+2026-06-03T13:27:47.881Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] RiaSummaryCurveDefinition::summaryAddressY() const at ResInsight/ApplicationLibCode/Application/Tools/Summary/RiaSummaryCurveDefinition.cpp:114
+  [4] RimCorrelationPlotCollection::applyFirstEnsembleFieldAddressesToReport(RimCorrelationReportPlot*, std::vector<QString, std::allocator<QString> > const&, QString const&) at ResInsight/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationPlotCollection.cpp:325
+  [5] RimCorrelationPlotCollection::createCorrelationReportPlot(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationPlotCollection.cpp:153
+  [6] RicNewCorrelationReportPlotFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/CorrelationPlotCommands/RicNewCorrelationReportPlotFeature.cpp:78
+  [7] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+  [8]  at :0
+  [9] QAction::triggered(bool) at :0
+  [10] QAction::activate(QAction::ActionEvent) at :0
+  [11]  at :0
+  [12]  at :0
+  [13] QWidget::event(QEvent*) at :0
+  [14] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [15] QApplication::notify(QObject*, QEvent*) at :0
+  [16] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [17] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [18] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [19]  at :0
+  [20]  at :0
+  [21] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [22] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [23] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [24] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [25] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [26]  at :0
+  [27] g_main_context_dispatch at :0
+  [28] g_main_context_iterate.isra.20 at :0
+  [29] g_main_context_iteration at :0
+  [30] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [31] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [32]  at :0
+  [33] QMenu::exec(QPoint const&, QAction*) at :0
+  [34] RiuPlotMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp:1058
+  [35]  at :0
+  [36] QWidget::customContextMenuRequested(QPoint const&) at :0
+  [37] QWidget::event(QEvent*) at :0
+  [38] QFrame::event(QEvent*) at :0
+  [39] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [40] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [41] QApplication::notify(QObject*, QEvent*) at :0
+  [42] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [43] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [44]  at :0
+  [45]  at :0
+  [46] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [47] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [48] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [49] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [50] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [51]  at :0
+  [52] g_main_context_dispatch at :0
+  [53] g_main_context_iterate.isra.20 at :0
+  [54] g_main_context_iteration at :0
+  [55] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [56] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [57] QCoreApplication::exec() at :0
+  [58] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [59] __libc_start_main at :0
+  [60] _start at :0
+  [61]  at :0
+"
+2026-06-03T12:54:09.158Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] ecl_kw_get_data_type at ResInsight/ThirdParty/Ert/lib/ecl/ecl_kw.cpp:1776
+  [4] ecl_file_kw_assert_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_kw.cpp:211
+  [5] ecl_file_kw_load_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_kw.cpp:244
+  [6] ecl_file_view_get_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_view.cpp:149
+  [7] RifEclipseOutputFileTools::keywordData(ecl_file_struct const*, QString const&, unsigned long, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseOutputFileTools.cpp:305
+  [8] RifEclipseUnifiedRestartFileAccess::results(QString const&, unsigned long, unsigned long, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseUnifiedRestartFileAccess.cpp:248
+  [9] RifReaderEclipseOutput::dynamicResult(QString const&, RiaDefines::PorosityModelType, unsigned long, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp:1070
+  [10] RigCaseCellResultsData::findOrLoadKnownScalarResult(RigEclipseResultAddress const&) at ResInsight/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp:1538
+  [11] RigCaseCellResultsData::ensureKnownResultLoaded(RigEclipseResultAddress const&) at ResInsight/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp:1264
+  [12] RimEclipseResultDefinition::loadResult() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:1134
+  [13] RimEclipseCellColors::loadResult() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCellColors.cpp:260
+  [14] RimEclipseResultDefinition::loadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:533
+  [15] RimEclipseResultDefinition::fieldChangedByUi(caf::PdmFieldHandle const*, QVariant const&, QVariant const&) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:305
+  [16] RimEclipseCellColors::fieldChangedByUi(caf::PdmFieldHandle const*, QVariant const&, QVariant const&) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCellColors.cpp:90
+  [17] caf::PdmUiFieldHandle::notifyFieldChanged(QVariant const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiFieldHandle.cpp:74
+  [18] caf::PdmFieldUiCap<caf::PdmField<QString> >::setValueFromUiEditor(QVariant const&, bool) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafInternalPdmUiFieldCapability.inl:110
+  [19] caf::PdmUiCommandSystemProxy::setUiValueToField(caf::PdmUiFieldHandle*, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiCommandSystemProxy.cpp:122
+  [20] caf::PdmUiTreeSelectionQModel::setData(QModelIndex const&, QVariant const&, int) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionQModel.cpp:482
+  [21] QSortFilterProxyModel::setData(QModelIndex const&, QVariant const&, int) at :0
+  [22] caf::PdmUiTreeSelectionEditor::currentChanged(QModelIndex const&) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionEditor.cpp:812
+  [23] caf::PdmUiTreeSelectionEditor::slotClicked(QModelIndex const&) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionEditor.cpp:759
+  [24]  at :0
+  [25] QAbstractItemView::clicked(QModelIndex const&) at :0
+  [26] QAbstractItemView::mouseReleaseEvent(QMouseEvent*) at :0
+  [27] QWidget::event(QEvent*) at :0
+  [28] QFrame::event(QEvent*) at :0
+  [29] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [30] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [31] QApplication::notify(QObject*, QEvent*) at :0
+  [32] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [33] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [34] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [35]  at :0
+  [36]  at :0
+  [37] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [38] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [39] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [40] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [41] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [42]  at :0
+  [43] g_main_context_dispatch at :0
+  [44] g_main_context_iterate.isra.20 at :0
+  [45] g_main_context_iteration at :0
+  [46] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [47] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [48] QCoreApplication::exec() at :0
+  [49] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [50] __libc_start_main at :0
+  [51] _start at :0
+  [52]  at :0
+"
+2026-06-03T10:30:00.652Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] QApplication::notify(QObject*, QEvent*) at :0
+  [4] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [5] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [6] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [7]  at :0
+  [8]  at :0
+  [9] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [10] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [11] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [12] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [13] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [14]  at :0
+  [15] g_main_context_dispatch at :0
+  [16] g_main_context_iterate.isra.20 at :0
+  [17] g_main_context_iteration at :0
+  [18] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [19] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [20] QCoreApplication::exec() at :0
+  [21] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [22] __libc_start_main at :0
+  [23] _start at :0
+  [24]  at :0
+"
+2026-06-03T08:42:17.326Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] std::terminate() at :0
+  [10] __cxa_rethrow at :0
+  [11] main at ResInsight/ApplicationExeCode/RiaMain.cpp:232
+  [12] __libc_start_main at :0
+  [13] _start at :0
+  [14]  at :0
+"
+2026-06-03T08:35:42.812Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] caf::PdmUiObjectHandle::uiOrdering(QString const&, caf::PdmUiOrdering&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiObjectHandle.cpp:40
+  [4] RimContourMapProjection::defineUiOrdering(QString, caf::PdmUiOrdering&) at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimContourMapProjection.cpp:616
+  [5] RimEclipseContourMapProjection::defineUiOrdering(QString, caf::PdmUiOrdering&) at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapProjection.cpp:333
+  [6] caf::PdmUiObjectHandle::uiOrdering(QString const&, caf::PdmUiOrdering&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiObjectHandle.cpp:40
+  [7] caf::PdmUiFormLayoutObjectEditor::configureAndUpdateUi(QString const&) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiFormLayoutObjectEditor.cpp:670
+  [8] caf::PdmUiEditorHandle::updateUi(QString const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiEditorHandle.cpp:66
+  [9] caf::PdmUiPropertyView::showProperties(caf::PdmObjectHandle*) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiPropertyView.cpp:213
+  [10] RiuMainWindow::selectedObjectsChanged() at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:1530
+  [11]  at :0
+  [12] caf::PdmUiTreeView::slotOnSelectionChanged() at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeView.cpp:154
+  [13]  at :0
+  [14]  at :0
+  [15] QItemSelectionModel::selectionChanged(QItemSelection const&, QItemSelection const&) at :0
+  [16] QItemSelectionModel::emitSelectionChanged(QItemSelection const&, QItemSelection const&) at :0
+  [17] QItemSelectionModel::select(QItemSelection const&, QFlags<QItemSelectionModel::SelectionFlag>) at :0
+  [18] QTreeViewPrivate::select(QModelIndex const&, QModelIndex const&, QFlags<QItemSelectionModel::SelectionFlag>) at :0
+  [19] QTreeView::setSelection(QRect const&, QFlags<QItemSelectionModel::SelectionFlag>) at :0
+  [20] QAbstractItemView::mousePressEvent(QMouseEvent*) at :0
+  [21] QWidget::event(QEvent*) at :0
+  [22] QFrame::event(QEvent*) at :0
+  [23] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [24] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [25] QApplication::notify(QObject*, QEvent*) at :0
+  [26] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [27] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [28] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [29]  at :0
+  [30]  at :0
+  [31] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [32] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [33] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [34] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [35] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [36]  at :0
+  [37] g_main_context_dispatch at :0
+  [38] g_main_context_iterate.isra.20 at :0
+  [39] g_main_context_iteration at :0
+  [40] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [41] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [42] QCoreApplication::exec() at :0
+  [43] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [44] __libc_start_main at :0
+  [45] _start at :0
+  [46]  at :0
+"
+2026-06-03T08:16:59.498Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] caf::PdmUiObjectHandle::uiOrdering(QString const&, caf::PdmUiOrdering&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiObjectHandle.cpp:40
+  [4] RimContourMapProjection::defineUiOrdering(QString, caf::PdmUiOrdering&) at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimContourMapProjection.cpp:616
+  [5] RimEclipseContourMapProjection::defineUiOrdering(QString, caf::PdmUiOrdering&) at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapProjection.cpp:333
+  [6] caf::PdmUiObjectHandle::uiOrdering(QString const&, caf::PdmUiOrdering&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiObjectHandle.cpp:40
+  [7] caf::PdmUiFormLayoutObjectEditor::configureAndUpdateUi(QString const&) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiFormLayoutObjectEditor.cpp:670
+  [8] caf::PdmUiEditorHandle::updateUi(QString const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiEditorHandle.cpp:66
+  [9] caf::PdmUiPropertyView::showProperties(caf::PdmObjectHandle*) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiPropertyView.cpp:213
+  [10] RiuMainWindow::selectedObjectsChanged() at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:1530
+  [11]  at :0
+  [12] caf::PdmUiTreeView::slotOnSelectionChanged() at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeView.cpp:154
+  [13]  at :0
+  [14]  at :0
+  [15] QItemSelectionModel::selectionChanged(QItemSelection const&, QItemSelection const&) at :0
+  [16] QItemSelectionModel::emitSelectionChanged(QItemSelection const&, QItemSelection const&) at :0
+  [17] QItemSelectionModel::select(QItemSelection const&, QFlags<QItemSelectionModel::SelectionFlag>) at :0
+  [18] QTreeViewPrivate::select(QModelIndex const&, QModelIndex const&, QFlags<QItemSelectionModel::SelectionFlag>) at :0
+  [19] QTreeView::setSelection(QRect const&, QFlags<QItemSelectionModel::SelectionFlag>) at :0
+  [20] QAbstractItemView::mousePressEvent(QMouseEvent*) at :0
+  [21] QWidget::event(QEvent*) at :0
+  [22] QFrame::event(QEvent*) at :0
+  [23] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [24] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [25] QApplication::notify(QObject*, QEvent*) at :0
+  [26] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [27] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [28] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [29]  at :0
+  [30]  at :0
+  [31] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [32] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [33] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [34] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [35] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [36]  at :0
+  [37] g_main_context_dispatch at :0
+  [38] g_main_context_iterate.isra.20 at :0
+  [39] g_main_context_iteration at :0
+  [40] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [41] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [42] QCoreApplication::exec() at :0
+  [43] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [44] __libc_start_main at :0
+  [45] _start at :0
+  [46]  at :0
+"
+2026-06-03T07:43:44.046Z,2026.02.3-dev.01,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:167
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:263
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
+  [6] RicWellPathExportMswTableData::generateCellSegments(RimEclipseCase const*, RimWellPath const*) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswTableData.cpp:702
+  [7] RicWellPathExportMswTableData::extractSingleWellMsw_Legacy[abi:cxx11](RimEclipseCase*, RimWellPath*, bool, RicWellPathExportMswTableData::CompletionType, std::optional<QDateTime> const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswTableData.cpp:136
+  [8] RicWellPathExportMswTableData::extractSingleWellMswData[abi:cxx11](RimEclipseCase*, RimWellPath*, bool, RicWellPathExportMswTableData::CompletionType, std::optional<QDateTime> const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswTableData.cpp:80
+  [9] internal::exportSplitMswData(RicExportCompletionDataSettingsUi const&, QString const&, std::vector<RimWellPath*, std::allocator<RimWellPath*> > const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswCompletionsImpl.cpp:151
+  [10] RicWellPathExportCompletionDataFeature::prepareExportSettingsAndExportCompletions(QString const&, std::vector<RimWellPath*, std::allocator<RimWellPath*> > const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportCompletionDataFeature.cpp:178
+  [11] RicExportCompletionsForVisibleWellPathsFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportCompletionsForVisibleWellPathsFeature.cpp:75
+  [12] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+  [13]  at :0
+  [14] QAction::triggered(bool) at :0
+  [15] QAction::activate(QAction::ActionEvent) at :0
+  [16]  at :0
+  [17]  at :0
+  [18] QWidget::event(QEvent*) at :0
+  [19] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [20] QApplication::notify(QObject*, QEvent*) at :0
+  [21] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1825
+  [22] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [23] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [24]  at :0
+  [25]  at :0
+  [26] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [27] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1825
+  [28] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [29] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [30] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [31]  at :0
+  [32] g_main_context_dispatch at :0
+  [33] g_main_context_iterate.isra.20 at :0
+  [34] g_main_context_iteration at :0
+  [35] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [36] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [37]  at :0
+  [38] QMenu::exec(QPoint const&, QAction*) at :0
+  [39] RiuMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:2092
+  [40]  at :0
+  [41] QWidget::customContextMenuRequested(QPoint const&) at :0
+  [42] QWidget::event(QEvent*) at :0
+  [43] QFrame::event(QEvent*) at :0
+  [44] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [45] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [46] QApplication::notify(QObject*, QEvent*) at :0
+  [47] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1825
+  [48] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [49]  at :0
+  [50]  at :0
+  [51] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [52] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1825
+  [53] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [54] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [55] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [56]  at :0
+  [57] g_main_context_dispatch at :0
+  [58] g_main_context_iterate.isra.20 at :0
+  [59] g_main_context_iteration at :0
+  [60] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [61] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [62] QCoreApplication::exec() at :0
+  [63] main at ResInsight/ApplicationExeCode/RiaMain.cpp:229
+  [64] __libc_start_main at :0
+  [65] _start at :0
+  [66]  at :0
+"
+2026-06-03T07:43:10.109Z,2026.02.3-dev.01,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:167
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:263
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
+  [6] RicWellPathExportMswTableData::generateCellSegments(RimEclipseCase const*, RimWellPath const*) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswTableData.cpp:702
+  [7] RicWellPathExportMswTableData::extractSingleWellMsw_Legacy[abi:cxx11](RimEclipseCase*, RimWellPath*, bool, RicWellPathExportMswTableData::CompletionType, std::optional<QDateTime> const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswTableData.cpp:136
+  [8] RicWellPathExportMswTableData::extractSingleWellMswData[abi:cxx11](RimEclipseCase*, RimWellPath*, bool, RicWellPathExportMswTableData::CompletionType, std::optional<QDateTime> const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswTableData.cpp:80
+  [9] internal::exportSplitMswData(RicExportCompletionDataSettingsUi const&, QString const&, std::vector<RimWellPath*, std::allocator<RimWellPath*> > const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswCompletionsImpl.cpp:151
+  [10] RicWellPathExportCompletionDataFeature::prepareExportSettingsAndExportCompletions(QString const&, std::vector<RimWellPath*, std::allocator<RimWellPath*> > const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportCompletionDataFeature.cpp:178
+  [11] RicExportCompletionsForVisibleWellPathsFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportCompletionsForVisibleWellPathsFeature.cpp:75
+  [12] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+  [13]  at :0
+  [14] QAction::triggered(bool) at :0
+  [15] QAction::activate(QAction::ActionEvent) at :0
+  [16]  at :0
+  [17]  at :0
+  [18] QWidget::event(QEvent*) at :0
+  [19] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [20] QApplication::notify(QObject*, QEvent*) at :0
+  [21] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1825
+  [22] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [23] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [24]  at :0
+  [25]  at :0
+  [26] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [27] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1825
+  [28] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [29] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [30] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [31]  at :0
+  [32] g_main_context_dispatch at :0
+  [33] g_main_context_iterate.isra.20 at :0
+  [34] g_main_context_iteration at :0
+  [35] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [36] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [37]  at :0
+  [38] QMenu::exec(QPoint const&, QAction*) at :0
+  [39] RiuMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:2092
+  [40]  at :0
+  [41] QWidget::customContextMenuRequested(QPoint const&) at :0
+  [42] QWidget::event(QEvent*) at :0
+  [43] QFrame::event(QEvent*) at :0
+  [44] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [45] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [46] QApplication::notify(QObject*, QEvent*) at :0
+  [47] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1825
+  [48] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [49]  at :0
+  [50]  at :0
+  [51] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [52] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1825
+  [53] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [54] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [55] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [56]  at :0
+  [57] g_main_context_dispatch at :0
+  [58] g_main_context_iterate.isra.20 at :0
+  [59] g_main_context_iteration at :0
+  [60] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [61] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [62] QCoreApplication::exec() at :0
+  [63] main at ResInsight/ApplicationExeCode/RiaMain.cpp:229
+  [64] __libc_start_main at :0
+  [65] _start at :0
+  [66]  at :0
+"
+2026-06-03T06:22:36.59Z,2026.02.2,"  [0]  at :0
+  [1]  at :0
+  [2]  at :0
+  [3]  at :0
+  [4]  at :0
+  [5]  at :0
+  [6]  at :0
+  [7]  at :0
+  [8]  at :0
+  [9]  at :0
+  [10]  at :0
+  [11]  at :0
+  [12]  at :0
+  [13]  at :0
+  [14]  at :0
+  [15]  at :0
+  [16]  at :0
+  [17]  at :0
+  [18]  at :0
+  [19]  at :0
+  [20]  at :0
+  [21]  at :0
+  [22]  at :0
+  [23]  at :0
+  [24]  at :0
+  [25]  at :0
+  [26]  at :0
+  [27]  at :0
+  [28]  at :0
+  [29]  at :0
+  [30]  at :0
+  [31]  at :0
+  [32]  at :0
+  [33]  at :0
+  [34]  at :0
+  [35]  at :0
+  [36]  at :0
+  [37]  at :0
+  [38]  at :0
+  [39]  at :0
+  [40]  at :0
+  [41]  at :0
+  [42]  at :0
+  [43]  at :0
+  [44]  at :0
+  [45]  at :0
+  [46]  at :0
+  [47]  at :0
+  [48]  at :0
+  [49]  at :0
+  [50]  at :0
+  [51]  at :0
+  [52]  at :0
+  [53]  at :0
+  [54]  at :0
+  [55]  at :0
+  [56]  at :0
+  [57]  at :0
+  [58]  at :0
+  [59]  at :0
+  [60]  at :0
+  [61]  at :0
+  [62]  at :0
+  [63]  at :0
+  [64]  at :0
+  [65]  at :0
+  [66]  at :0
+  [67]  at :0
+  [68]  at :0
+  [69]  at :0
+  [70]  at :0
+  [71]  at :0
+  [72]  at :0
+  [73]  at :0
+  [74]  at :0
+  [75]  at :0
+  [76]  at :0
+  [77]  at :0
+  [78]  at :0
+  [79]  at :0
+  [80]  at :0
+  [81]  at :0
+"
+2026-06-03T06:12:19.342Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] QWidgetPrivate::shouldPaintOnScreen() const at :0
+  [4] QWidgetRepaintManager::markNeedsFlush(QWidget*, QRegion const&, QPoint const&) at :0
+  [5] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [6] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [7] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [8] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [9] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [10] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [11] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [12] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [13] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [14] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [15] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [16] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [17] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [18] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [19] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [20] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [21] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [22] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [23] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [24] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [25] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [26] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [27] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [28] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [29] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [30] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [31] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [32] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [33] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [34] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [35] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [36] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [37] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [38] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [39] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [40] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [41] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [42] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [43] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [44] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [45] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [46] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [47] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [48] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [49] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [50] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [51] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [52] QWidgetRepaintManager::paintAndFlush() at :0
+  [53] QWidget::event(QEvent*) at :0
+  [54] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [55] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [56] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [57] QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*) at :0
+  [58]  at :0
+  [59] g_main_context_dispatch at :0
+  [60] g_main_context_iterate.isra.20 at :0
+  [61] g_main_context_iteration at :0
+  [62] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [63] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [64] QCoreApplication::exec() at :0
+  [65] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [66] __libc_start_main at :0
+  [67] _start at :0
+  [68]  at :0
+"
+2026-06-02T22:18:46.523Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] QEventLoop::exit(int) at :0
+  [4] QMenu::~QMenu() at :0
+  [5] RiuMainWindow::customMenuRequested(QPoint const&) at /private/f_resinsight_build/resbuild/qt/6.6.3/gcc_64/include/QtCore/qstring.h:1169
+  [6]  at :0
+  [7] QWidget::customContextMenuRequested(QPoint const&) at :0
+  [8] QWidget::event(QEvent*) at :0
+  [9] QFrame::event(QEvent*) at :0
+  [10] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [11] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [12] QApplication::notify(QObject*, QEvent*) at :0
+  [13] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [14] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [15]  at :0
+  [16]  at :0
+  [17] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [18] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [19] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [20] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [21] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [22]  at :0
+  [23] g_main_context_dispatch at :0
+  [24] g_main_context_iterate.isra.20 at :0
+  [25] g_main_context_iteration at :0
+  [26] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [27] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [28] QCoreApplication::exec() at :0
+  [29] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [30] __libc_start_main at :0
+  [31] _start at :0
+  [32]  at :0
+"
+2026-06-02T22:18:35.432Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] std::terminate() at :0
+  [10] __cxa_rethrow at :0
+  [11] main at ResInsight/ApplicationExeCode/RiaMain.cpp:232
+  [12] __libc_start_main at :0
+  [13] _start at :0
+  [14]  at :0
+"
+2026-06-02T21:49:45.715Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] std::terminate() at :0
+  [10] __cxa_rethrow at :0
+  [11] main at ResInsight/ApplicationExeCode/RiaMain.cpp:232
+  [12] __libc_start_main at :0
+  [13] _start at :0
+  [14]  at :0
+"
+2026-06-02T20:12:32.867Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] cvf::Vector3<double>::operator=(cvf::Vector3<double> const&) at ResInsight/Fwk/VizFwk/LibCore/cvfVector3.inl:140
+  [4] void std::_Construct<cvf::BoundingBox, cvf::BoundingBox&>(cvf::BoundingBox*, cvf::BoundingBox&) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/stl_construct.h:119
+  [5] __gnu_cxx::__normal_iterator<cvf::BoundingBox*, std::vector<cvf::BoundingBox, std::allocator<cvf::BoundingBox> > > std::vector<cvf::BoundingBox, std::allocator<cvf::BoundingBox> >::insert<__gnu_cxx::__normal_iterator<cvf::BoundingBox*, std::vector<cvf::BoundingBox, std::allocator<cvf::BoundingBox> > >, void>(__gnu_cxx::__normal_iterator<cvf::BoundingBox const*, std::vector<cvf::BoundingBox, std::allocator<cvf::BoundingBox> > >, __gnu_cxx::__normal_iterator<cvf::BoundingBox*, std::vector<cvf::BoundingBox, std::allocator<cvf::BoundingBox> > >, __gnu_cxx::__normal_iterator<cvf::BoundingBox*, std::vector<cvf::BoundingBox, std::allocator<cvf::BoundingBox> > >) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/stl_vector.h:1486
+  [6] GOMP_parallel at :0
+  [7] RigMainGrid::buildCellSearchTree() const at ResInsight/ApplicationLibCode/ReservoirDataModel/RigMainGrid.cpp:894
+  [8] RigMainGrid::doBuildCellSearchTree(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*) const at ResInsight/ApplicationLibCode/ReservoirDataModel/RigMainGrid.cpp:870
+  [9] RigMainGrid::computeCachedData(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*) at ResInsight/ApplicationLibCode/ReservoirDataModel/RigMainGrid.cpp:277
+  [10] RimEclipseCase::computeCachedData() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCase.cpp:714
+  [11] RimEclipseResultCase::importGridAndResultMetaData(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultCase.cpp:297
+  [12] RiaImportEclipseCaseTools::openEclipseCaseShowTimeStepFilterImpl(QString const&, bool, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:372
+  [13] RiaImportEclipseCaseTools::openEclipseCasesFromFile(QList<QString> const&, bool, std::map<QString, int, std::less<QString>, std::allocator<std::pair<QString const, int> > >*, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:107
+  [14] RicImportGeneralDataFeature::openEclipseCaseFromFileNames(QList<QString> const&, bool, std::vector<int, std::allocator<int> >&, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:362
+  [15] RicImportGeneralDataFeature::openEclipseFilesFromFileNames(QList<QString> const&, bool, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:104
+  [16] RicfLoadCase::execute() at ResInsight/ApplicationLibCode/CommandFileInterface/RicfLoadCase.cpp:77
+  [17] RiaGrpcCommandService::Execute(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) at ResInsight/GrpcInterface/RiaGrpcCommandService.cpp:92
+  [18] grpc::Status std::__invoke_impl<grpc::Status, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*>(std::__invoke_memfun_ref, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*&&, rips::CommandParams const*&&, rips::CommandReply*&&) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/invoke.h:67
+  [19] std::function<grpc::Status (RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*)>::operator()(RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:591
+  [20] RiaGrpcServerImpl::processAllQueuedRequests() at ResInsight/GrpcInterface/RiaGrpcServer.cpp:200
+  [21] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:115
+  [22] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:33
+  [23]  at :0
+  [24] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [25] QObject::event(QEvent*) at :0
+  [26] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [27] QTimerInfoList::activateTimers() at :0
+  [28]  at :0
+  [29] g_main_context_dispatch at :0
+  [30] g_main_context_iterate.isra.20 at :0
+  [31] g_main_context_iteration at :0
+  [32] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [33] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [34] QCoreApplication::exec() at :0
+  [35] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [36] __libc_start_main at :0
+  [37] _start at :0
+  [38]  at :0
+"
+2026-06-02T20:12:32.83Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3]  at :0
+  [4]  at :0
+  [5]  at :0
+  [6]  at :0
+  [7]  at :0
+  [8]  at :0
+  [9] QRegularExpression::isValid() const at :0
+  [10] QString::replace(QRegularExpression const&, QString const&) at :0
+  [11] RiaTextStringTools::replaceTemplateTextWithValues(QString const&, std::map<QString, QString, std::less<QString>, std::allocator<std::pair<QString const, QString> > > const&) at ResInsight/ApplicationLibCode/Application/Tools/RiaTextStringTools.cpp:178
+  [12] RimDepthTrackPlot::createPlotNameFromTemplate(QString const&) const at ResInsight/ApplicationLibCode/ProjectDataModel/RimDepthTrackPlot.cpp:608
+  [13] RimDepthTrackPlot::createAutoName() const at ResInsight/ApplicationLibCode/ProjectDataModel/RimDepthTrackPlot.cpp:712
+  [14] RimDepthTrackPlot::performAutoNameUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimDepthTrackPlot.cpp:788
+  [15] non-virtual thunk to RimDepthTrackPlot::onLoadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimDepthTrackPlot.h:196
+  [16] RimViewWindow::loadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimViewWindow.cpp:88
+  [17] non-virtual thunk to RimWellLogPlotCollection::loadDataAndUpdateAllPlots() at ResInsight/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogPlotCollection.h:66
+  [18] RiaPlotCollectionScheduler::performScheduledUpdates() at ResInsight/ApplicationLibCode/Application/RiaPlotCollectionScheduler.cpp:69
+  [19]  at :0
+  [20] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [21] QObject::event(QEvent*) at :0
+  [22] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [23] QTimerInfoList::activateTimers() at :0
+  [24]  at :0
+  [25] g_main_context_dispatch at :0
+  [26] g_main_context_iterate.isra.20 at :0
+  [27] g_main_context_iteration at :0
+  [28] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [29] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [30] QCoreApplication::exec() at :0
+  [31] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [32] __libc_start_main at :0
+  [33] _start at :0
+  [34]  at :0
+"
+2026-06-02T20:12:32.595Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] cvf::BoundingBox::addValid(cvf::BoundingBox const&) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBox.cpp:210
+  [4] cvf::AABBTree::buildTree(cvf::AABBTreeNodeInternal*, unsigned long, unsigned long, int, int) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:573
+  [5] cvf::AABBTree::buildTree(cvf::AABBTreeNodeInternal*, unsigned long, unsigned long, int, int) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:595
+  [6] cvf::AABBTree::buildTree(cvf::AABBTreeNodeInternal*, unsigned long, unsigned long, int, int) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:595
+  [7] cvf::AABBTree::buildTree() at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:489
+  [8] cvf::BoundingBoxTreeImpl::buildTree(std::vector<cvf::BoundingBox, std::allocator<cvf::BoundingBox> > const&, std::vector<std::vector<int, std::allocator<int> >, std::allocator<std::vector<int, std::allocator<int> > > > const&) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:816
+  [9] cvf::BoundingBoxTree::buildTreeFromBoundingBoxes(std::vector<cvf::BoundingBox, std::allocator<cvf::BoundingBox> > const&, std::vector<unsigned long, std::allocator<unsigned long> > const*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:948
+  [10] RigMainGrid::buildCellSearchTree() const at ResInsight/ApplicationLibCode/ReservoirDataModel/RigMainGrid.cpp:939
+  [11] RigMainGrid::doBuildCellSearchTree(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*) const at ResInsight/ApplicationLibCode/ReservoirDataModel/RigMainGrid.cpp:870
+  [12] RigMainGrid::computeCachedData(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*) at ResInsight/ApplicationLibCode/ReservoirDataModel/RigMainGrid.cpp:277
+  [13] RimEclipseCase::computeCachedData() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCase.cpp:714
+  [14] RimEclipseResultCase::importGridAndResultMetaData(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultCase.cpp:297
+  [15] RiaImportEclipseCaseTools::openEclipseCaseShowTimeStepFilterImpl(QString const&, bool, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:372
+  [16] RiaImportEclipseCaseTools::openEclipseCasesFromFile(QList<QString> const&, bool, std::map<QString, int, std::less<QString>, std::allocator<std::pair<QString const, int> > >*, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:107
+  [17] RicImportGeneralDataFeature::openEclipseCaseFromFileNames(QList<QString> const&, bool, std::vector<int, std::allocator<int> >&, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:362
+  [18] RicImportGeneralDataFeature::openEclipseFilesFromFileNames(QList<QString> const&, bool, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:104
+  [19] RicfLoadCase::execute() at ResInsight/ApplicationLibCode/CommandFileInterface/RicfLoadCase.cpp:77
+  [20] RiaGrpcCommandService::Execute(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) at ResInsight/GrpcInterface/RiaGrpcCommandService.cpp:92
+  [21] grpc::Status std::__invoke_impl<grpc::Status, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*>(std::__invoke_memfun_ref, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*&&, rips::CommandParams const*&&, rips::CommandReply*&&) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/invoke.h:67
+  [22] std::function<grpc::Status (RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*)>::operator()(RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:591
+  [23] RiaGrpcServerImpl::processAllQueuedRequests() at ResInsight/GrpcInterface/RiaGrpcServer.cpp:200
+  [24] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:115
+  [25] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:33
+  [26]  at :0
+  [27] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [28] QObject::event(QEvent*) at :0
+  [29] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [30] QTimerInfoList::activateTimers() at :0
+  [31]  at :0
+  [32] g_main_context_dispatch at :0
+  [33] g_main_context_iterate.isra.20 at :0
+  [34] g_main_context_iteration at :0
+  [35] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [36] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [37] QCoreApplication::exec() at :0
+  [38] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [39] __libc_start_main at :0
+  [40] _start at :0
+  [41]  at :0
+"
+2026-06-02T20:12:32.553Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3]  at :0
+  [4] QRegularExpression::isValid() const at :0
+  [5] QString::replace(QRegularExpression const&, QString const&) at :0
+  [6] RiaTextStringTools::replaceTemplateTextWithValues(QString const&, std::map<QString, QString, std::less<QString>, std::allocator<std::pair<QString const, QString> > > const&) at ResInsight/ApplicationLibCode/Application/Tools/RiaTextStringTools.cpp:178
+  [7] RimDepthTrackPlot::createPlotNameFromTemplate(QString const&) const at ResInsight/ApplicationLibCode/ProjectDataModel/RimDepthTrackPlot.cpp:608
+  [8] RimDepthTrackPlot::createAutoName() const at ResInsight/ApplicationLibCode/ProjectDataModel/RimDepthTrackPlot.cpp:712
+  [9] RimDepthTrackPlot::performAutoNameUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimDepthTrackPlot.cpp:788
+  [10] non-virtual thunk to RimDepthTrackPlot::onLoadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimDepthTrackPlot.h:196
+  [11] RimViewWindow::loadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimViewWindow.cpp:88
+  [12] non-virtual thunk to RimWellLogPlotCollection::loadDataAndUpdateAllPlots() at ResInsight/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogPlotCollection.h:66
+  [13] RiaPlotCollectionScheduler::performScheduledUpdates() at ResInsight/ApplicationLibCode/Application/RiaPlotCollectionScheduler.cpp:69
+  [14]  at :0
+  [15] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [16] QObject::event(QEvent*) at :0
+  [17] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [18] QTimerInfoList::activateTimers() at :0
+  [19]  at :0
+  [20] g_main_context_dispatch at :0
+  [21] g_main_context_iterate.isra.20 at :0
+  [22] g_main_context_iteration at :0
+  [23] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [24] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [25] QCoreApplication::exec() at :0
+  [26] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [27] __libc_start_main at :0
+  [28] _start at :0
+  [29]  at :0
+"
+2026-06-02T20:12:32.462Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] RigEclipseWellLogExtractor::calculateIntersection() at ResInsight/ApplicationLibCode/ReservoirDataModel/Well/RigEclipseWellLogExtractor.cpp:82
+  [4] RigEclipseWellLogExtractor::RigEclipseWellLogExtractor(gsl::not_null<RigEclipseCaseData const*>, gsl::not_null<RigWellPath const*>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) at ResInsight/ApplicationLibCode/ReservoirDataModel/Well/RigEclipseWellLogExtractor.cpp:49
+  [5] RigWellPathIntersectionTools::findCellIntersectionInfosAlongPath(RigEclipseCaseData const*, QString const&, std::vector<cvf::Vector3<double>, std::allocator<cvf::Vector3<double> > > const&, std::vector<double, std::allocator<double> > const&) at ResInsight/ApplicationLibCode/ReservoirDataModel/Well/RigWellPathIntersectionTools.cpp:50
+  [6] RicWellPathExportMswTableData::generateCellSegments(RimEclipseCase const*, RimWellPath const*) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswTableData.cpp:658
+  [7] RicWellPathExportMswTableData::generateFishbonesMswExportInfoForWell(RimEclipseCase const*, RimWellPath const*, RicMswExportInfo*, RicMswBranch*) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswTableData.cpp:197
+  [8] RicFishbonesTransmissibilityCalculationFeatureImp::findFishboneLateralsWellBoreParts(std::map<unsigned long, std::vector<WellBorePartForTransCalc, std::allocator<WellBorePartForTransCalc> >, std::less<unsigned long>, std::allocator<std::pair<unsigned long const, std::vector<WellBorePartForTransCalc, std::allocator<WellBorePartForTransCalc> > > > >&, RimWellPath const*, RimEclipseCase const*) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicFishbonesTransmissibilityCalculationFeatureImp.cpp:209
+  [9] RicFishbonesTransmissibilityCalculationFeatureImp::generateFishboneCompdatValuesUsingAdjustedCellVolume(RimWellPath const*, RicExportCompletionDataSettingsUi const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicFishbonesTransmissibilityCalculationFeatureImp.cpp:92
+  [10] RicWellPathExportCompletionDataFeatureImpl::exportCompletions(std::vector<RimWellPath*, std::allocator<RimWellPath*> > const&, RicExportCompletionDataSettingsUi const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportCompletionDataFeatureImpl.cpp:208
+  [11] RicfExportWellPathCompletions::execute() at ResInsight/ApplicationLibCode/CommandFileInterface/RicfExportWellPathCompletions.cpp:184
+  [12] RiaGrpcCommandService::Execute(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) at ResInsight/GrpcInterface/RiaGrpcCommandService.cpp:92
+  [13] grpc::Status std::__invoke_impl<grpc::Status, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*>(std::__invoke_memfun_ref, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*&&, rips::CommandParams const*&&, rips::CommandReply*&&) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/invoke.h:67
+  [14] std::function<grpc::Status (RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*)>::operator()(RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:591
+  [15] RiaGrpcServerImpl::processAllQueuedRequests() at ResInsight/GrpcInterface/RiaGrpcServer.cpp:200
+  [16] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:115
+  [17] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:33
+  [18]  at :0
+  [19] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [20] QObject::event(QEvent*) at :0
+  [21] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [22] QTimerInfoList::activateTimers() at :0
+  [23]  at :0
+  [24] g_main_context_dispatch at :0
+  [25] g_main_context_iterate.isra.20 at :0
+  [26] g_main_context_iteration at :0
+  [27] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [28] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [29] QCoreApplication::exec() at :0
+  [30] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [31] __libc_start_main at :0
+  [32] _start at :0
+  [33]  at :0
+"
+2026-06-02T20:12:32.25Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
+  [6] RimEclipseCase::~RimEclipseCase() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCase.cpp:170
+  [7] RimEclipseResultCase::~RimEclipseResultCase() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultCase.cpp:585
+  [8] caf::PdmChildArrayField<RimEclipseCase*>::deleteChildren() at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmChildArrayField.inl:181
+  [9] RimEclipseCaseCollection::close() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCaseCollection.cpp:73
+  [10] RimEclipseCaseCollection::~RimEclipseCaseCollection() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCaseCollection.cpp:63
+  [11] RimEclipseCaseCollection::~RimEclipseCaseCollection() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCaseCollection.cpp:64
+  [12] caf::PdmChildField<RimEclipseCaseCollection*>::~PdmChildField() at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmChildField.inl:80
+  [13] RimOilField::~RimOilField() at ResInsight/ApplicationLibCode/ProjectDataModel/RimOilField.cpp:113
+  [14] caf::PdmChildArrayField<RimOilField*>::deleteChildren() at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmChildArrayField.inl:181
+  [15] RimProject::close() at ResInsight/ApplicationLibCode/ProjectDataModel/RimProject.cpp:257
+  [16] RiaApplication::closeProject() at ResInsight/ApplicationLibCode/Application/RiaApplication.cpp:1021
+  [17] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:36
+  [18]  at :0
+  [19] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [20] QObject::event(QEvent*) at :0
+  [21] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [22] QTimerInfoList::activateTimers() at :0
+  [23]  at :0
+  [24] g_main_context_dispatch at :0
+  [25] g_main_context_iterate.isra.20 at :0
+  [26] g_main_context_iteration at :0
+  [27] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [28] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [29] RiaOpenTelemetryManager::reportCrash(int, std::basic_stacktrace<std::allocator<std::stacktrace_entry> > const&, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > const&) at ResInsight/ApplicationLibCode/Application/Tools/Telemetry/RiaOpenTelemetryManager.cpp:415
+  [30] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:174
+  [31] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [32]  at :0
+  [33] QtPrivate::compareStrings(QStringView, QStringView, Qt::CaseSensitivity) at :0
+  [34] operator<(QString const&, QString const&) at /private/f_resinsight_build/resbuild/qt/6.6.3/gcc_64/include/QtCore/qstring.h:697
+  [35] operator() at ResInsight/ApplicationLibCode/Application/Tools/RiaWellNameComparer.cpp:87
+  [36] std::function<QString (QString)>::operator()(QString) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:591
+  [37] RiaWellNameComparer::tryMatchNameInList(QString, std::vector<QString, std::allocator<QString> > const&) at ResInsight/ApplicationLibCode/Application/Tools/RiaWellNameComparer.cpp:82
+  [38] RiaWellNameComparer::tryFindMatchingSimWellName(QString) at ResInsight/ApplicationLibCode/Application/Tools/RiaWellNameComparer.cpp:40
+  [39] RimWellPath::tryAssociateWithSimulationWell() at ResInsight/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPath.cpp:1107
+  [40] RimEclipseCase::openReservoirCase() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCase.cpp:1152
+  [41] RimEclipseResultDefinition::loadResult() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:1097
+  [42] RimWellLogExtractionCurve::extractEclipseData(RimEclipseCase*, bool*) at ResInsight/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogExtractionCurve.cpp:546
+  [43] RimWellLogExtractionCurve::extractData(bool*, std::optional<double> const&, std::optional<double> const&) at ResInsight/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogExtractionCurve.cpp:457
+  [44] RimWellLogExtractionCurve::performDataExtraction(bool*) at ResInsight/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogExtractionCurve.cpp:433
+  [45] RimWellLogExtractionCurve::onLoadDataAndUpdate(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogExtractionCurve.cpp:342
+  [46] RimPlotCurve::loadDataAndUpdate(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimPlotCurve.cpp:587
+  [47] RimWellLogTrack::onLoadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogTrack.cpp:1213
+  [48] RimViewWindow::loadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimViewWindow.cpp:88
+  [49] RimDepthTrackPlot::updatePlots() at ResInsight/ApplicationLibCode/ProjectDataModel/RimDepthTrackPlot.cpp:1248
+  [50] non-virtual thunk to RimDepthTrackPlot::onLoadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimDepthTrackPlot.h:196
+  [51] RimViewWindow::loadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimViewWindow.cpp:88
+  [52] non-virtual thunk to RimWellLogPlotCollection::loadDataAndUpdateAllPlots() at ResInsight/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogPlotCollection.h:66
+  [53] RiaPlotCollectionScheduler::performScheduledUpdates() at ResInsight/ApplicationLibCode/Application/RiaPlotCollectionScheduler.cpp:69
+  [54]  at :0
+  [55] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [56] QObject::event(QEvent*) at :0
+  [57] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [58] QTimerInfoList::activateTimers() at :0
+  [59]  at :0
+  [60] g_main_context_dispatch at :0
+  [61] g_main_context_iterate.isra.20 at :0
+  [62] g_main_context_iteration at :0
+  [63] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [64] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [65] QCoreApplication::exec() at :0
+  [66] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [67] __libc_start_main at :0
+  [68] _start at :0
+  [69]  at :0
+"
+2026-06-02T20:12:32.248Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] ecl_cell_memcpy at ResInsight/ThirdParty/Ert/lib/ecl/ecl_grid.cpp:1138
+  [4] ecl_grid_alloc_GRDECL_data__ at ResInsight/ThirdParty/Ert/lib/ecl/ecl_grid.cpp:2492
+  [5] ecl_grid_alloc_GRDECL_kw__ at ResInsight/ThirdParty/Ert/lib/ecl/ecl_grid.cpp:2760
+  [6] ecl_grid_alloc_EGRID__ at ResInsight/ThirdParty/Ert/lib/ecl/ecl_grid.cpp:3073
+  [7] ecl_grid_alloc_EGRID_all_grids at ResInsight/ThirdParty/Ert/lib/ecl/ecl_grid.cpp:3106
+  [8] RifReaderEclipseOutput::loadAllGrids() const at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp:1161
+  [9] RifReaderEclipseOutput::open(QString const&, RigEclipseCaseData*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp:389
+  [10] RimEclipseResultCase::importGridAndResultMetaData(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultCase.cpp:261
+  [11] RiaImportEclipseCaseTools::openEclipseCaseShowTimeStepFilterImpl(QString const&, bool, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:372
+  [12] RiaImportEclipseCaseTools::openEclipseCasesFromFile(QList<QString> const&, bool, std::map<QString, int, std::less<QString>, std::allocator<std::pair<QString const, int> > >*, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:107
+  [13] RicImportGeneralDataFeature::openEclipseCaseFromFileNames(QList<QString> const&, bool, std::vector<int, std::allocator<int> >&, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:362
+  [14] RicImportGeneralDataFeature::openEclipseFilesFromFileNames(QList<QString> const&, bool, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:104
+  [15] RicfLoadCase::execute() at ResInsight/ApplicationLibCode/CommandFileInterface/RicfLoadCase.cpp:77
+  [16] RiaGrpcCommandService::Execute(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) at ResInsight/GrpcInterface/RiaGrpcCommandService.cpp:92
+  [17] grpc::Status std::__invoke_impl<grpc::Status, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*>(std::__invoke_memfun_ref, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*&&, rips::CommandParams const*&&, rips::CommandReply*&&) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/invoke.h:67
+  [18] std::function<grpc::Status (RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*)>::operator()(RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:591
+  [19] RiaGrpcServerImpl::processAllQueuedRequests() at ResInsight/GrpcInterface/RiaGrpcServer.cpp:200
+  [20] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:115
+  [21] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:33
+  [22]  at :0
+  [23] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [24] QObject::event(QEvent*) at :0
+  [25] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [26] QTimerInfoList::activateTimers() at :0
+  [27]  at :0
+  [28] g_main_context_dispatch at :0
+  [29] g_main_context_iterate.isra.20 at :0
+  [30] g_main_context_iteration at :0
+  [31] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [32] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [33] QCoreApplication::exec() at :0
+  [34] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [35] __libc_start_main at :0
+  [36] _start at :0
+  [37]  at :0
+"
+2026-06-02T20:12:32.248Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_read at :0
+  [4] _IO_new_file_underflow at :0
+  [5] __GI__IO_file_xsgetn at :0
+  [6] __GI__IO_fread at :0
+  [7] fortio_fread_record at ResInsight/ThirdParty/Ert/lib/ecl/fortio.c:529
+  [8] ecl_kw_fread_data at ResInsight/ThirdParty/Ert/lib/ecl/ecl_kw.cpp:1246
+  [9] ecl_kw_fread_alloc at ResInsight/ThirdParty/Ert/lib/ecl/ecl_kw.cpp:1562
+  [10] ecl_file_kw_load_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_kw.cpp:243
+  [11] ecl_file_view_get_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_view.cpp:149
+  [12] well_state_add_connections__ at ResInsight/ThirdParty/Ert/lib/ecl/well_state.cpp:435
+  [13] well_state_add_global_connections at ResInsight/ThirdParty/Ert/lib/ecl/well_state.cpp:449
+  [14] well_state_alloc_from_file2 at ResInsight/ThirdParty/Ert/lib/ecl/well_state.cpp:610
+  [15] well_info_add_wells2 at ResInsight/ThirdParty/Ert/lib/ecl/well_info.cpp:286
+  [16] well_info_add_UNRST_wells2 at ResInsight/ThirdParty/Ert/lib/ecl/well_info.cpp:316
+  [17] RifReaderEclipseWell::readWellCells(RifEclipseRestartDataAccess*, RigEclipseCaseData*, std::vector<QDateTime, std::allocator<QDateTime> >, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, bool) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseWell.cpp:464
+  [18] RifReaderEclipseOutput::open(QString const&, RigEclipseCaseData*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp:523
+  [19] RimEclipseResultCase::importGridAndResultMetaData(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultCase.cpp:261
+  [20] RiaImportEclipseCaseTools::openEclipseCaseShowTimeStepFilterImpl(QString const&, bool, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:372
+  [21] RiaImportEclipseCaseTools::openEclipseCasesFromFile(QList<QString> const&, bool, std::map<QString, int, std::less<QString>, std::allocator<std::pair<QString const, int> > >*, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:107
+  [22] RicImportGeneralDataFeature::openEclipseCaseFromFileNames(QList<QString> const&, bool, std::vector<int, std::allocator<int> >&, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:362
+  [23] RicImportGeneralDataFeature::openEclipseFilesFromFileNames(QList<QString> const&, bool, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:104
+  [24] RicfLoadCase::execute() at ResInsight/ApplicationLibCode/CommandFileInterface/RicfLoadCase.cpp:77
+  [25] RiaGrpcCommandService::Execute(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) at ResInsight/GrpcInterface/RiaGrpcCommandService.cpp:92
+  [26] grpc::Status std::__invoke_impl<grpc::Status, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*>(std::__invoke_memfun_ref, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*&&, rips::CommandParams const*&&, rips::CommandReply*&&) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/invoke.h:67
+  [27] std::function<grpc::Status (RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*)>::operator()(RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:591
+  [28] RiaGrpcServerImpl::processAllQueuedRequests() at ResInsight/GrpcInterface/RiaGrpcServer.cpp:200
+  [29] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:115
+  [30] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:33
+  [31]  at :0
+  [32] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [33] QObject::event(QEvent*) at :0
+  [34] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [35] QTimerInfoList::activateTimers() at :0
+  [36]  at :0
+  [37] g_main_context_dispatch at :0
+  [38] g_main_context_iterate.isra.20 at :0
+  [39] g_main_context_iteration at :0
+  [40] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [41] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [42] QCoreApplication::exec() at :0
+  [43] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [44] __libc_start_main at :0
+  [45] _start at :0
+  [46]  at :0
+"
+2026-06-02T20:12:32.248Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] ecl_grid_set_active_index at ResInsight/ThirdParty/Ert/lib/ecl/ecl_grid.cpp:1863
+  [4] ecl_grid_update_index at ResInsight/ThirdParty/Ert/lib/ecl/ecl_grid.cpp:1968
+  [5] RifActiveCellsReader::applyActiveCellsToAllGrids(ecl_grid_struct*, std::vector<std::vector<int, std::allocator<int> >, std::allocator<std::vector<int, std::allocator<int> > > > const&) at ResInsight/ApplicationLibCode/FileInterface/RifActiveCellsReader.cpp:144
+  [6] RifReaderEclipseOutput::loadAllGrids() const at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp:1174
+  [7] RifReaderEclipseOutput::open(QString const&, RigEclipseCaseData*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp:389
+  [8] RimEclipseResultCase::importGridAndResultMetaData(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultCase.cpp:261
+  [9] RiaImportEclipseCaseTools::openEclipseCaseShowTimeStepFilterImpl(QString const&, bool, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:372
+  [10] RiaImportEclipseCaseTools::openEclipseCasesFromFile(QList<QString> const&, bool, std::map<QString, int, std::less<QString>, std::allocator<std::pair<QString const, int> > >*, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:107
+  [11] RicImportGeneralDataFeature::openEclipseCaseFromFileNames(QList<QString> const&, bool, std::vector<int, std::allocator<int> >&, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:362
+  [12] RicImportGeneralDataFeature::openEclipseFilesFromFileNames(QList<QString> const&, bool, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:104
+  [13] RicfLoadCase::execute() at ResInsight/ApplicationLibCode/CommandFileInterface/RicfLoadCase.cpp:77
+  [14] RiaGrpcCommandService::Execute(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) at ResInsight/GrpcInterface/RiaGrpcCommandService.cpp:92
+  [15] grpc::Status std::__invoke_impl<grpc::Status, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*>(std::__invoke_memfun_ref, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*&&, rips::CommandParams const*&&, rips::CommandReply*&&) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/invoke.h:67
+  [16] std::function<grpc::Status (RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*)>::operator()(RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:591
+  [17] RiaGrpcServerImpl::processAllQueuedRequests() at ResInsight/GrpcInterface/RiaGrpcServer.cpp:200
+  [18] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:115
+  [19] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:33
+  [20]  at :0
+  [21] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [22] QObject::event(QEvent*) at :0
+  [23] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [24] QTimerInfoList::activateTimers() at :0
+  [25]  at :0
+  [26] g_main_context_dispatch at :0
+  [27] g_main_context_iterate.isra.20 at :0
+  [28] g_main_context_iteration at :0
+  [29] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [30] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [31] QCoreApplication::exec() at :0
+  [32] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [33] __libc_start_main at :0
+  [34] _start at :0
+  [35]  at :0
+"
+2026-06-02T20:12:32.248Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_read at :0
+  [4] _IO_new_file_underflow at :0
+  [5] __GI__IO_file_xsgetn at :0
+  [6] __GI__IO_fread at :0
+  [7] fortio_fread_record at ResInsight/ThirdParty/Ert/lib/ecl/fortio.c:529
+  [8] ecl_kw_fread_data at ResInsight/ThirdParty/Ert/lib/ecl/ecl_kw.cpp:1246
+  [9] ecl_kw_fread_alloc at ResInsight/ThirdParty/Ert/lib/ecl/ecl_kw.cpp:1562
+  [10] ecl_file_kw_load_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_kw.cpp:243
+  [11] ecl_file_view_get_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_view.cpp:149
+  [12] well_state_add_connections__ at ResInsight/ThirdParty/Ert/lib/ecl/well_state.cpp:435
+  [13] well_state_add_global_connections at ResInsight/ThirdParty/Ert/lib/ecl/well_state.cpp:449
+  [14] well_state_alloc_from_file2 at ResInsight/ThirdParty/Ert/lib/ecl/well_state.cpp:610
+  [15] well_info_add_wells2 at ResInsight/ThirdParty/Ert/lib/ecl/well_info.cpp:286
+  [16] well_info_add_UNRST_wells2 at ResInsight/ThirdParty/Ert/lib/ecl/well_info.cpp:316
+  [17] RifReaderEclipseWell::readWellCells(RifEclipseRestartDataAccess*, RigEclipseCaseData*, std::vector<QDateTime, std::allocator<QDateTime> >, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, bool) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseWell.cpp:464
+  [18] RifReaderEclipseOutput::open(QString const&, RigEclipseCaseData*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp:523
+  [19] RimEclipseResultCase::importGridAndResultMetaData(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultCase.cpp:261
+  [20] RiaImportEclipseCaseTools::openEclipseCaseShowTimeStepFilterImpl(QString const&, bool, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:372
+  [21] RiaImportEclipseCaseTools::openEclipseCasesFromFile(QList<QString> const&, bool, std::map<QString, int, std::less<QString>, std::allocator<std::pair<QString const, int> > >*, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:107
+  [22] RicImportGeneralDataFeature::openEclipseCaseFromFileNames(QList<QString> const&, bool, std::vector<int, std::allocator<int> >&, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:362
+  [23] RicImportGeneralDataFeature::openEclipseFilesFromFileNames(QList<QString> const&, bool, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:104
+  [24] RicfLoadCase::execute() at ResInsight/ApplicationLibCode/CommandFileInterface/RicfLoadCase.cpp:77
+  [25] RiaGrpcCommandService::Execute(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) at ResInsight/GrpcInterface/RiaGrpcCommandService.cpp:92
+  [26] grpc::Status std::__invoke_impl<grpc::Status, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*>(std::__invoke_memfun_ref, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*&&, rips::CommandParams const*&&, rips::CommandReply*&&) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/invoke.h:67
+  [27] std::function<grpc::Status (RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*)>::operator()(RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:591
+  [28] RiaGrpcServerImpl::processAllQueuedRequests() at ResInsight/GrpcInterface/RiaGrpcServer.cpp:200
+  [29] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:115
+  [30] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:33
+  [31]  at :0
+  [32] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [33] QObject::event(QEvent*) at :0
+  [34] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [35] QTimerInfoList::activateTimers() at :0
+  [36]  at :0
+  [37] g_main_context_dispatch at :0
+  [38] g_main_context_iterate.isra.20 at :0
+  [39] g_main_context_iteration at :0
+  [40] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [41] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [42] QCoreApplication::exec() at :0
+  [43] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [44] __libc_start_main at :0
+  [45] _start at :0
+  [46]  at :0
+"
+2026-06-02T20:12:32.193Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] cvf::AABBTree::deleteInternalNodesBottomUp(cvf::AABBTreeNode*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:796
+  [4] cvf::AABBTree::deleteInternalNodesBottomUp(cvf::AABBTreeNode*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:802
+  [5] cvf::AABBTree::deleteInternalNodesBottomUp(cvf::AABBTreeNode*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:801
+  [6] cvf::AABBTree::deleteInternalNodesBottomUp(cvf::AABBTreeNode*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:801
+  [7] cvf::AABBTree::deleteInternalNodesBottomUp(cvf::AABBTreeNode*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:802
+  [8] cvf::AABBTree::deleteInternalNodesBottomUp(cvf::AABBTreeNode*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:802
+  [9] cvf::AABBTree::deleteInternalNodesBottomUp(cvf::AABBTreeNode*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:801
+  [10] cvf::AABBTree::deleteInternalNodesBottomUp(cvf::AABBTreeNode*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:802
+  [11] cvf::AABBTree::deleteInternalNodesBottomUp(cvf::AABBTreeNode*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:801
+  [12] cvf::AABBTree::deleteInternalNodesBottomUp(cvf::AABBTreeNode*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:802
+  [13] cvf::AABBTree::deleteInternalNodesBottomUp(cvf::AABBTreeNode*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:802
+  [14] cvf::AABBTree::deleteInternalNodesBottomUp(cvf::AABBTreeNode*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:801
+  [15] cvf::AABBTree::deleteInternalNodesBottomUp(cvf::AABBTreeNode*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:801
+  [16] cvf::AABBTree::deleteInternalNodesBottomUp(cvf::AABBTreeNode*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:801
+  [17] cvf::AABBTree::deleteInternalNodesBottomUp(cvf::AABBTreeNode*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:802
+  [18] cvf::AABBTree::deleteInternalNodesBottomUp(cvf::AABBTreeNode*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:802
+  [19] cvf::AABBTree::deleteInternalNodesBottomUp(cvf::AABBTreeNode*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:802
+  [20] cvf::AABBTree::deleteInternalNodesBottomUp(cvf::AABBTreeNode*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:802
+  [21] cvf::AABBTree::deleteInternalNodesBottomUp(cvf::AABBTreeNode*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:802
+  [22] cvf::AABBTree::deleteInternalNodesBottomUp(cvf::AABBTreeNode*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:801
+  [23] cvf::AABBTree::deleteInternalNodesBottomUp(cvf::AABBTreeNode*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:801
+  [24] cvf::AABBTree::deleteInternalNodesBottomUp(cvf::AABBTreeNode*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:801
+  [25] cvf::AABBTree::deleteInternalNodesBottomUp(cvf::AABBTreeNode*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:801
+  [26] cvf::AABBTree::deleteInternalNodesBottomUp(cvf::AABBTreeNode*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:801
+  [27] cvf::AABBTree::deleteInternalNodesBottomUp(cvf::AABBTreeNode*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:801
+  [28] cvf::AABBTree::deleteInternalNodesBottomUp(cvf::AABBTreeNode*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:801
+  [29] cvf::AABBTree::deleteInternalNodesBottomUp(cvf::AABBTreeNode*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:802
+  [30] cvf::AABBTree::freeThis() at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:614
+  [31] cvf::AABBTree::~AABBTree() at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:453
+  [32] cvf::BoundingBoxTreeImpl::~BoundingBoxTreeImpl() at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:219
+  [33] cvf::BoundingBoxTree::~BoundingBoxTree() at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:913
+  [34] cvf::Object::release() const at ResInsight/Fwk/VizFwk/LibCore/cvfObject.inl:90
+  [35] RigMainGrid::~RigMainGrid() at ResInsight/ApplicationLibCode/ReservoirDataModel/RigMainGrid.cpp:58
+  [36] cvf::Object::release() const at ResInsight/Fwk/VizFwk/LibCore/cvfObject.inl:90
+  [37] RigEclipseCaseData::~RigEclipseCaseData() at ResInsight/ApplicationLibCode/ReservoirDataModel/RigEclipseCaseData.cpp:70
+  [38] cvf::Object::release() const at ResInsight/Fwk/VizFwk/LibCore/cvfObject.inl:90
+  [39] RimEclipseResultCase::~RimEclipseResultCase() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultCase.cpp:585
+  [40] caf::PdmChildArrayField<RimEclipseCase*>::deleteChildren() at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmChildArrayField.inl:181
+  [41] RimEclipseCaseCollection::close() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCaseCollection.cpp:73
+  [42] RimEclipseCaseCollection::~RimEclipseCaseCollection() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCaseCollection.cpp:63
+  [43] RimEclipseCaseCollection::~RimEclipseCaseCollection() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCaseCollection.cpp:64
+  [44] caf::PdmChildField<RimEclipseCaseCollection*>::~PdmChildField() at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmChildField.inl:80
+  [45] RimOilField::~RimOilField() at ResInsight/ApplicationLibCode/ProjectDataModel/RimOilField.cpp:113
+  [46] caf::PdmChildArrayField<RimOilField*>::deleteChildren() at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmChildArrayField.inl:181
+  [47] RimProject::close() at ResInsight/ApplicationLibCode/ProjectDataModel/RimProject.cpp:257
+  [48] RiaApplication::closeProject() at ResInsight/ApplicationLibCode/Application/RiaApplication.cpp:1021
+  [49] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:36
+  [50]  at :0
+  [51] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [52] QObject::event(QEvent*) at :0
+  [53] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [54] QTimerInfoList::activateTimers() at :0
+  [55]  at :0
+  [56] g_main_context_dispatch at :0
+  [57] g_main_context_iterate.isra.20 at :0
+  [58] g_main_context_iteration at :0
+  [59] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [60] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [61] QCoreApplication::exec() at :0
+  [62] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [63] __libc_start_main at :0
+  [64] _start at :0
+  [65]  at :0
+"
+2026-06-02T20:12:32.053Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] QtPrivate::compareStrings(QStringView, QStringView, Qt::CaseSensitivity) at :0
+  [4] operator<(QString const&, QString const&) at /private/f_resinsight_build/resbuild/qt/6.6.3/gcc_64/include/QtCore/qstring.h:697
+  [5] operator() at ResInsight/ApplicationLibCode/Application/Tools/RiaWellNameComparer.cpp:87
+  [6] std::function<QString (QString)>::operator()(QString) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:591
+  [7] RiaWellNameComparer::tryMatchNameInList(QString, std::vector<QString, std::allocator<QString> > const&) at ResInsight/ApplicationLibCode/Application/Tools/RiaWellNameComparer.cpp:82
+  [8] RiaWellNameComparer::tryFindMatchingSimWellName(QString) at ResInsight/ApplicationLibCode/Application/Tools/RiaWellNameComparer.cpp:40
+  [9] RimWellPath::tryAssociateWithSimulationWell() at ResInsight/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPath.cpp:1107
+  [10] RimEclipseCase::openReservoirCase() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCase.cpp:1152
+  [11] RimEclipseResultDefinition::loadResult() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:1097
+  [12] RimWellLogExtractionCurve::extractEclipseData(RimEclipseCase*, bool*) at ResInsight/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogExtractionCurve.cpp:546
+  [13] RimWellLogExtractionCurve::extractData(bool*, std::optional<double> const&, std::optional<double> const&) at ResInsight/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogExtractionCurve.cpp:457
+  [14] RimWellLogExtractionCurve::performDataExtraction(bool*) at ResInsight/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogExtractionCurve.cpp:433
+  [15] RimWellLogExtractionCurve::onLoadDataAndUpdate(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogExtractionCurve.cpp:342
+  [16] RimPlotCurve::loadDataAndUpdate(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimPlotCurve.cpp:587
+  [17] RimWellLogTrack::onLoadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogTrack.cpp:1213
+  [18] RimViewWindow::loadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimViewWindow.cpp:88
+  [19] RimDepthTrackPlot::updatePlots() at ResInsight/ApplicationLibCode/ProjectDataModel/RimDepthTrackPlot.cpp:1248
+  [20] non-virtual thunk to RimDepthTrackPlot::onLoadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimDepthTrackPlot.h:196
+  [21] RimViewWindow::loadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimViewWindow.cpp:88
+  [22] non-virtual thunk to RimWellLogPlotCollection::loadDataAndUpdateAllPlots() at ResInsight/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogPlotCollection.h:66
+  [23] RiaPlotCollectionScheduler::performScheduledUpdates() at ResInsight/ApplicationLibCode/Application/RiaPlotCollectionScheduler.cpp:69
+  [24]  at :0
+  [25] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [26] QObject::event(QEvent*) at :0
+  [27] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [28] QTimerInfoList::activateTimers() at :0
+  [29]  at :0
+  [30] g_main_context_dispatch at :0
+  [31] g_main_context_iterate.isra.20 at :0
+  [32] g_main_context_iteration at :0
+  [33] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [34] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [35] QCoreApplication::exec() at :0
+  [36] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [37] __libc_start_main at :0
+  [38] _start at :0
+  [39]  at :0
+"
+2026-06-02T20:12:31.767Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_read at :0
+  [4] __GI__IO_file_seekoff at :0
+  [5] __GI_fseek at :0
+  [6] Opm::EclIO::ESmry::getListOfArrays(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool) at ResInsight/ThirdParty/custom-opm-common/opm-common/opm/io/eclipse/ESmry.cpp:1059
+  [7] Opm::EclIO::ESmry::ESmry(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool) at ResInsight/ThirdParty/custom-opm-common/opm-common/opm/io/eclipse/ESmry.cpp:561
+  [8] std::__detail::_MakeUniq<Opm::EclIO::ESmry>::__single_object std::make_unique<Opm::EclIO::ESmry, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool&>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&, bool&) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/unique_ptr.h:1070
+  [9] RifOpmCommonEclipseSummary::open(QString const&, bool, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/FileInterface/RifOpmCommonSummary.cpp:174
+  [10] RifReaderEclipseSummary::open(QString const&, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseSummary.cpp:141
+  [11] RimFileSummaryCase::findRelatedFilesAndCreateReader(QString const&, bool, RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:238
+  [12] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:110
+  [13] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+  [14] GOMP_parallel at :0
+  [15] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:561
+  [16] RimSummaryCaseMainCollection::loadSummaryCaseData(std::vector<RimSummaryCase*, std::allocator<RimSummaryCase*> > const&, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:457
+  [17] RimSummaryCaseMainCollection::createSummaryCasesFromFileInfos(std::vector<RifSummaryCaseFileResultInfo, std::allocator<RifSummaryCaseFileResultInfo> > const&, bool, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:712
+  [18] RiaImportEclipseCaseTools::openEclipseCasesFromFile(QList<QString> const&, bool, std::map<QString, int, std::less<QString>, std::allocator<std::pair<QString const, int> > >*, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:127
+  [19] RicImportGeneralDataFeature::openEclipseCaseFromFileNames(QList<QString> const&, bool, std::vector<int, std::allocator<int> >&, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:362
+  [20] RicImportGeneralDataFeature::openEclipseFilesFromFileNames(QList<QString> const&, bool, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:104
+  [21] RicfLoadCase::execute() at ResInsight/ApplicationLibCode/CommandFileInterface/RicfLoadCase.cpp:77
+  [22] RiaGrpcCommandService::Execute(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) at ResInsight/GrpcInterface/RiaGrpcCommandService.cpp:92
+  [23] grpc::Status std::__invoke_impl<grpc::Status, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*>(std::__invoke_memfun_ref, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*&&, rips::CommandParams const*&&, rips::CommandReply*&&) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/invoke.h:67
+  [24] std::function<grpc::Status (RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*)>::operator()(RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:591
+  [25] RiaGrpcServerImpl::processAllQueuedRequests() at ResInsight/GrpcInterface/RiaGrpcServer.cpp:200
+  [26] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:115
+  [27] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:33
+  [28]  at :0
+  [29] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [30] QObject::event(QEvent*) at :0
+  [31] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [32] QTimerInfoList::activateTimers() at :0
+  [33]  at :0
+  [34] g_main_context_dispatch at :0
+  [35] g_main_context_iterate.isra.20 at :0
+  [36] g_main_context_iteration at :0
+  [37] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [38] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [39] QCoreApplication::exec() at :0
+  [40] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [41] __libc_start_main at :0
+  [42] _start at :0
+  [43]  at :0
+"
+2026-06-02T20:12:31.727Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] void caf::addXmlCapabilityToField<caf::PdmField<int> >(caf::PdmField<int>*) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmXml/cafInternalPdmXmlFieldCapability.h:235
+  [4] RimTernaryLegendConfig::RimTernaryLegendConfig() at ResInsight/ApplicationLibCode/ProjectDataModel/RimTernaryLegendConfig.cpp:51
+  [5] Rim2dIntersectionView::Rim2dIntersectionView() at ResInsight/ApplicationLibCode/ProjectDataModel/Rim2dIntersectionView.cpp:83
+  [6] Rim2dIntersectionViewCollection::syncFromExistingIntersections(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Rim2dIntersectionViewCollection.cpp:97
+  [7] RimIntersectionCollection::onChildAdded(caf::PdmFieldHandle*) at ResInsight/ApplicationLibCode/ProjectDataModel/Intersections/RimIntersectionCollection.cpp:430
+  [8] RiaGrpcServiceInterface::emplaceChildField(caf::PdmObject*, QString const&, QString const&) at ResInsight/GrpcInterface/RiaGrpcServiceInterface.cpp:362
+  [9] RiaGrpcPdmObjectService::CreateChildPdmObject(grpc::ServerContext*, rips::CreatePdmChildObjectRequest const*, rips::PdmObject*) at ResInsight/GrpcInterface/RiaGrpcPdmObjectService.cpp:514
+  [10] grpc::Status std::__invoke_impl<grpc::Status, grpc::Status (RiaGrpcPdmObjectService::*&)(grpc::ServerContext*, rips::CreatePdmChildObjectRequest const*, rips::PdmObject*), RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::CreatePdmChildObjectRequest const*, rips::PdmObject*>(std::__invoke_memfun_ref, grpc::Status (RiaGrpcPdmObjectService::*&)(grpc::ServerContext*, rips::CreatePdmChildObjectRequest const*, rips::PdmObject*), RiaGrpcPdmObjectService&, grpc::ServerContext*&&, rips::CreatePdmChildObjectRequest const*&&, rips::PdmObject*&&) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/invoke.h:67
+  [11] std::function<grpc::Status (RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::CreatePdmChildObjectRequest const*, rips::PdmObject*)>::operator()(RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::CreatePdmChildObjectRequest const*, rips::PdmObject*) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:591
+  [12] RiaGrpcServerImpl::processAllQueuedRequests() at ResInsight/GrpcInterface/RiaGrpcServer.cpp:200
+  [13] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:115
+  [14] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:33
+  [15]  at :0
+  [16] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [17] QObject::event(QEvent*) at :0
+  [18] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [19] QTimerInfoList::activateTimers() at :0
+  [20]  at :0
+  [21] g_main_context_dispatch at :0
+  [22] g_main_context_iterate.isra.20 at :0
+  [23] g_main_context_iteration at :0
+  [24] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [25] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [26] QCoreApplication::exec() at :0
+  [27] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [28] __libc_start_main at :0
+  [29] _start at :0
+  [30]  at :0
+"
+2026-06-02T20:12:31.674Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_read at :0
+  [4] _IO_new_file_underflow at :0
+  [5] __GI__IO_file_xsgetn at :0
+  [6] __GI__IO_fread at :0
+  [7] fortio_fread_record at ResInsight/ThirdParty/Ert/lib/ecl/fortio.c:529
+  [8] ecl_kw_fread_data at ResInsight/ThirdParty/Ert/lib/ecl/ecl_kw.cpp:1246
+  [9] ecl_kw_fread_alloc at ResInsight/ThirdParty/Ert/lib/ecl/ecl_kw.cpp:1562
+  [10] ecl_file_kw_load_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_kw.cpp:243
+  [11] ecl_file_view_get_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_view.cpp:149
+  [12] well_state_add_connections__ at ResInsight/ThirdParty/Ert/lib/ecl/well_state.cpp:435
+  [13] well_state_add_global_connections at ResInsight/ThirdParty/Ert/lib/ecl/well_state.cpp:449
+  [14] well_state_alloc_from_file2 at ResInsight/ThirdParty/Ert/lib/ecl/well_state.cpp:610
+  [15] well_info_add_wells2 at ResInsight/ThirdParty/Ert/lib/ecl/well_info.cpp:286
+  [16] well_info_add_UNRST_wells2 at ResInsight/ThirdParty/Ert/lib/ecl/well_info.cpp:316
+  [17] RifReaderEclipseWell::readWellCells(RifEclipseRestartDataAccess*, RigEclipseCaseData*, std::vector<QDateTime, std::allocator<QDateTime> >, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, bool) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseWell.cpp:464
+  [18] RifReaderEclipseOutput::open(QString const&, RigEclipseCaseData*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp:523
+  [19] RimEclipseResultCase::importGridAndResultMetaData(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultCase.cpp:261
+  [20] RiaImportEclipseCaseTools::openEclipseCaseShowTimeStepFilterImpl(QString const&, bool, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:372
+  [21] RiaImportEclipseCaseTools::openEclipseCasesFromFile(QList<QString> const&, bool, std::map<QString, int, std::less<QString>, std::allocator<std::pair<QString const, int> > >*, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:107
+  [22] RicImportGeneralDataFeature::openEclipseCaseFromFileNames(QList<QString> const&, bool, std::vector<int, std::allocator<int> >&, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:362
+  [23] RicImportGeneralDataFeature::openEclipseFilesFromFileNames(QList<QString> const&, bool, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:104
+  [24] RicfLoadCase::execute() at ResInsight/ApplicationLibCode/CommandFileInterface/RicfLoadCase.cpp:77
+  [25] RiaGrpcCommandService::Execute(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) at ResInsight/GrpcInterface/RiaGrpcCommandService.cpp:92
+  [26] grpc::Status std::__invoke_impl<grpc::Status, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*>(std::__invoke_memfun_ref, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*&&, rips::CommandParams const*&&, rips::CommandReply*&&) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/invoke.h:67
+  [27] std::function<grpc::Status (RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*)>::operator()(RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:591
+  [28] RiaGrpcServerImpl::processAllQueuedRequests() at ResInsight/GrpcInterface/RiaGrpcServer.cpp:200
+  [29] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:115
+  [30] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:33
+  [31]  at :0
+  [32] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [33] QObject::event(QEvent*) at :0
+  [34] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [35] QTimerInfoList::activateTimers() at :0
+  [36]  at :0
+  [37] g_main_context_dispatch at :0
+  [38] g_main_context_iterate.isra.20 at :0
+  [39] g_main_context_iteration at :0
+  [40] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [41] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [42] QCoreApplication::exec() at :0
+  [43] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [44] __libc_start_main at :0
+  [45] _start at :0
+  [46]  at :0
+"
+2026-06-02T20:12:31.674Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] cvf::Vector3<double>::Vector3() at ResInsight/Fwk/VizFwk/LibCore/cvfVector3.inl:69
+  [4] std::vector<cvf::AABBTreeNodeLeaf, std::allocator<cvf::AABBTreeNodeLeaf> >::resize(unsigned long) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/stl_vector.h:1016
+  [5] cvf::AABBTree::buildTree() at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:474
+  [6] cvf::BoundingBoxTreeImpl::buildTree(std::vector<cvf::BoundingBox, std::allocator<cvf::BoundingBox> > const&, std::vector<std::vector<int, std::allocator<int> >, std::allocator<std::vector<int, std::allocator<int> > > > const&) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:816
+  [7] cvf::BoundingBoxTree::buildTreeFromBoundingBoxes(std::vector<cvf::BoundingBox, std::allocator<cvf::BoundingBox> > const&, std::vector<unsigned long, std::allocator<unsigned long> > const*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:948
+  [8] RigMainGrid::buildCellSearchTree() const at ResInsight/ApplicationLibCode/ReservoirDataModel/RigMainGrid.cpp:939
+  [9] RigMainGrid::doBuildCellSearchTree(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*) const at ResInsight/ApplicationLibCode/ReservoirDataModel/RigMainGrid.cpp:870
+  [10] RigMainGrid::computeCachedData(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*) at ResInsight/ApplicationLibCode/ReservoirDataModel/RigMainGrid.cpp:277
+  [11] RimEclipseCase::computeCachedData() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCase.cpp:714
+  [12] RimEclipseResultCase::importGridAndResultMetaData(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultCase.cpp:297
+  [13] RiaImportEclipseCaseTools::openEclipseCaseShowTimeStepFilterImpl(QString const&, bool, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:372
+  [14] RiaImportEclipseCaseTools::openEclipseCasesFromFile(QList<QString> const&, bool, std::map<QString, int, std::less<QString>, std::allocator<std::pair<QString const, int> > >*, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:107
+  [15] RicImportGeneralDataFeature::openEclipseCaseFromFileNames(QList<QString> const&, bool, std::vector<int, std::allocator<int> >&, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:362
+  [16] RicImportGeneralDataFeature::openEclipseFilesFromFileNames(QList<QString> const&, bool, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:104
+  [17] RicfLoadCase::execute() at ResInsight/ApplicationLibCode/CommandFileInterface/RicfLoadCase.cpp:77
+  [18] RiaGrpcCommandService::Execute(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) at ResInsight/GrpcInterface/RiaGrpcCommandService.cpp:92
+  [19] grpc::Status std::__invoke_impl<grpc::Status, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*>(std::__invoke_memfun_ref, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*&&, rips::CommandParams const*&&, rips::CommandReply*&&) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/invoke.h:67
+  [20] std::function<grpc::Status (RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*)>::operator()(RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:591
+  [21] RiaGrpcServerImpl::processAllQueuedRequests() at ResInsight/GrpcInterface/RiaGrpcServer.cpp:200
+  [22] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:115
+  [23] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:33
+  [24]  at :0
+  [25] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [26] QObject::event(QEvent*) at :0
+  [27] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [28] QTimerInfoList::activateTimers() at :0
+  [29]  at :0
+  [30] g_main_context_dispatch at :0
+  [31] g_main_context_iterate.isra.20 at :0
+  [32] g_main_context_iteration at :0
+  [33] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [34] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [35] QCoreApplication::exec() at :0
+  [36] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [37] __libc_start_main at :0
+  [38] _start at :0
+  [39]  at :0
+"
+2026-06-02T20:12:31.674Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] cvf::Vector3<double>::operator=(cvf::Vector3<double> const&) at ResInsight/Fwk/VizFwk/LibCore/cvfVector3.inl:140
+  [4] cvf::BoundingBoxTree::buildTreeFromBoundingBoxes(std::vector<cvf::BoundingBox, std::allocator<cvf::BoundingBox> > const&, std::vector<unsigned long, std::allocator<unsigned long> > const*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:948
+  [5] RigMainGrid::buildCellSearchTree() const at ResInsight/ApplicationLibCode/ReservoirDataModel/RigMainGrid.cpp:939
+  [6] RigMainGrid::doBuildCellSearchTree(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*) const at ResInsight/ApplicationLibCode/ReservoirDataModel/RigMainGrid.cpp:870
+  [7] RigMainGrid::computeCachedData(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*) at ResInsight/ApplicationLibCode/ReservoirDataModel/RigMainGrid.cpp:277
+  [8] RimEclipseCase::computeCachedData() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCase.cpp:714
+  [9] RimEclipseResultCase::importGridAndResultMetaData(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultCase.cpp:297
+  [10] RiaImportEclipseCaseTools::openEclipseCaseShowTimeStepFilterImpl(QString const&, bool, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:372
+  [11] RiaImportEclipseCaseTools::openEclipseCasesFromFile(QList<QString> const&, bool, std::map<QString, int, std::less<QString>, std::allocator<std::pair<QString const, int> > >*, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:107
+  [12] RicImportGeneralDataFeature::openEclipseCaseFromFileNames(QList<QString> const&, bool, std::vector<int, std::allocator<int> >&, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:362
+  [13] RicImportGeneralDataFeature::openEclipseFilesFromFileNames(QList<QString> const&, bool, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:104
+  [14] RicfLoadCase::execute() at ResInsight/ApplicationLibCode/CommandFileInterface/RicfLoadCase.cpp:77
+  [15] RiaGrpcCommandService::Execute(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) at ResInsight/GrpcInterface/RiaGrpcCommandService.cpp:92
+  [16] grpc::Status std::__invoke_impl<grpc::Status, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*>(std::__invoke_memfun_ref, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*&&, rips::CommandParams const*&&, rips::CommandReply*&&) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/invoke.h:67
+  [17] std::function<grpc::Status (RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*)>::operator()(RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:591
+  [18] RiaGrpcServerImpl::processAllQueuedRequests() at ResInsight/GrpcInterface/RiaGrpcServer.cpp:200
+  [19] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:115
+  [20] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:33
+  [21]  at :0
+  [22] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [23] QObject::event(QEvent*) at :0
+  [24] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [25] QTimerInfoList::activateTimers() at :0
+  [26]  at :0
+  [27] g_main_context_dispatch at :0
+  [28] g_main_context_iterate.isra.20 at :0
+  [29] g_main_context_iteration at :0
+  [30] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [31] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [32] QCoreApplication::exec() at :0
+  [33] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [34] __libc_start_main at :0
+  [35] _start at :0
+  [36]  at :0
+"
+2026-06-02T20:12:31.642Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3]  at :0
+  [4]  at :0
+  [5]  at :0
+  [6]  at :0
+  [7]  at :0
+  [8] QRegularExpression::isValid() const at :0
+  [9] QString::replace(QRegularExpression const&, QString const&) at :0
+  [10] RiaTextStringTools::replaceTemplateTextWithValues(QString const&, std::map<QString, QString, std::less<QString>, std::allocator<std::pair<QString const, QString> > > const&) at ResInsight/ApplicationLibCode/Application/Tools/RiaTextStringTools.cpp:178
+  [11] RimDepthTrackPlot::createPlotNameFromTemplate(QString const&) const at ResInsight/ApplicationLibCode/ProjectDataModel/RimDepthTrackPlot.cpp:608
+  [12] RimDepthTrackPlot::createAutoName() const at ResInsight/ApplicationLibCode/ProjectDataModel/RimDepthTrackPlot.cpp:712
+  [13] RimDepthTrackPlot::performAutoNameUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimDepthTrackPlot.cpp:788
+  [14] non-virtual thunk to RimDepthTrackPlot::onLoadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimDepthTrackPlot.h:196
+  [15] RimViewWindow::loadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimViewWindow.cpp:88
+  [16] non-virtual thunk to RimWellLogPlotCollection::loadDataAndUpdateAllPlots() at ResInsight/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogPlotCollection.h:66
+  [17] RiaPlotCollectionScheduler::performScheduledUpdates() at ResInsight/ApplicationLibCode/Application/RiaPlotCollectionScheduler.cpp:69
+  [18]  at :0
+  [19] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [20] QObject::event(QEvent*) at :0
+  [21] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [22] QTimerInfoList::activateTimers() at :0
+  [23]  at :0
+  [24] g_main_context_dispatch at :0
+  [25] g_main_context_iterate.isra.20 at :0
+  [26] g_main_context_iteration at :0
+  [27] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [28] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [29] QCoreApplication::exec() at :0
+  [30] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [31] __libc_start_main at :0
+  [32] _start at :0
+  [33]  at :0
+"
+2026-06-02T20:12:31.626Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3]  at :0
+  [4]  at :0
+  [5]  at :0
+  [6]  at :0
+  [7]  at :0
+  [8]  at :0
+  [9] QRegularExpression::isValid() const at :0
+  [10] QString::replace(QRegularExpression const&, QString const&) at :0
+  [11] RiaTextStringTools::replaceTemplateTextWithValues(QString const&, std::map<QString, QString, std::less<QString>, std::allocator<std::pair<QString const, QString> > > const&) at ResInsight/ApplicationLibCode/Application/Tools/RiaTextStringTools.cpp:178
+  [12] RimDepthTrackPlot::createPlotNameFromTemplate(QString const&) const at ResInsight/ApplicationLibCode/ProjectDataModel/RimDepthTrackPlot.cpp:608
+  [13] RimDepthTrackPlot::createAutoName() const at ResInsight/ApplicationLibCode/ProjectDataModel/RimDepthTrackPlot.cpp:712
+  [14] RimDepthTrackPlot::performAutoNameUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimDepthTrackPlot.cpp:788
+  [15] non-virtual thunk to RimDepthTrackPlot::onLoadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimDepthTrackPlot.h:196
+  [16] RimViewWindow::loadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimViewWindow.cpp:88
+  [17] non-virtual thunk to RimWellLogPlotCollection::loadDataAndUpdateAllPlots() at ResInsight/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogPlotCollection.h:66
+  [18] RiaPlotCollectionScheduler::performScheduledUpdates() at ResInsight/ApplicationLibCode/Application/RiaPlotCollectionScheduler.cpp:69
+  [19]  at :0
+  [20] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [21] QObject::event(QEvent*) at :0
+  [22] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [23] QTimerInfoList::activateTimers() at :0
+  [24]  at :0
+  [25] g_main_context_dispatch at :0
+  [26] g_main_context_iterate.isra.20 at :0
+  [27] g_main_context_iteration at :0
+  [28] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [29] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [30] QCoreApplication::exec() at :0
+  [31] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [32] __libc_start_main at :0
+  [33] _start at :0
+  [34]  at :0
+"
+2026-06-02T20:12:31.53Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __libc_poll at :0
+  [4] g_main_context_iterate.isra.20 at :0
+  [5] g_main_context_iteration at :0
+  [6] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [7] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [8] QCoreApplication::exec() at :0
+  [9] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [10] __libc_start_main at :0
+  [11] _start at :0
+  [12]  at :0
+"
+2026-06-02T20:12:31.511Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __libc_poll at :0
+  [4] g_main_context_iterate.isra.20 at :0
+  [5] g_main_context_iteration at :0
+  [6] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [7] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [8] QThread::exec() at :0
+  [9]  at :0
+  [10] start_thread at :0
+  [11] __GI___clone at :0
+  [12]  at :0
+"
+2026-06-02T20:12:31.249Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __free at :0
+  [4]  at :0
+  [5] QRegularExpression::match(QString const&, long long, QRegularExpression::MatchType, QFlags<QRegularExpression::MatchOption>) const at :0
+  [6] QRegularExpression::globalMatch(QString const&, long long, QRegularExpression::MatchType, QFlags<QRegularExpression::MatchOption>) const at :0
+  [7] QString::replace(QRegularExpression const&, QString const&) at :0
+  [8] RiaTextStringTools::replaceTemplateTextWithValues(QString const&, std::map<QString, QString, std::less<QString>, std::allocator<std::pair<QString const, QString> > > const&) at ResInsight/ApplicationLibCode/Application/Tools/RiaTextStringTools.cpp:178
+  [9] RimDepthTrackPlot::createPlotNameFromTemplate(QString const&) const at ResInsight/ApplicationLibCode/ProjectDataModel/RimDepthTrackPlot.cpp:608
+  [10] RimDepthTrackPlot::createAutoName() const at ResInsight/ApplicationLibCode/ProjectDataModel/RimDepthTrackPlot.cpp:712
+  [11] RimDepthTrackPlot::performAutoNameUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimDepthTrackPlot.cpp:788
+  [12] non-virtual thunk to RimDepthTrackPlot::onLoadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimDepthTrackPlot.h:196
+  [13] RimViewWindow::loadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimViewWindow.cpp:88
+  [14] non-virtual thunk to RimWellLogPlotCollection::loadDataAndUpdateAllPlots() at ResInsight/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogPlotCollection.h:66
+  [15] RiaPlotCollectionScheduler::performScheduledUpdates() at ResInsight/ApplicationLibCode/Application/RiaPlotCollectionScheduler.cpp:69
+  [16]  at :0
+  [17] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [18] QObject::event(QEvent*) at :0
+  [19] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [20] QTimerInfoList::activateTimers() at :0
+  [21]  at :0
+  [22] g_main_context_dispatch at :0
+  [23] g_main_context_iterate.isra.20 at :0
+  [24] g_main_context_iteration at :0
+  [25] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [26] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [27] QCoreApplication::exec() at :0
+  [28] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [29] __libc_start_main at :0
+  [30] _start at :0
+  [31]  at :0
+"
+2026-06-02T20:05:08.552Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] std::terminate() at :0
+  [10] __cxa_rethrow at :0
+  [11] main at ResInsight/ApplicationExeCode/RiaMain.cpp:232
+  [12] __libc_start_main at :0
+  [13] _start at :0
+  [14]  at :0
+"
+2026-06-02T19:57:19.87Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] QEventLoop::exit(int) at :0
+  [4] QMenu::~QMenu() at :0
+  [5] RiuMainWindow::customMenuRequested(QPoint const&) at /private/f_resinsight_build/resbuild/qt/6.6.3/gcc_64/include/QtCore/qstring.h:1169
+  [6]  at :0
+  [7] QWidget::customContextMenuRequested(QPoint const&) at :0
+  [8] QWidget::event(QEvent*) at :0
+  [9] QFrame::event(QEvent*) at :0
+  [10] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [11] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [12] QApplication::notify(QObject*, QEvent*) at :0
+  [13] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [14] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [15]  at :0
+  [16]  at :0
+  [17] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [18] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [19] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [20] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [21] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [22]  at :0
+  [23] g_main_context_dispatch at :0
+  [24] g_main_context_iterate.isra.20 at :0
+  [25] g_main_context_iteration at :0
+  [26] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [27] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [28] QCoreApplication::exec() at :0
+  [29] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [30] __libc_start_main at :0
+  [31] _start at :0
+  [32]  at :0
+"
+2026-06-02T19:57:07.059Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] std::terminate() at :0
+  [10] __cxa_rethrow at :0
+  [11] main at ResInsight/ApplicationExeCode/RiaMain.cpp:232
+  [12] __libc_start_main at :0
+  [13] _start at :0
+  [14]  at :0
+"
+2026-06-02T16:20:04.653Z,2026.02.3-dev.01,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:167
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:263
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
+  [6] RicWellPathExportMswTableData::generateCellSegments(RimEclipseCase const*, RimWellPath const*) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswTableData.cpp:702
+  [7] RicWellPathExportMswTableData::extractSingleWellMsw_Legacy[abi:cxx11](RimEclipseCase*, RimWellPath*, bool, RicWellPathExportMswTableData::CompletionType, std::optional<QDateTime> const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswTableData.cpp:136
+  [8] RicWellPathExportMswTableData::extractSingleWellMswData[abi:cxx11](RimEclipseCase*, RimWellPath*, bool, RicWellPathExportMswTableData::CompletionType, std::optional<QDateTime> const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswTableData.cpp:80
+  [9] internal::exportSplitMswData(RicExportCompletionDataSettingsUi const&, QString const&, std::vector<RimWellPath*, std::allocator<RimWellPath*> > const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswCompletionsImpl.cpp:151
+  [10] RicWellPathExportCompletionDataFeature::prepareExportSettingsAndExportCompletions(QString const&, std::vector<RimWellPath*, std::allocator<RimWellPath*> > const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportCompletionDataFeature.cpp:178
+  [11] RicExportCompletionsForVisibleWellPathsFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportCompletionsForVisibleWellPathsFeature.cpp:75
+  [12] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+  [13]  at :0
+  [14] QAction::triggered(bool) at :0
+  [15] QAction::activate(QAction::ActionEvent) at :0
+  [16]  at :0
+  [17]  at :0
+  [18] QWidget::event(QEvent*) at :0
+  [19] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [20] QApplication::notify(QObject*, QEvent*) at :0
+  [21] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1825
+  [22] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [23] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [24]  at :0
+  [25]  at :0
+  [26] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [27] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1825
+  [28] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [29] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [30] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [31]  at :0
+  [32] g_main_context_dispatch at :0
+  [33] g_main_context_iterate.isra.20 at :0
+  [34] g_main_context_iteration at :0
+  [35] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [36] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [37]  at :0
+  [38] QMenu::exec(QPoint const&, QAction*) at :0
+  [39] RiuMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:2092
+  [40]  at :0
+  [41] QWidget::customContextMenuRequested(QPoint const&) at :0
+  [42] QWidget::event(QEvent*) at :0
+  [43] QFrame::event(QEvent*) at :0
+  [44] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [45] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [46] QApplication::notify(QObject*, QEvent*) at :0
+  [47] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1825
+  [48] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [49]  at :0
+  [50]  at :0
+  [51] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [52] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1825
+  [53] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [54] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [55] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [56]  at :0
+  [57] g_main_context_dispatch at :0
+  [58] g_main_context_iterate.isra.20 at :0
+  [59] g_main_context_iteration at :0
+  [60] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [61] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [62] QCoreApplication::exec() at :0
+  [63] main at ResInsight/ApplicationExeCode/RiaMain.cpp:229
+  [64] __libc_start_main at :0
+  [65] _start at :0
+  [66]  at :0
+"
+2026-06-02T16:18:34.409Z,2026.02.3-dev.01,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:167
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:263
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
+  [6] RicWellPathExportMswTableData::generateCellSegments(RimEclipseCase const*, RimWellPath const*) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswTableData.cpp:702
+  [7] RicWellPathExportMswTableData::extractSingleWellMsw_Legacy[abi:cxx11](RimEclipseCase*, RimWellPath*, bool, RicWellPathExportMswTableData::CompletionType, std::optional<QDateTime> const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswTableData.cpp:136
+  [8] RicWellPathExportMswTableData::extractSingleWellMswData[abi:cxx11](RimEclipseCase*, RimWellPath*, bool, RicWellPathExportMswTableData::CompletionType, std::optional<QDateTime> const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswTableData.cpp:80
+  [9] internal::exportSplitMswData(RicExportCompletionDataSettingsUi const&, QString const&, std::vector<RimWellPath*, std::allocator<RimWellPath*> > const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswCompletionsImpl.cpp:151
+  [10] RicWellPathExportCompletionDataFeature::prepareExportSettingsAndExportCompletions(QString const&, std::vector<RimWellPath*, std::allocator<RimWellPath*> > const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportCompletionDataFeature.cpp:178
+  [11] RicExportCompletionsForVisibleWellPathsFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportCompletionsForVisibleWellPathsFeature.cpp:75
+  [12] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+  [13]  at :0
+  [14] QAction::triggered(bool) at :0
+  [15] QAction::activate(QAction::ActionEvent) at :0
+  [16]  at :0
+  [17]  at :0
+  [18] QWidget::event(QEvent*) at :0
+  [19] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [20] QApplication::notify(QObject*, QEvent*) at :0
+  [21] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1825
+  [22] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [23] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [24]  at :0
+  [25]  at :0
+  [26] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [27] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1825
+  [28] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [29] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [30] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [31]  at :0
+  [32] g_main_context_dispatch at :0
+  [33] g_main_context_iterate.isra.20 at :0
+  [34] g_main_context_iteration at :0
+  [35] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [36] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [37]  at :0
+  [38] QMenu::exec(QPoint const&, QAction*) at :0
+  [39] RiuMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:2092
+  [40]  at :0
+  [41] QWidget::customContextMenuRequested(QPoint const&) at :0
+  [42] QWidget::event(QEvent*) at :0
+  [43] QFrame::event(QEvent*) at :0
+  [44] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [45] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [46] QApplication::notify(QObject*, QEvent*) at :0
+  [47] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1825
+  [48] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [49]  at :0
+  [50]  at :0
+  [51] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [52] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1825
+  [53] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [54] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [55] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [56]  at :0
+  [57] g_main_context_dispatch at :0
+  [58] g_main_context_iterate.isra.20 at :0
+  [59] g_main_context_iteration at :0
+  [60] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [61] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [62] QCoreApplication::exec() at :0
+  [63] main at ResInsight/ApplicationExeCode/RiaMain.cpp:229
+  [64] __libc_start_main at :0
+  [65] _start at :0
+  [66]  at :0
+"
+2026-06-02T11:49:12.47Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3]  at :0
+  [4] QComboBox::textActivated(QString const&) at :0
+  [5]  at :0
+  [6]  at :0
+  [7]  at :0
+  [8] QComboBoxPrivateContainer::itemSelected(QModelIndex const&) at :0
+  [9] QComboBoxPrivateContainer::eventFilter(QObject*, QEvent*) at :0
+  [10] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [11] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [12] QApplication::notify(QObject*, QEvent*) at :0
+  [13] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [14] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [15] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [16]  at :0
+  [17]  at :0
+  [18] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [19] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [20] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [21] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [22] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [23]  at :0
+  [24] g_main_context_dispatch at :0
+  [25] g_main_context_iterate.isra.20 at :0
+  [26] g_main_context_iteration at :0
+  [27] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [28] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [29] QCoreApplication::exec() at :0
+  [30] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [31] __libc_start_main at :0
+  [32] _start at :0
+  [33]  at :0
+"
+2026-06-02T11:34:47.01Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] caf::PdmObjectHandle::prepareForDelete() at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmObjectHandle.cpp:155
+  [4] caf::AsyncPdmObjectVectorDeleter<RimSummaryCase>::AsyncPdmObjectVectorDeleter(std::vector<RimSummaryCase*, std::allocator<RimSummaryCase*> >&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafAsyncObjectDeleter.inl:20
+  [5] RicCloseSummaryCaseFeature::deleteSummaryCases(std::vector<RimSummaryCase*, std::allocator<RimSummaryCase*> >) at ResInsight/ApplicationLibCode/Commands/RicCloseSummaryCaseFeature.cpp:99
+  [6] RicCloseSummaryCaseInCollectionFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/RicCloseSummaryCaseInCollectionFeature.cpp:79
+  [7] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+  [8]  at :0
+  [9] QAction::triggered(bool) at :0
+  [10] QAction::activate(QAction::ActionEvent) at :0
+  [11]  at :0
+  [12]  at :0
+  [13] QWidget::event(QEvent*) at :0
+  [14] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [15] QApplication::notify(QObject*, QEvent*) at :0
+  [16] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [17] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [18] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [19]  at :0
+  [20]  at :0
+  [21] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [22] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [23] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [24] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [25] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [26]  at :0
+  [27] g_main_context_dispatch at :0
+  [28] g_main_context_iterate.isra.20 at :0
+  [29] g_main_context_iteration at :0
+  [30] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [31] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [32]  at :0
+  [33] QMenu::exec(QPoint const&, QAction*) at :0
+  [34] RiuPlotMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp:1058
+  [35]  at :0
+  [36] QWidget::customContextMenuRequested(QPoint const&) at :0
+  [37] QWidget::event(QEvent*) at :0
+  [38] QFrame::event(QEvent*) at :0
+  [39] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [40] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [41] QApplication::notify(QObject*, QEvent*) at :0
+  [42] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [43] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [44]  at :0
+  [45]  at :0
+  [46] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [47] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [48] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [49] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [50] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [51]  at :0
+  [52] g_main_context_dispatch at :0
+  [53] g_main_context_iterate.isra.20 at :0
+  [54] g_main_context_iteration at :0
+  [55] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [56] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [57] QCoreApplication::exec() at :0
+  [58] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [59] __libc_start_main at :0
+  [60] _start at :0
+  [61]  at :0
+"
+2026-06-02T11:04:25.087Z,2026.02.3-dev.01,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:167
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:263
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
+  [6] RicWellPathExportMswTableData::generateCellSegments(RimEclipseCase const*, RimWellPath const*) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswTableData.cpp:702
+  [7] RicWellPathExportMswTableData::extractSingleWellMsw_Legacy[abi:cxx11](RimEclipseCase*, RimWellPath*, bool, RicWellPathExportMswTableData::CompletionType, std::optional<QDateTime> const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswTableData.cpp:136
+  [8] RicWellPathExportMswTableData::extractSingleWellMswData[abi:cxx11](RimEclipseCase*, RimWellPath*, bool, RicWellPathExportMswTableData::CompletionType, std::optional<QDateTime> const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswTableData.cpp:80
+  [9] internal::exportSplitMswData(RicExportCompletionDataSettingsUi const&, QString const&, std::vector<RimWellPath*, std::allocator<RimWellPath*> > const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswCompletionsImpl.cpp:151
+  [10] RicWellPathExportCompletionDataFeature::prepareExportSettingsAndExportCompletions(QString const&, std::vector<RimWellPath*, std::allocator<RimWellPath*> > const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportCompletionDataFeature.cpp:178
+  [11] RicWellPathExportCompletionDataFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportCompletionDataFeature.cpp:201
+  [12] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+  [13]  at :0
+  [14] QAction::triggered(bool) at :0
+  [15] QAction::activate(QAction::ActionEvent) at :0
+  [16]  at :0
+  [17]  at :0
+  [18] QWidget::event(QEvent*) at :0
+  [19] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [20] QApplication::notify(QObject*, QEvent*) at :0
+  [21] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1825
+  [22] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [23] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [24]  at :0
+  [25]  at :0
+  [26] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [27] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1825
+  [28] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [29] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [30] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [31]  at :0
+  [32] g_main_context_dispatch at :0
+  [33] g_main_context_iterate.isra.20 at :0
+  [34] g_main_context_iteration at :0
+  [35] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [36] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [37]  at :0
+  [38] QMenu::exec(QPoint const&, QAction*) at :0
+  [39] RiuMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:2092
+  [40]  at :0
+  [41] QWidget::customContextMenuRequested(QPoint const&) at :0
+  [42] QWidget::event(QEvent*) at :0
+  [43] QFrame::event(QEvent*) at :0
+  [44] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [45] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [46] QApplication::notify(QObject*, QEvent*) at :0
+  [47] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1825
+  [48] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [49]  at :0
+  [50]  at :0
+  [51] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [52] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1825
+  [53] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [54] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [55] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [56]  at :0
+  [57] g_main_context_dispatch at :0
+  [58] g_main_context_iterate.isra.20 at :0
+  [59] g_main_context_iteration at :0
+  [60] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [61] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [62] QCoreApplication::exec() at :0
+  [63] main at ResInsight/ApplicationExeCode/RiaMain.cpp:229
+  [64] __libc_start_main at :0
+  [65] _start at :0
+  [66]  at :0
+"
+2026-06-02T11:03:23.056Z,2026.02.3-dev.01,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:167
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:263
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
+  [6] RicWellPathExportMswTableData::generateCellSegments(RimEclipseCase const*, RimWellPath const*) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswTableData.cpp:702
+  [7] RicWellPathExportMswTableData::extractSingleWellMsw_Legacy[abi:cxx11](RimEclipseCase*, RimWellPath*, bool, RicWellPathExportMswTableData::CompletionType, std::optional<QDateTime> const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswTableData.cpp:136
+  [8] RicWellPathExportMswTableData::extractSingleWellMswData[abi:cxx11](RimEclipseCase*, RimWellPath*, bool, RicWellPathExportMswTableData::CompletionType, std::optional<QDateTime> const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswTableData.cpp:80
+  [9] internal::exportSplitMswData(RicExportCompletionDataSettingsUi const&, QString const&, std::vector<RimWellPath*, std::allocator<RimWellPath*> > const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswCompletionsImpl.cpp:151
+  [10] RicWellPathExportCompletionDataFeature::prepareExportSettingsAndExportCompletions(QString const&, std::vector<RimWellPath*, std::allocator<RimWellPath*> > const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportCompletionDataFeature.cpp:178
+  [11] RicExportCompletionsForVisibleWellPathsFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportCompletionsForVisibleWellPathsFeature.cpp:75
+  [12] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+  [13]  at :0
+  [14] QAction::triggered(bool) at :0
+  [15] QAction::activate(QAction::ActionEvent) at :0
+  [16]  at :0
+  [17]  at :0
+  [18] QWidget::event(QEvent*) at :0
+  [19] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [20] QApplication::notify(QObject*, QEvent*) at :0
+  [21] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1825
+  [22] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [23] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [24]  at :0
+  [25]  at :0
+  [26] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [27] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1825
+  [28] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [29] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [30] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [31]  at :0
+  [32] g_main_context_dispatch at :0
+  [33] g_main_context_iterate.isra.20 at :0
+  [34] g_main_context_iteration at :0
+  [35] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [36] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [37]  at :0
+  [38] QMenu::exec(QPoint const&, QAction*) at :0
+  [39] RiuMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:2092
+  [40]  at :0
+  [41] QWidget::customContextMenuRequested(QPoint const&) at :0
+  [42] QWidget::event(QEvent*) at :0
+  [43] QFrame::event(QEvent*) at :0
+  [44] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [45] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [46] QApplication::notify(QObject*, QEvent*) at :0
+  [47] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1825
+  [48] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [49]  at :0
+  [50]  at :0
+  [51] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [52] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1825
+  [53] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [54] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [55] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [56]  at :0
+  [57] g_main_context_dispatch at :0
+  [58] g_main_context_iterate.isra.20 at :0
+  [59] g_main_context_iteration at :0
+  [60] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [61] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [62] QCoreApplication::exec() at :0
+  [63] main at ResInsight/ApplicationExeCode/RiaMain.cpp:229
+  [64] __libc_start_main at :0
+  [65] _start at :0
+  [66]  at :0
+"
+2026-06-02T11:01:12.439Z,2026.02.3-dev.01,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:167
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:263
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
+  [6] RicWellPathExportMswTableData::generateCellSegments(RimEclipseCase const*, RimWellPath const*) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswTableData.cpp:702
+  [7] RicWellPathExportMswTableData::extractSingleWellMsw_Legacy[abi:cxx11](RimEclipseCase*, RimWellPath*, bool, RicWellPathExportMswTableData::CompletionType, std::optional<QDateTime> const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswTableData.cpp:136
+  [8] RicWellPathExportMswTableData::extractSingleWellMswData[abi:cxx11](RimEclipseCase*, RimWellPath*, bool, RicWellPathExportMswTableData::CompletionType, std::optional<QDateTime> const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswTableData.cpp:80
+  [9] internal::exportSplitMswData(RicExportCompletionDataSettingsUi const&, QString const&, std::vector<RimWellPath*, std::allocator<RimWellPath*> > const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswCompletionsImpl.cpp:151
+  [10] RicWellPathExportCompletionDataFeature::prepareExportSettingsAndExportCompletions(QString const&, std::vector<RimWellPath*, std::allocator<RimWellPath*> > const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportCompletionDataFeature.cpp:178
+  [11] RicExportCompletionsForVisibleWellPathsFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportCompletionsForVisibleWellPathsFeature.cpp:75
+  [12] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+  [13]  at :0
+  [14] QAction::triggered(bool) at :0
+  [15] QAction::activate(QAction::ActionEvent) at :0
+  [16]  at :0
+  [17]  at :0
+  [18] QWidget::event(QEvent*) at :0
+  [19] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [20] QApplication::notify(QObject*, QEvent*) at :0
+  [21] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1825
+  [22] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [23] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [24]  at :0
+  [25]  at :0
+  [26] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [27] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1825
+  [28] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [29] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [30] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [31]  at :0
+  [32] g_main_context_dispatch at :0
+  [33] g_main_context_iterate.isra.20 at :0
+  [34] g_main_context_iteration at :0
+  [35] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [36] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [37]  at :0
+  [38] QMenu::exec(QPoint const&, QAction*) at :0
+  [39] RiuMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:2092
+  [40]  at :0
+  [41] QWidget::customContextMenuRequested(QPoint const&) at :0
+  [42] QWidget::event(QEvent*) at :0
+  [43] QFrame::event(QEvent*) at :0
+  [44] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [45] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [46] QApplication::notify(QObject*, QEvent*) at :0
+  [47] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1825
+  [48] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [49]  at :0
+  [50]  at :0
+  [51] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [52] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1825
+  [53] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [54] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [55] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [56]  at :0
+  [57] g_main_context_dispatch at :0
+  [58] g_main_context_iterate.isra.20 at :0
+  [59] g_main_context_iteration at :0
+  [60] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [61] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [62] QCoreApplication::exec() at :0
+  [63] main at ResInsight/ApplicationExeCode/RiaMain.cpp:229
+  [64] __libc_start_main at :0
+  [65] _start at :0
+  [66]  at :0
+"
+2026-06-02T10:13:14.805Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] QWidgetPrivate::shouldPaintOnScreen() const at :0
+  [4] QWidgetRepaintManager::markNeedsFlush(QWidget*, QRegion const&, QPoint const&) at :0
+  [5] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [6] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [7] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [8] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [9] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [10] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [11] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [12] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [13] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [14] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [15] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [16] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [17] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [18] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [19] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [20] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [21] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [22] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [23] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [24] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [25] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [26] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [27] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [28] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [29] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [30] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [31] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [32] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [33] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [34] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [35] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [36] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [37] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [38] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [39] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [40] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [41] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [42] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [43] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [44] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [45] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [46] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [47] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [48] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [49] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [50] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [51] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [52] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [53] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [54] QWidgetRepaintManager::paintAndFlush() at :0
+  [55] QWidget::event(QEvent*) at :0
+  [56] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [57] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [58] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [59] QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*) at :0
+  [60]  at :0
+  [61] g_main_context_dispatch at :0
+  [62] g_main_context_iterate.isra.20 at :0
+  [63] g_main_context_iteration at :0
+  [64] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [65] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [66] QCoreApplication::exec() at :0
+  [67] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [68] __libc_start_main at :0
+  [69] _start at :0
+  [70]  at :0
+"
+2026-06-02T09:03:25.291Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] std::__atomic_base<int>::load(std::memory_order) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/atomic_base.h:505
+  [4]  at :0
+  [5] QAbstractSlider::valueChanged(int) at :0
+  [6] QAbstractSlider::setValue(int) at :0
+  [7] QWidget::event(QEvent*) at :0
+  [8] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [9] QApplication::notify(QObject*, QEvent*) at :0
+  [10] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [11] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [12] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [13]  at :0
+  [14]  at :0
+  [15] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [16] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [17] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [18] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [19] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [20]  at :0
+  [21] g_main_context_dispatch at :0
+  [22] g_main_context_iterate.isra.20 at :0
+  [23] g_main_context_iteration at :0
+  [24] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [25] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [26] QCoreApplication::exec() at :0
+  [27] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [28] __libc_start_main at :0
+  [29] _start at :0
+  [30]  at :0
+"
+2026-06-02T07:15:41.229Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] QWidgetPrivate::shouldPaintOnScreen() const at :0
+  [4] QWidgetRepaintManager::markNeedsFlush(QWidget*, QRegion const&, QPoint const&) at :0
+  [5] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [6] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [7] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [8] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [9] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [10] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [11] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [12] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [13] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [14] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [15] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [16] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [17] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [18] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [19] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [20] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [21] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [22] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [23] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [24] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [25] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [26] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [27] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [28] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [29] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [30] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [31] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [32] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [33] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [34] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [35] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [36] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [37] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [38] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [39] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [40] QWidgetRepaintManager::paintAndFlush() at :0
+  [41] QWidget::event(QEvent*) at :0
+  [42] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [43] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [44] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [45] QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*) at :0
+  [46]  at :0
+  [47] g_main_context_dispatch at :0
+  [48] g_main_context_iterate.isra.20 at :0
+  [49] g_main_context_iteration at :0
+  [50] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [51] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [52] QCoreApplication::exec() at :0
+  [53] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [54] __libc_start_main at :0
+  [55] _start at :0
+  [56]  at :0
+"
+2026-06-02T07:05:17.144Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] caf::TickMarkGenerator::roundUpToLog_1_2_5_10(double) at ResInsight/Fwk/AppFwk/CommonCode/cafTickMarkGenerator.h:74
+  [6] caf::OverlayScaleLegend::updateFromCamera(cvf::Camera const*) at ResInsight/Fwk/AppFwk/cafVizExtensions/cafOverlayScaleLegend.cpp:762
+  [7] RiuViewer::optimizeClippingPlanes() at ResInsight/ApplicationLibCode/UserInterface/RiuViewer.cpp:1062
+  [8] caf::Viewer::paintGL() at ResInsight/Fwk/AppFwk/cafViewer/cafViewer.cpp:884
+  [9]  at :0
+  [10] QWidget::event(QEvent*) at :0
+  [11] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [12] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [13] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [14] QWidgetPrivate::sendPaintEvent(QRegion const&) at :0
+  [15] QOpenGLWidget::resizeEvent(QResizeEvent*) at :0
+  [16] QWidget::event(QEvent*) at :0
+  [17] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [18] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [19] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [20] QWidgetPrivate::setGeometry_sys(int, int, int, int, bool) at :0
+  [21] QWidget::setGeometry(QRect const&) at :0
+  [22] QWidgetItem::setGeometry(QRect const&) at :0
+  [23] QBoxLayout::setGeometry(QRect const&) at :0
+  [24] QLayoutPrivate::doResize() at :0
+  [25] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [26] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [27] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [28] QWidgetPrivate::setGeometry_sys(int, int, int, int, bool) at :0
+  [29] QWidget::setGeometry(QRect const&) at :0
+  [30] QWidgetItem::setGeometry(QRect const&) at :0
+  [31] QBoxLayout::setGeometry(QRect const&) at :0
+  [32] QLayoutPrivate::doResize() at :0
+  [33] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [34] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [35] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [36] QWidgetPrivate::setGeometry_sys(int, int, int, int, bool) at :0
+  [37] QWidget::resize(QSize const&) at :0
+  [38] QMdiArea::resizeEvent(QResizeEvent*) at :0
+  [39] QWidget::event(QEvent*) at :0
+  [40] QFrame::event(QEvent*) at :0
+  [41] QMdiArea::viewportEvent(QEvent*) at :0
+  [42] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [43] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [44] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [45] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [46] QWidgetPrivate::setGeometry_sys(int, int, int, int, bool) at :0
+  [47] QWidget::setGeometry(QRect const&) at :0
+  [48]  at :0
+  [49] QAbstractScrollArea::event(QEvent*) at :0
+  [50] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [51] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [52] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [53] QWidgetPrivate::setGeometry_sys(int, int, int, int, bool) at :0
+  [54] QWidget::setGeometry(QRect const&) at :0
+  [55] QWidgetItem::setGeometry(QRect const&) at :0
+  [56] QBoxLayout::setGeometry(QRect const&) at :0
+  [57] QLayoutPrivate::doResize() at :0
+  [58] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [59] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [60] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [61] QWidgetPrivate::setGeometry_sys(int, int, int, int, bool) at :0
+  [62] QWidget::setGeometry(QRect const&) at :0
+  [63] QWidgetItem::setGeometry(QRect const&) at :0
+  [64] QBoxLayout::setGeometry(QRect const&) at :0
+  [65] QLayoutPrivate::doResize() at :0
+  [66] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [67] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [68] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [69] QWidgetPrivate::setGeometry_sys(int, int, int, int, bool) at :0
+  [70] QWidget::setGeometry(QRect const&) at :0
+  [71]  at :0
+  [72]  at :0
+  [73] QWidget::event(QEvent*) at :0
+  [74] QFrame::event(QEvent*) at :0
+  [75] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [76] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [77] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [78] QWidgetPrivate::setGeometry_sys(int, int, int, int, bool) at :0
+  [79] QWidget::setGeometry(QRect const&) at :0
+  [80]  at :0
+  [81]  at :0
+  [82] QWidget::event(QEvent*) at :0
+  [83] QFrame::event(QEvent*) at :0
+  [84] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [85] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [86] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [87] QWidgetPrivate::setGeometry_sys(int, int, int, int, bool) at :0
+  [88] QWidget::setGeometry(QRect const&) at :0
+  [89]  at :0
+  [90]  at :0
+  [91] QWidget::event(QEvent*) at :0
+  [92] QFrame::event(QEvent*) at :0
+  [93] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [94] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [95] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [96] QWidgetPrivate::setGeometry_sys(int, int, int, int, bool) at :0
+  [97] QWidget::setGeometry(QRect const&) at :0
+  [98] QWidgetItem::setGeometry(QRect const&) at :0
+  [99]  at :0
+  [100] QGridLayout::setGeometry(QRect const&) at :0
+  [101] QLayoutPrivate::doResize() at :0
+  [102] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [103] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [104] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [105] QWidgetPrivate::setGeometry_sys(int, int, int, int, bool) at :0
+  [106] QWidget::setGeometry(QRect const&) at :0
+  [107] QWidget::qt_metacall(QMetaObject::Call, int, void**) at :0
+  [108] QFrame::qt_metacall(QMetaObject::Call, int, void**) at :0
+  [109] ads::CDockContainerWidget::qt_metacall(QMetaObject::Call, int, void**) at ResInsight/cmakebuild/ThirdParty/qtadvanceddocking/src/qtadvanceddocking-qt6_autogen/EWIEGA46WW/moc_DockContainerWidget.cpp:212
+  [110] ads::CDockManager::qt_metacall(QMetaObject::Call, int, void**) at ResInsight/cmakebuild/ThirdParty/qtadvanceddocking/src/qtadvanceddocking-qt6_autogen/EWIEGA46WW/moc_DockManager.cpp:480
+  [111] QPropertyAnimation::updateCurrentValue(QVariant const&) at :0
+  [112]  at :0
+  [113] QPropertyAnimation::updateState(QAbstractAnimation::State, QAbstractAnimation::State) at :0
+  [114] QAbstractAnimationPrivate::setState(QAbstractAnimation::State) at :0
+  [115]  at :0
+  [116]  at :0
+  [117]  at :0
+  [118]  at :0
+  [119] QLayoutPrivate::doResize() at :0
+  [120] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [121] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [122] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [123]  at :0
+  [124]  at :0
+  [125] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [126] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [127] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [128] QGuiApplicationPrivate::processGeometryChangeEvent(QWindowSystemInterfacePrivate::GeometryChangeEvent*) at :0
+  [129] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [130]  at :0
+  [131] g_main_context_dispatch at :0
+  [132] g_main_context_iterate.isra.20 at :0
+  [133] g_main_context_iteration at :0
+  [134] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [135] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [136] QCoreApplication::exec() at :0
+  [137] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [138] __libc_start_main at :0
+  [139] _start at :0
+  [140]  at :0
+"
+2026-06-02T06:59:16.143Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] std::terminate() at :0
+  [10] __cxa_rethrow at :0
+  [11] main at ResInsight/ApplicationExeCode/RiaMain.cpp:232
+  [12] __libc_start_main at :0
+  [13] _start at :0
+  [14]  at :0
+"
+2026-06-02T04:22:53.943Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] void QWidgetPrivate::update<QRect>(QRect) at :0
+  [4] QWidget::update() at :0
+  [5] QWidget::focusOutEvent(QFocusEvent*) at :0
+  [6] QWidget::event(QEvent*) at :0
+  [7] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [8] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [9] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [10] QApplicationPrivate::setFocusWidget(QWidget*, Qt::FocusReason) at :0
+  [11] QWidget::setFocus(Qt::FocusReason) at :0
+  [12] QApplicationPrivate::giveFocusAccordingToFocusPolicy(QWidget*, QEvent*, QPoint) at :0
+  [13] QApplication::notify(QObject*, QEvent*) at :0
+  [14] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [15] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [16] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [17]  at :0
+  [18]  at :0
+  [19] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [20] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [21] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [22] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [23] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [24]  at :0
+  [25] g_main_context_dispatch at :0
+  [26] g_main_context_iterate.isra.20 at :0
+  [27] g_main_context_iteration at :0
+  [28] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [29] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [30] QCoreApplication::exec() at :0
+  [31] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [32] __libc_start_main at :0
+  [33] _start at :0
+  [34]  at :0
+"
+2026-06-01T21:47:26.942Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] cvf::ref<RigFaultsPrCellAccumulator>::isNull() const at ResInsight/Fwk/VizFwk/LibCore/cvfObject.inl:327
+  [4] RiuViewerCommands::displayContextMenu(QMouseEvent*) at ResInsight/ApplicationLibCode/UserInterface/RiuViewerCommands.cpp:425
+  [5] QWidget::event(QEvent*) at :0
+  [6] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [7] QApplication::notify(QObject*, QEvent*) at :0
+  [8] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [9] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [10] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [11]  at :0
+  [12]  at :0
+  [13] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [14] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [15] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [16] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [17] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [18]  at :0
+  [19] g_main_context_dispatch at :0
+  [20] g_main_context_iterate.isra.20 at :0
+  [21] g_main_context_iteration at :0
+  [22] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [23] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [24] QCoreApplication::exec() at :0
+  [25] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [26] __libc_start_main at :0
+  [27] _start at :0
+  [28]  at :0
+"
+2026-06-01T21:28:34.266Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] std::terminate() at :0
+  [10] __cxa_rethrow at :0
+  [11] main at ResInsight/ApplicationExeCode/RiaMain.cpp:232
+  [12] __libc_start_main at :0
+  [13] _start at :0
+  [14]  at :0
+"
+2026-06-01T13:39:24.146Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] fmemopen_write at :0
+  [6] new_heap at :0
+  [7] _int_free at :0
+  [8] __GI___libc_realloc at :0
+  [9] start_thread at :0
+  [10] __GI___clone at :0
+  [11]  at :0
+"
+2026-06-01T12:43:51.841Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] ecl_kw_get_data_type at ResInsight/ThirdParty/Ert/lib/ecl/ecl_kw.cpp:1776
+  [4] ecl_file_kw_assert_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_kw.cpp:211
+  [5] ecl_file_kw_load_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_kw.cpp:244
+  [6] ecl_file_view_get_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_view.cpp:149
+  [7] RifEclipseOutputFileTools::keywordData(ecl_file_struct const*, QString const&, unsigned long, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseOutputFileTools.cpp:305
+  [8] RifReaderEclipseOutput::staticResult(QString const&, RiaDefines::PorosityModelType, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp:999
+  [9] RigCaseCellResultsData::findOrLoadKnownScalarResult(RigEclipseResultAddress const&) at ResInsight/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp:1558
+  [10] RigCaseCellResultsData::ensureKnownResultLoaded(RigEclipseResultAddress const&) at ResInsight/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp:1264
+  [11] RimEclipseResultDefinition::loadResult() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:1134
+  [12] RimEclipseCellColors::loadResult() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCellColors.cpp:260
+  [13] RimEclipseResultDefinition::loadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:533
+  [14] RimEclipseResultDefinition::fieldChangedByUi(caf::PdmFieldHandle const*, QVariant const&, QVariant const&) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:305
+  [15] RimEclipseCellColors::fieldChangedByUi(caf::PdmFieldHandle const*, QVariant const&, QVariant const&) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCellColors.cpp:90
+  [16] caf::PdmUiFieldHandle::notifyFieldChanged(QVariant const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiFieldHandle.cpp:74
+  [17] caf::PdmFieldUiCap<caf::PdmField<QString> >::setValueFromUiEditor(QVariant const&, bool) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafInternalPdmUiFieldCapability.inl:110
+  [18] caf::PdmUiCommandSystemProxy::setUiValueToField(caf::PdmUiFieldHandle*, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiCommandSystemProxy.cpp:122
+  [19] caf::PdmUiTreeSelectionQModel::setData(QModelIndex const&, QVariant const&, int) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionQModel.cpp:482
+  [20] QSortFilterProxyModel::setData(QModelIndex const&, QVariant const&, int) at :0
+  [21] caf::PdmUiTreeSelectionEditor::currentChanged(QModelIndex const&) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionEditor.cpp:812
+  [22] caf::PdmUiTreeSelectionEditor::slotClicked(QModelIndex const&) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionEditor.cpp:759
+  [23]  at :0
+  [24] QAbstractItemView::clicked(QModelIndex const&) at :0
+  [25] QAbstractItemView::mouseReleaseEvent(QMouseEvent*) at :0
+  [26] QWidget::event(QEvent*) at :0
+  [27] QFrame::event(QEvent*) at :0
+  [28] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [29] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [30] QApplication::notify(QObject*, QEvent*) at :0
+  [31] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [32] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [33] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [34]  at :0
+  [35]  at :0
+  [36] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [37] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [38] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [39] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [40] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [41]  at :0
+  [42] g_main_context_dispatch at :0
+  [43] g_main_context_iterate.isra.20 at :0
+  [44] g_main_context_iteration at :0
+  [45] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [46] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [47] QCoreApplication::exec() at :0
+  [48] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [49] __libc_start_main at :0
+  [50] _start at :0
+  [51]  at :0
+"
+2026-06-01T11:02:54.109Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] QDateTime::isValid() const at :0
+  [4] QDateTime::equals(QDateTime const&) const at :0
+  [5] operator==(QDateTime const&, QDateTime const&) at /private/f_resinsight_build/resbuild/qt/6.6.3/gcc_64/include/QtCore/qdatetime.h:526
+  [6] operator() at ResInsight/ApplicationLibCode/ProjectDataModel/Flow/RimWellAllocationOverTimePlot.cpp:813
+  [7] RimWellAllocationOverTimePlot::setValidTimeStepRangeForCase() at ResInsight/ApplicationLibCode/ProjectDataModel/Flow/RimWellAllocationOverTimePlot.cpp:815
+  [8] RimWellAllocationOverTimePlot::setFromSimulationWell(RimSimWellInView*) at ResInsight/ApplicationLibCode/ProjectDataModel/Flow/RimWellAllocationOverTimePlot.cpp:164
+  [9] RicShowWellAllocationPlotFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/FlowCommands/RicShowWellAllocationPlotFeature.cpp:99
+  [10] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+  [11]  at :0
+  [12] QAction::triggered(bool) at :0
+  [13] QAction::activate(QAction::ActionEvent) at :0
+  [14]  at :0
+  [15]  at :0
+  [16] QWidget::event(QEvent*) at :0
+  [17] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [18] QApplication::notify(QObject*, QEvent*) at :0
+  [19] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [20] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [21] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [22]  at :0
+  [23]  at :0
+  [24] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [25] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [26] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [27] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [28] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [29]  at :0
+  [30] g_main_context_dispatch at :0
+  [31] g_main_context_iterate.isra.20 at :0
+  [32] g_main_context_iteration at :0
+  [33] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [34] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [35]  at :0
+  [36] QMenu::exec(QPoint const&, QAction*) at :0
+  [37] RiuMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:2056
+  [38]  at :0
+  [39] QWidget::customContextMenuRequested(QPoint const&) at :0
+  [40] QWidget::event(QEvent*) at :0
+  [41] QFrame::event(QEvent*) at :0
+  [42] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [43] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [44] QApplication::notify(QObject*, QEvent*) at :0
+  [45] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [46] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [47]  at :0
+  [48]  at :0
+  [49] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [50] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [51] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [52] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [53] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [54]  at :0
+  [55] g_main_context_dispatch at :0
+  [56] g_main_context_iterate.isra.20 at :0
+  [57] g_main_context_iteration at :0
+  [58] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [59] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [60] QCoreApplication::exec() at :0
+  [61] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [62] __libc_start_main at :0
+  [63] _start at :0
+  [64]  at :0
+"
+2026-06-01T08:24:29.915Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] QAbstractSpinBox::lineEdit() const at :0
+  [4] QAbstractSpinBox::text() const at :0
+  [5] caf::PdmUiSliderEditor::writeValueToField() at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiSliderEditor.cpp:190
+  [6]  at :0
+  [7] QAbstractSlider::valueChanged(int) at :0
+  [8] QAbstractSlider::setValue(int) at :0
+  [9] QWidget::event(QEvent*) at :0
+  [10] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [11] QApplication::notify(QObject*, QEvent*) at :0
+  [12] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [13] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [14] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [15]  at :0
+  [16]  at :0
+  [17] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [18] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [19] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [20] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [21] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [22]  at :0
+  [23] g_main_context_dispatch at :0
+  [24] g_main_context_iterate.isra.20 at :0
+  [25] g_main_context_iteration at :0
+  [26] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [27] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [28] QCoreApplication::exec() at :0
+  [29] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [30] __libc_start_main at :0
+  [31] _start at :0
+  [32]  at :0
+"
+2026-06-01T06:23:42.554Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3]  at :0
+  [4]  at :0
+  [5]  at :0
+  [6] cvf::PrimitiveSetIndexedUInt::render(cvf::OpenGLContext*) const at ResInsight/Fwk/VizFwk/LibRender/cvfPrimitiveSetIndexedUInt.cpp:125
+  [7] cvf::DrawableGeo::render(cvf::OpenGLContext*, cvf::ShaderProgram*, cvf::MatrixState const&) at ResInsight/Fwk/VizFwk/LibRender/cvfDrawableGeo.cpp:141
+  [8] cvf::RenderEngine::render(cvf::OpenGLContext*, cvf::RenderQueue*, unsigned long, cvf::Camera const&, cvf::UniformSet const*) at ResInsight/Fwk/VizFwk/LibViewing/cvfRenderEngine.cpp:284
+  [9] cvf::Rendering::render(cvf::OpenGLContext*) at ResInsight/Fwk/VizFwk/LibViewing/cvfRendering.cpp:271
+  [10] cvf::RenderSequence::render(cvf::OpenGLContext*) at ResInsight/Fwk/VizFwk/LibViewing/cvfRenderSequence.cpp:211
+  [11] caf::Viewer::paintGL() at ResInsight/Fwk/AppFwk/cafViewer/cafViewer.cpp:901
+  [12]  at :0
+  [13] QWidget::event(QEvent*) at :0
+  [14] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [15] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [16] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [17] QWidgetPrivate::sendPaintEvent(QRegion const&) at :0
+  [18] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [19] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [20] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [21] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [22] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [23] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [24] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [25] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [26] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [27] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [28] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [29] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [30] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [31] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [32] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [33] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [34] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [35] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [36] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [37] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [38] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [39] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [40] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [41] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [42] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [43] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [44] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [45] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [46] QWidgetRepaintManager::paintAndFlush() at :0
+  [47] QWidget::event(QEvent*) at :0
+  [48] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [49] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [50] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [51] QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*) at :0
+  [52]  at :0
+  [53] g_main_context_dispatch at :0
+  [54] g_main_context_iterate.isra.20 at :0
+  [55] g_main_context_iteration at :0
+  [56] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [57] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [58] QCoreApplication::exec() at :0
+  [59] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [60] __libc_start_main at :0
+  [61] _start at :0
+  [62]  at :0
+"
+2026-05-31T19:17:29.126Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] ecl_kw_get_data_type at ResInsight/ThirdParty/Ert/lib/ecl/ecl_kw.cpp:1776
+  [4] ecl_file_kw_assert_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_kw.cpp:211
+  [5] ecl_file_kw_load_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_kw.cpp:244
+  [6] ecl_file_view_get_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_view.cpp:149
+  [7] RifEclipseOutputFileTools::keywordData(ecl_file_struct const*, QString const&, unsigned long, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseOutputFileTools.cpp:305
+  [8] RifEclipseUnifiedRestartFileAccess::results(QString const&, unsigned long, unsigned long, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseUnifiedRestartFileAccess.cpp:248
+  [9] RifReaderEclipseOutput::dynamicResult(QString const&, RiaDefines::PorosityModelType, unsigned long, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp:1070
+  [10] RigCaseCellResultsData::findOrLoadKnownScalarResult(RigEclipseResultAddress const&) at ResInsight/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp:1538
+  [11] RigCaseCellResultsData::ensureKnownResultLoaded(RigEclipseResultAddress const&) at ResInsight/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp:1264
+  [12] RiuRelativePermeabilityPlotUpdater::queryDataAndUpdatePlot(RimEclipseResultDefinition const*, unsigned long, unsigned long, unsigned long) at ResInsight/ApplicationLibCode/UserInterface/RiuRelativePermeabilityPlotUpdater.cpp:192
+  [13] RiuPlotUpdater::updateOnSelectionChanged(RiuSelectionItem const*) at ResInsight/ApplicationLibCode/UserInterface/RiuPlotUpdater.cpp:138
+  [14] RiuSelectionChangedHandler::handleItemAppended(RiuSelectionItem const*) const at ResInsight/ApplicationLibCode/UserInterface/RiuSelectionChangedHandler.cpp:124
+  [15] RiuCellAndNncPickEventHandler::handle3dPickEvent(Ric3dPickEvent const&) at ResInsight/ApplicationLibCode/UserInterface/RiuCellAndNncPickEventHandler.cpp:459
+  [16] RiuViewerCommands::handlePickAction(int, int, QFlags<Qt::KeyboardModifier>) at ResInsight/ApplicationLibCode/UserInterface/RiuViewerCommands.cpp:702
+  [17] QWidget::event(QEvent*) at :0
+  [18] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [19] QApplication::notify(QObject*, QEvent*) at :0
+  [20] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [21] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [22] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [23]  at :0
+  [24]  at :0
+  [25] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [26] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [27] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [28] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [29] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [30]  at :0
+  [31] g_main_context_dispatch at :0
+  [32] g_main_context_iterate.isra.20 at :0
+  [33] g_main_context_iteration at :0
+  [34] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [35] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [36] QCoreApplication::exec() at :0
+  [37] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [38] __libc_start_main at :0
+  [39] _start at :0
+  [40]  at :0
+"
+2026-05-31T18:14:12.006Z,2026.02.2,"  [0] ResInsight+0x12679BD at :0
+  [1] ResInsight+0x126793F at :0
+  [2] ucrtbase!seh_filter_exe+0x84 at :0
+  [3] ResInsight!cJSON_malloc+0x529743 at :0
+  [4] VCRUNTIME140!_C_specific_handler+0x9F at :0
+  [5] ntdll!_chkstk+0x9F at :0
+  [6] ntdll!RtlLocateExtendedFeature+0x597 at :0
+  [7] ntdll!KiUserExceptionDispatcher+0x2E at :0
+  [8] Qt6Widgets!QStatusBar::tr+0xCFE4 at :0
+  [9] Qt6Widgets!QMainWindow::statusBar+0x30 at :0
+  [10] ResInsight+0xEF673B at :0
+  [11] ResInsight+0xEF5883 at :0
+  [12] ResInsight+0xEF7489 at :0
+  [13] ResInsight+0x1328B4 at :0
+  [14] ResInsight+0x12377F at :0
+  [15] ResInsight+0x132859 at :0
+  [16] Qt6Core!QObject::qt_static_metacall+0x1816 at :0
+  [17] Qt6Core!QMetaObject::activate+0x84 at :0
+  [18] Qt6Gui!QGuiApplicationPrivate::maybeLastWindowClosed+0x33 at :0
+  [19] Qt6Gui!QWindow::event+0x298 at :0
+  [20] Qt6Widgets!QWidgetRepaintManager::updateStaticContentsSize+0x12E2 at :0
+  [21] Qt6Widgets!QApplicationPrivate::notify_helper+0x10E at :0
+  [22] Qt6Widgets!QApplication::notify+0x18C1 at :0
+  [23] ResInsight+0x13278B at :0
+  [24] Qt6Core!QCoreApplication::notifyInternal2+0x11F at :0
+  [25] Qt6Gui!QGuiApplicationPrivate::processCloseEvent+0xBA at :0
+  [26] Qt6Gui!QWindowSystemInterface::handleCloseEvent<QWindowSystemInterface::SynchronousDelivery>+0xC2 at :0
+  [27] Qt6Gui!QWindow::close+0x64 at :0
+  [28] Qt6Widgets!QWidget::~QWidget+0x529 at :0
+  [29] ResInsight+0x1315184 at :0
+  [30] ResInsight+0x12FE3B0 at :0
+  [31] ResInsight+0x12FE604 at :0
+  [32] Qt6Core!QObjectPrivate::deleteChildren+0x80 at :0
+  [33] Qt6Widgets!QWidget::~QWidget+0x67C at :0
+  [34] ResInsight+0xECEF47 at :0
+  [35] Qt6Core!QObject::event+0x9A at :0
+  [36] Qt6Widgets!QWidget::event+0xEB4 at :0
+  [37] Qt6Widgets!QApplicationPrivate::notify_helper+0x10E at :0
+  [38] Qt6Widgets!QApplication::notify+0x18C1 at :0
+  [39] ResInsight+0x13278B at :0
+  [40] Qt6Core!QCoreApplication::notifyInternal2+0x11F at :0
+  [41] Qt6Core!QCoreApplicationPrivate::sendPostedEvents+0x1F6 at :0
+  [42] Qt6Gui!QWindowsGuiEventDispatcher::sendPostedEvents+0xF at :0
+  [43] Qt6Core!QEventDispatcherWin32::processEvents+0x90 at :0
+  [44] Qt6Gui!QWindowsGuiEventDispatcher::processEvents+0x19 at :0
+  [45] Qt6Core!QEventLoop::exec+0x19F at :0
+  [46] Qt6Core!QCoreApplication::exec+0x15D at :0
+  [47] ResInsight+0x1267031 at :0
+  [48] ResInsight!cJSON_malloc+0x451E5D at :0
+  [49] ResInsight!cJSON_malloc+0x450B2A at :0
+  [50] KERNEL32!BaseThreadInitThunk+0x17 at :0
+  [51] ntdll!RtlUserThreadStart+0x2C at :0
+"
+2026-05-31T07:42:21.605Z,2026.02.3-dev.01,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] QArrayDataPointer<char16_t>::QArrayDataPointer(QArrayDataPointer<char16_t> const&) at /private/f_resinsight_build/resbuild/qt/6.6.3/gcc_64/include/QtCore/qarraydatapointer.h:38
+  [4] RimCase::gridFileName() const at ResInsight/ApplicationLibCode/ProjectDataModel/RimCase.cpp:136
+  [5] RimReloadCaseTools::findSummaryCaseFromEclipseResultCase(RimEclipseResultCase const*) at ResInsight/ApplicationLibCode/ProjectDataModel/RimReloadCaseTools.cpp:197
+  [6] RimReloadCaseTools::reloadEclipseData(RimEclipseCase*, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimReloadCaseTools.cpp:101
+  [7] RicReloadCaseFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/RicReloadCaseFeature.cpp:62
+  [8] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+  [9]  at :0
+  [10] QAction::triggered(bool) at :0
+  [11] QAction::activate(QAction::ActionEvent) at :0
+  [12]  at :0
+  [13]  at :0
+  [14] QWidget::event(QEvent*) at :0
+  [15] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [16] QApplication::notify(QObject*, QEvent*) at :0
+  [17] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1825
+  [18] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [19] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [20]  at :0
+  [21]  at :0
+  [22] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [23] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1825
+  [24] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [25] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [26] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [27]  at :0
+  [28] g_main_context_dispatch at :0
+  [29] g_main_context_iterate.isra.20 at :0
+  [30] g_main_context_iteration at :0
+  [31] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [32] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [33]  at :0
+  [34] QMenu::exec(QPoint const&, QAction*) at :0
+  [35] RiuMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:2094
+  [36]  at :0
+  [37] QWidget::customContextMenuRequested(QPoint const&) at :0
+  [38] QWidget::event(QEvent*) at :0
+  [39] QFrame::event(QEvent*) at :0
+  [40] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [41] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [42] QApplication::notify(QObject*, QEvent*) at :0
+  [43] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1825
+  [44] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [45]  at :0
+  [46]  at :0
+  [47] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [48] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1825
+  [49] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [50] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [51] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [52]  at :0
+  [53] g_main_context_dispatch at :0
+  [54] g_main_context_iterate.isra.20 at :0
+  [55] g_main_context_iteration at :0
+  [56] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [57] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [58] QCoreApplication::exec() at :0
+  [59] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [60] __libc_start_main at :0
+  [61] _start at :0
+  [62]  at :0
+"
+2026-05-29T17:47:58.638Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] caf::PdmUiObjectHandle::uiOrdering(QString const&, caf::PdmUiOrdering&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiObjectHandle.cpp:40
+  [4] RimContourMapProjection::defineUiOrdering(QString, caf::PdmUiOrdering&) at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimContourMapProjection.cpp:616
+  [5] RimEclipseContourMapProjection::defineUiOrdering(QString, caf::PdmUiOrdering&) at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapProjection.cpp:333
+  [6] caf::PdmUiObjectHandle::uiOrdering(QString const&, caf::PdmUiOrdering&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiObjectHandle.cpp:40
+  [7] caf::PdmUiFormLayoutObjectEditor::configureAndUpdateUi(QString const&) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiFormLayoutObjectEditor.cpp:670
+  [8] caf::PdmUiEditorHandle::updateUi(QString const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiEditorHandle.cpp:66
+  [9] caf::PdmUiPropertyView::showProperties(caf::PdmObjectHandle*) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiPropertyView.cpp:213
+  [10] RiuMainWindow::selectedObjectsChanged() at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:1530
+  [11]  at :0
+  [12] caf::PdmUiTreeView::slotOnSelectionChanged() at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeView.cpp:154
+  [13]  at :0
+  [14]  at :0
+  [15] QItemSelectionModel::selectionChanged(QItemSelection const&, QItemSelection const&) at :0
+  [16] QItemSelectionModel::emitSelectionChanged(QItemSelection const&, QItemSelection const&) at :0
+  [17] QItemSelectionModel::select(QItemSelection const&, QFlags<QItemSelectionModel::SelectionFlag>) at :0
+  [18] QTreeViewPrivate::select(QModelIndex const&, QModelIndex const&, QFlags<QItemSelectionModel::SelectionFlag>) at :0
+  [19] QTreeView::setSelection(QRect const&, QFlags<QItemSelectionModel::SelectionFlag>) at :0
+  [20] QAbstractItemView::mousePressEvent(QMouseEvent*) at :0
+  [21] QWidget::event(QEvent*) at :0
+  [22] QFrame::event(QEvent*) at :0
+  [23] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [24] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [25] QApplication::notify(QObject*, QEvent*) at :0
+  [26] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [27] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [28] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [29]  at :0
+  [30]  at :0
+  [31] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [32] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [33] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [34] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [35] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [36]  at :0
+  [37] g_main_context_dispatch at :0
+  [38] g_main_context_iterate.isra.20 at :0
+  [39] g_main_context_iteration at :0
+  [40] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [41] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [42] QCoreApplication::exec() at :0
+  [43] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [44] __libc_start_main at :0
+  [45] _start at :0
+  [46]  at :0
+"
+2026-05-29T14:06:22.726Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] ecl_kw_get_data_type at ResInsight/ThirdParty/Ert/lib/ecl/ecl_kw.cpp:1776
+  [4] ecl_file_kw_assert_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_kw.cpp:211
+  [5] ecl_file_kw_load_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_kw.cpp:244
+  [6] ecl_file_view_get_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_view.cpp:149
+  [7] RifEclipseOutputFileTools::keywordData(ecl_file_struct const*, QString const&, unsigned long, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseOutputFileTools.cpp:305
+  [8] RifReaderEclipseOutput::staticResult(QString const&, RiaDefines::PorosityModelType, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp:999
+  [9] RigCaseCellResultsData::findOrLoadKnownScalarResult(RigEclipseResultAddress const&) at ResInsight/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp:1558
+  [10] RigCaseCellResultsData::ensureKnownResultLoaded(RigEclipseResultAddress const&) at ResInsight/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp:1264
+  [11] RimEclipseResultDefinition::loadResult() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:1134
+  [12] RimEclipseCellColors::loadResult() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCellColors.cpp:260
+  [13] RimEclipseResultDefinition::loadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:533
+  [14] RimEclipseResultDefinition::fieldChangedByUi(caf::PdmFieldHandle const*, QVariant const&, QVariant const&) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:305
+  [15] RimEclipseCellColors::fieldChangedByUi(caf::PdmFieldHandle const*, QVariant const&, QVariant const&) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCellColors.cpp:90
+  [16] caf::PdmUiFieldHandle::notifyFieldChanged(QVariant const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiFieldHandle.cpp:74
+  [17] caf::PdmFieldUiCap<caf::PdmField<QString> >::setValueFromUiEditor(QVariant const&, bool) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafInternalPdmUiFieldCapability.inl:110
+  [18] caf::PdmUiCommandSystemProxy::setUiValueToField(caf::PdmUiFieldHandle*, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiCommandSystemProxy.cpp:122
+  [19] caf::PdmUiTreeSelectionQModel::setData(QModelIndex const&, QVariant const&, int) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionQModel.cpp:482
+  [20] QSortFilterProxyModel::setData(QModelIndex const&, QVariant const&, int) at :0
+  [21] QStyledItemDelegate::editorEvent(QEvent*, QAbstractItemModel*, QStyleOptionViewItem const&, QModelIndex const&) at :0
+  [22]  at :0
+  [23] QAbstractItemView::edit(QModelIndex const&, QAbstractItemView::EditTrigger, QEvent*) at :0
+  [24] QAbstractItemView::mouseReleaseEvent(QMouseEvent*) at :0
+  [25] QWidget::event(QEvent*) at :0
+  [26] QFrame::event(QEvent*) at :0
+  [27] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [28] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [29] QApplication::notify(QObject*, QEvent*) at :0
+  [30] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [31] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [32] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [33]  at :0
+  [34]  at :0
+  [35] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [36] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [37] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [38] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [39] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [40]  at :0
+  [41] g_main_context_dispatch at :0
+  [42] g_main_context_iterate.isra.20 at :0
+  [43] g_main_context_iteration at :0
+  [44] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [45] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [46] QCoreApplication::exec() at :0
+  [47] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [48] __libc_start_main at :0
+  [49] _start at :0
+  [50]  at :0
+"
+2026-05-29T13:57:09.92Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] QWidgetPrivate::shouldPaintOnScreen() const at :0
+  [4] QWidgetRepaintManager::markNeedsFlush(QWidget*, QRegion const&, QPoint const&) at :0
+  [5] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [6] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [7] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [8] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [9] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [10] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [11] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [12] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [13] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [14] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [15] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [16] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [17] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [18] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [19] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [20] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [21] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [22] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [23] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [24] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [25] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [26] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [27] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [28] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [29] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [30] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [31] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [32] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [33] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [34] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [35] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [36] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [37] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [38] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [39] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [40] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [41] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [42] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [43] QWidgetRepaintManager::paintAndFlush() at :0
+  [44] QWidget::event(QEvent*) at :0
+  [45] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [46] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [47] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [48] QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*) at :0
+  [49]  at :0
+  [50] g_main_context_dispatch at :0
+  [51] g_main_context_iterate.isra.20 at :0
+  [52] g_main_context_iteration at :0
+  [53] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [54] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [55] QCoreApplication::exec() at :0
+  [56] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [57] __libc_start_main at :0
+  [58] _start at :0
+  [59]  at :0
+"
+2026-05-29T13:31:33.488Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] H5::H5Location::createGroup(char const*, unsigned long) const at :0
+  [4] H5::H5Location::createGroup(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, unsigned long) const at :0
+  [5] RifHdf5Exporter::createGroup(H5::Group*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) at ResInsight/ApplicationLibCode/FileInterface/RifHdf5Exporter.cpp:117
+  [6] RifHdf5SummaryExporter::writeGeneralSection(RifHdf5Exporter&, Opm::EclIO::ESmry&) at ResInsight/ApplicationLibCode/FileInterface/RifHdf5SummaryExporter.cpp:167
+  [7] RifHdf5SummaryExporter::ensureHdf5FileIsCreated(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool, unsigned long&) at ResInsight/ApplicationLibCode/FileInterface/RifHdf5SummaryExporter.cpp:141
+  [8] RifReaderEclipseSummary::open(QString const&, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseSummary.cpp:107
+  [9] RimFileSummaryCase::findRelatedFilesAndCreateReader(QString const&, bool, RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:238
+  [10] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:110
+  [11] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+  [12] GOMP_parallel at :0
+  [13] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:561
+  [14] RimSummaryCaseMainCollection::loadSummaryCaseData(std::vector<RimSummaryCase*, std::allocator<RimSummaryCase*> > const&, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:457
+  [15] RimSummaryCaseMainCollection::createSummaryCasesFromFileInfos(std::vector<RifSummaryCaseFileResultInfo, std::allocator<RifSummaryCaseFileResultInfo> > const&, bool, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:712
+  [16] RiaEnsembleImportTools::createSummaryCasesFromFiles(QList<QString> const&, RiaEnsembleImportTools::CreateConfig) at ResInsight/ApplicationLibCode/Application/Tools/Ensemble/RiaEnsembleImportTools.cpp:82
+  [17] RicImportSummaryCasesFeature::createAndAddSummaryCasesFromFiles(QList<QString> const&, bool) at ResInsight/ApplicationLibCode/Commands/RicImportSummaryCasesFeature.cpp:126
+  [18] RicImportGeneralDataFeature::openSummaryCaseFromFileNames(QList<QString> const&, bool) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:378
+  [19] RicImportGeneralDataFeature::openEclipseFilesFromFileNames(QList<QString> const&, bool, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:122
+  [20] RicImportGeneralDataFeature::openEclipseFilesFromFileNames(QList<QString> const&, bool, bool) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:55
+  [21] RicImportGeneralDataFeature::openFileDialog(RiaDefines::ImportFileType) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:339
+  [22] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+  [23]  at :0
+  [24] QAction::triggered(bool) at :0
+  [25] QAction::activate(QAction::ActionEvent) at :0
+  [26]  at :0
+  [27]  at :0
+  [28] QWidget::event(QEvent*) at :0
+  [29] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [30] QApplication::notify(QObject*, QEvent*) at :0
+  [31] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [32] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [33] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [34]  at :0
+  [35]  at :0
+  [36] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [37] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [38] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [39] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [40] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [41]  at :0
+  [42] g_main_context_dispatch at :0
+  [43] g_main_context_iterate.isra.20 at :0
+  [44] g_main_context_iteration at :0
+  [45] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [46] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [47]  at :0
+  [48] QMenu::exec(QPoint const&, QAction*) at :0
+  [49] RiuPlotMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp:1058
+  [50]  at :0
+  [51] QWidget::customContextMenuRequested(QPoint const&) at :0
+  [52] QWidget::event(QEvent*) at :0
+  [53] QFrame::event(QEvent*) at :0
+  [54] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [55] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [56] QApplication::notify(QObject*, QEvent*) at :0
+  [57] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [58] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [59]  at :0
+  [60]  at :0
+  [61] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [62] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [63] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [64] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [65] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [66]  at :0
+  [67] g_main_context_dispatch at :0
+  [68] g_main_context_iterate.isra.20 at :0
+  [69] g_main_context_iteration at :0
+  [70] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [71] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [72] QCoreApplication::exec() at :0
+  [73] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [74] __libc_start_main at :0
+  [75] _start at :0
+  [76]  at :0
+"
+2026-05-29T12:33:42.315Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] std::terminate() at :0
+  [10] __cxa_rethrow at :0
+  [11] main at ResInsight/ApplicationExeCode/RiaMain.cpp:232
+  [12] __libc_start_main at :0
+  [13] _start at :0
+  [14]  at :0
+"
+2026-05-29T11:34:24.723Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] QWidgetPrivate::shouldPaintOnScreen() const at :0
+  [4] QWidgetRepaintManager::markNeedsFlush(QWidget*, QRegion const&, QPoint const&) at :0
+  [5] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [6] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [7] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [8] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [9] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [10] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [11] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [12] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [13] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [14] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [15] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [16] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [17] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [18] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [19] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [20] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [21] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [22] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [23] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [24] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [25] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [26] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [27] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [28] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [29] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [30] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [31] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [32] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [33] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [34] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [35] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [36] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [37] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [38] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [39] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [40] QWidgetRepaintManager::paintAndFlush() at :0
+  [41] QWidget::event(QEvent*) at :0
+  [42] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [43] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [44] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [45] QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*) at :0
+  [46]  at :0
+  [47] g_main_context_dispatch at :0
+  [48] g_main_context_iterate.isra.20 at :0
+  [49] g_main_context_iteration at :0
+  [50] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [51] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [52] QCoreApplication::exec() at :0
+  [53] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [54] __libc_start_main at :0
+  [55] _start at :0
+  [56]  at :0
+"
+2026-05-29T11:04:08.19Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] caf::PdmUiObjectHandle::uiOrdering(QString const&, caf::PdmUiOrdering&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiObjectHandle.cpp:40
+  [4] RimContourMapProjection::defineUiOrdering(QString, caf::PdmUiOrdering&) at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimContourMapProjection.cpp:616
+  [5] RimEclipseContourMapProjection::defineUiOrdering(QString, caf::PdmUiOrdering&) at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapProjection.cpp:333
+  [6] caf::PdmUiObjectHandle::uiOrdering(QString const&, caf::PdmUiOrdering&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiObjectHandle.cpp:40
+  [7] caf::PdmUiFormLayoutObjectEditor::configureAndUpdateUi(QString const&) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiFormLayoutObjectEditor.cpp:670
+  [8] caf::PdmUiEditorHandle::updateUi(QString const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiEditorHandle.cpp:66
+  [9] caf::PdmUiPropertyView::showProperties(caf::PdmObjectHandle*) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiPropertyView.cpp:213
+  [10] RiuMainWindow::selectedObjectsChanged() at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:1530
+  [11]  at :0
+  [12] caf::PdmUiTreeView::slotOnSelectionChanged() at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeView.cpp:154
+  [13]  at :0
+  [14]  at :0
+  [15] QItemSelectionModel::selectionChanged(QItemSelection const&, QItemSelection const&) at :0
+  [16] QItemSelectionModel::emitSelectionChanged(QItemSelection const&, QItemSelection const&) at :0
+  [17] QItemSelectionModel::select(QItemSelection const&, QFlags<QItemSelectionModel::SelectionFlag>) at :0
+  [18] QTreeViewPrivate::select(QModelIndex const&, QModelIndex const&, QFlags<QItemSelectionModel::SelectionFlag>) at :0
+  [19] QTreeView::setSelection(QRect const&, QFlags<QItemSelectionModel::SelectionFlag>) at :0
+  [20] QAbstractItemView::mousePressEvent(QMouseEvent*) at :0
+  [21] QWidget::event(QEvent*) at :0
+  [22] QFrame::event(QEvent*) at :0
+  [23] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [24] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [25] QApplication::notify(QObject*, QEvent*) at :0
+  [26] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [27] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [28] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [29]  at :0
+  [30]  at :0
+  [31] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [32] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [33] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [34] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [35] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [36]  at :0
+  [37] g_main_context_dispatch at :0
+  [38] g_main_context_iterate.isra.20 at :0
+  [39] g_main_context_iteration at :0
+  [40] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [41] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [42] QCoreApplication::exec() at :0
+  [43] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [44] __libc_start_main at :0
+  [45] _start at :0
+  [46]  at :0
+"
+2026-05-29T10:46:46.704Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] QtSharedPointer::ExternalRefCountData::getAndRef(QObject const*) at :0
+  [4] QApplication::notify(QObject*, QEvent*) at :0
+  [5] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [6] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [7] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [8]  at :0
+  [9]  at :0
+  [10] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [11] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [12] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [13] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [14] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [15]  at :0
+  [16] g_main_context_dispatch at :0
+  [17] g_main_context_iterate.isra.20 at :0
+  [18] g_main_context_iteration at :0
+  [19] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [20] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [21] QCoreApplication::exec() at :0
+  [22] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [23] __libc_start_main at :0
+  [24] _start at :0
+  [25]  at :0
+"
+2026-05-29T10:15:01.06Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] QWeakPointer<QObject>::internalData() const at /private/f_resinsight_build/resbuild/qt/6.6.3/gcc_64/include/QtCore/qsharedpointer_impl.h:704
+  [4] RimViewController::applyCellFilterCollectionByUserChoice() at ResInsight/ApplicationLibCode/ProjectDataModel/RimViewController.cpp:1105
+  [5] RimViewLinker::applyCellFilterCollectionByUserChoice() at ResInsight/ApplicationLibCode/ProjectDataModel/RimViewLinker.cpp:669
+  [6] RicDeleteAllLinkedViewsFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/ViewLink/RicDeleteAllLinkedViewsFeature.cpp:81
+  [7] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+  [8] RiuTreeViewEventFilter::activateFirstEnabledFeature(std::vector<caf::CmdFeature*, std::allocator<caf::CmdFeature*> > const&) at ResInsight/ApplicationLibCode/UserInterface/RiuTreeViewEventFilter.cpp:95
+  [9] RiuTreeViewEventFilter::eventFilter(QObject*, QEvent*) at ResInsight/ApplicationLibCode/UserInterface/RiuTreeViewEventFilter.cpp:143
+  [10] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [11] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [12] QApplication::notify(QObject*, QEvent*) at :0
+  [13] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [14] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [15]  at :0
+  [16] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [17] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [18] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [19] QGuiApplicationPrivate::processKeyEvent(QWindowSystemInterfacePrivate::KeyEvent*) at :0
+  [20] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [21]  at :0
+  [22] g_main_context_dispatch at :0
+  [23] g_main_context_iterate.isra.20 at :0
+  [24] g_main_context_iteration at :0
+  [25] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [26] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [27] QCoreApplication::exec() at :0
+  [28] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [29] __libc_start_main at :0
+  [30] _start at :0
+  [31]  at :0
+"
+2026-05-29T10:09:28.978Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] std::terminate() at :0
+  [10] __cxa_rethrow at :0
+  [11] main at ResInsight/ApplicationExeCode/RiaMain.cpp:232
+  [12] __libc_start_main at :0
+  [13] _start at :0
+  [14]  at :0
+"
+2026-05-29T09:28:52.74Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] caf::PdmUiObjectHandle::uiOrdering(QString const&, caf::PdmUiOrdering&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiObjectHandle.cpp:40
+  [4] RimContourMapProjection::defineUiOrdering(QString, caf::PdmUiOrdering&) at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimContourMapProjection.cpp:616
+  [5] RimEclipseContourMapProjection::defineUiOrdering(QString, caf::PdmUiOrdering&) at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapProjection.cpp:333
+  [6] caf::PdmUiObjectHandle::uiOrdering(QString const&, caf::PdmUiOrdering&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiObjectHandle.cpp:40
+  [7] caf::PdmUiFormLayoutObjectEditor::configureAndUpdateUi(QString const&) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiFormLayoutObjectEditor.cpp:670
+  [8] caf::PdmUiEditorHandle::updateUi(QString const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiEditorHandle.cpp:66
+  [9] caf::PdmUiPropertyView::showProperties(caf::PdmObjectHandle*) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiPropertyView.cpp:213
+  [10] RiuMainWindow::selectedObjectsChanged() at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:1530
+  [11]  at :0
+  [12] caf::PdmUiTreeView::slotOnSelectionChanged() at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeView.cpp:154
+  [13]  at :0
+  [14]  at :0
+  [15] QItemSelectionModel::selectionChanged(QItemSelection const&, QItemSelection const&) at :0
+  [16] QItemSelectionModel::emitSelectionChanged(QItemSelection const&, QItemSelection const&) at :0
+  [17] QItemSelectionModel::select(QItemSelection const&, QFlags<QItemSelectionModel::SelectionFlag>) at :0
+  [18] QTreeViewPrivate::select(QModelIndex const&, QModelIndex const&, QFlags<QItemSelectionModel::SelectionFlag>) at :0
+  [19] QTreeView::setSelection(QRect const&, QFlags<QItemSelectionModel::SelectionFlag>) at :0
+  [20] QAbstractItemView::mousePressEvent(QMouseEvent*) at :0
+  [21] QWidget::event(QEvent*) at :0
+  [22] QFrame::event(QEvent*) at :0
+  [23] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [24] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [25] QApplication::notify(QObject*, QEvent*) at :0
+  [26] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [27] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [28] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [29]  at :0
+  [30]  at :0
+  [31] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [32] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [33] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [34] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [35] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [36]  at :0
+  [37] g_main_context_dispatch at :0
+  [38] g_main_context_iterate.isra.20 at :0
+  [39] g_main_context_iteration at :0
+  [40] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [41] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [42] QCoreApplication::exec() at :0
+  [43] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [44] __libc_start_main at :0
+  [45] _start at :0
+  [46]  at :0
+"
+2026-05-29T08:17:06.473Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] QtPrivate::compareStrings(QStringView, QStringView, Qt::CaseSensitivity) at :0
+  [4] operator<(QString const&, QString const&) at /private/f_resinsight_build/resbuild/qt/6.6.3/gcc_64/include/QtCore/qstring.h:697
+  [5] std::map<QString, QString, std::less<QString>, std::allocator<std::pair<QString const, QString> > >::contains(QString const&) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/stl_map.h:1285
+  [6] RigCaseCellResultsData::hasResultEntry(RigEclipseResultAddress const&) const at ResInsight/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp:1287
+  [7] RigEclipseContourMapProjection::generateResults(RigEclipseContourMapProjection const&, RigContourMapGrid const&, RigCaseCellResultsData&, RigEclipseResultAddress const&, RigContourMapCalculator::ResultAggregationType, int, RigFloodingSettings&) at ResInsight/ApplicationLibCode/ReservoirDataModel/ContourMap/RigEclipseContourMapProjection.cpp:103
+  [8] RigEclipseContourMapProjection::generateAndSaveResults(RigEclipseResultAddress const&, RigContourMapCalculator::ResultAggregationType, int, RigFloodingSettings&) at ResInsight/ApplicationLibCode/ReservoirDataModel/ContourMap/RigEclipseContourMapProjection.cpp:71
+  [9] RimEclipseContourMapProjection::generateAndSaveResults(int) at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapProjection.cpp:213
+  [10] RimContourMapProjection::generateResultsIfNecessary(int) at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimContourMapProjection.cpp:164
+  [11] RimEclipseContourMapView::updateGeometry() at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapView.cpp:282
+  [12] Rim3dView::updateDisplayModelForCurrentTimeStepAndRedraw() at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:673
+  [13] RiuViewer::setCurrentFrame(int) at ResInsight/ApplicationLibCode/UserInterface/RiuViewer.cpp:1008
+  [14] RimEclipseView::onCreateDisplayModel() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp:791
+  [15] RimEclipseContourMapView::onCreateDisplayModel() at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapView.cpp:205
+  [16] Rim3dView::createDisplayModelAndRedraw() at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:718
+  [17] RiaViewRedrawScheduler::updateAndRedrawScheduledViews() at ResInsight/ApplicationLibCode/Application/RiaViewRedrawScheduler.cpp:93
+  [18]  at :0
+  [19] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [20] QObject::event(QEvent*) at :0
+  [21] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [22] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [23] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [24] QTimerInfoList::activateTimers() at :0
+  [25]  at :0
+  [26] g_main_context_dispatch at :0
+  [27] g_main_context_iterate.isra.20 at :0
+  [28] g_main_context_iteration at :0
+  [29] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [30] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [31] QDialog::exec() at :0
+  [32] RicReplaceCaseFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/RicReplaceCaseFeature.cpp:108
+  [33] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+  [34]  at :0
+  [35] QAction::triggered(bool) at :0
+  [36] QAction::activate(QAction::ActionEvent) at :0
+  [37]  at :0
+  [38]  at :0
+  [39] QWidget::event(QEvent*) at :0
+  [40] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [41] QApplication::notify(QObject*, QEvent*) at :0
+  [42] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [43] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [44] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [45]  at :0
+  [46]  at :0
+  [47] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [48] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [49] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [50] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [51] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [52]  at :0
+  [53] g_main_context_dispatch at :0
+  [54] g_main_context_iterate.isra.20 at :0
+  [55] g_main_context_iteration at :0
+  [56] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [57] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [58]  at :0
+  [59] QMenu::exec(QPoint const&, QAction*) at :0
+  [60] RiuMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:2056
+  [61]  at :0
+  [62] QWidget::customContextMenuRequested(QPoint const&) at :0
+  [63] QWidget::event(QEvent*) at :0
+  [64] QFrame::event(QEvent*) at :0
+  [65] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [66] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [67] QApplication::notify(QObject*, QEvent*) at :0
+  [68] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [69] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [70]  at :0
+  [71]  at :0
+  [72] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [73] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [74] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [75] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [76] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [77]  at :0
+  [78] g_main_context_dispatch at :0
+  [79] g_main_context_iterate.isra.20 at :0
+  [80] g_main_context_iteration at :0
+  [81] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [82] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [83] QCoreApplication::exec() at :0
+  [84] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [85] __libc_start_main at :0
+  [86] _start at :0
+  [87]  at :0
+"
+2026-05-29T06:57:22.879Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] backtrace_free_locked at /root/gcc-build/gcc-13.3.0-build/x86_64-pc-linux-gnu/libstdc++-v3/src/libbacktrace/mmap.c:104
+  [4] backtrace_free_locked at /root/gcc-build/gcc-13.3.0-build/x86_64-pc-linux-gnu/libstdc++-v3/src/libbacktrace/mmap.c:226
+  [5] free_line_header at /root/gcc-build/gcc-13.3.0-build/x86_64-pc-linux-gnu/libstdc++-v3/src/libbacktrace/dwarf.c:2335
+  [6] dwarf_fileline at /root/gcc-build/gcc-13.3.0-build/x86_64-pc-linux-gnu/libstdc++-v3/src/libbacktrace/dwarf.c:3935
+  [7] std::stacktrace_entry::_M_get_info(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*, int*) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/stacktrace:196
+  [8] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:164
+  [9] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [10]  at :0
+  [11] __GI_raise at :0
+  [12] __GI_abort at :0
+  [13] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [14]  at :0
+  [15]  at :0
+  [16] __cxxabiv1::__terminate(void (*)()) at :0
+  [17] __cxa_call_terminate at :0
+  [18] __gxx_personality_v0 at :0
+  [19] _Unwind_RaiseException_Phase2 at :0
+  [20] _Unwind_RaiseException at :0
+  [21] __cxa_throw at :0
+  [22] operator new(unsigned long) at :0
+  [23] std::__new_allocator<double>::allocate(unsigned long, void const*) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/new_allocator.h:151
+  [24] __gnu_cxx::__normal_iterator<double*, std::vector<double, std::allocator<double> > > std::vector<double, std::allocator<double> >::insert<__gnu_cxx::__normal_iterator<double*, std::vector<double, std::allocator<double> > >, void>(__gnu_cxx::__normal_iterator<double const*, std::vector<double, std::allocator<double> > >, __gnu_cxx::__normal_iterator<double*, std::vector<double, std::allocator<double> > >, __gnu_cxx::__normal_iterator<double*, std::vector<double, std::allocator<double> > >) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/stl_vector.h:1486
+  [25] RifEclipseUnifiedRestartFileAccess::results(QString const&, unsigned long, unsigned long, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseUnifiedRestartFileAccess.cpp:248
+  [26] RifReaderEclipseOutput::dynamicResult(QString const&, RiaDefines::PorosityModelType, unsigned long, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp:1070
+  [27] RigCaseCellResultsData::findOrLoadKnownScalarResult(RigEclipseResultAddress const&) [clone .localalias] at :0
+  [28] RigCaseCellResultsData::ensureKnownResultLoaded(RigEclipseResultAddress const&) at :0
+  [29] RimEclipseResultDefinition::loadResult() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:1134
+  [30] RimEclipseCellColors::loadResult() [clone .localalias] at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCellColors.cpp:260
+  [31] RimEclipseResultDefinition::loadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:533
+  [32] RimEclipseResultDefinition::fieldChangedByUi(caf::PdmFieldHandle const*, QVariant const&, QVariant const&) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:305
+  [33] RimEclipseCellColors::fieldChangedByUi(caf::PdmFieldHandle const*, QVariant const&, QVariant const&) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCellColors.cpp:90
+  [34] caf::PdmUiFieldHandle::notifyFieldChanged(QVariant const&, QVariant const&) at :0
+  [35] caf::PdmFieldUiCap<caf::PdmField<QString> >::setValueFromUiEditor(QVariant const&, bool) at :0
+  [36] caf::PdmUiCommandSystemProxy::setUiValueToField(caf::PdmUiFieldHandle*, QVariant const&) at :0
+  [37] caf::PdmUiTreeSelectionQModel::setData(QModelIndex const&, QVariant const&, int) at :0
+  [38] QSortFilterProxyModel::setData(QModelIndex const&, QVariant const&, int) at :0
+  [39] QStyledItemDelegate::editorEvent(QEvent*, QAbstractItemModel*, QStyleOptionViewItem const&, QModelIndex const&) at :0
+  [40]  at :0
+  [41] QAbstractItemView::edit(QModelIndex const&, QAbstractItemView::EditTrigger, QEvent*) at :0
+  [42] QAbstractItemView::mouseReleaseEvent(QMouseEvent*) at :0
+  [43] QWidget::event(QEvent*) at :0
+  [44] QFrame::event(QEvent*) at :0
+  [45] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [46] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [47] QApplication::notify(QObject*, QEvent*) at :0
+  [48] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [49] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [50] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [51]  at :0
+  [52]  at :0
+  [53] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [54] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [55] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [56] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [57] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [58]  at :0
+  [59] g_main_context_dispatch at :0
+  [60] g_main_context_iterate.isra.20 at :0
+  [61] g_main_context_iteration at :0
+  [62] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [63] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [64] QCoreApplication::exec() at :0
+  [65] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [66] __libc_start_main at :0
+  [67] _start at :0
+  [68]  at :0
+"
+2026-05-28T18:04:48.924Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] QDateTime::isValid() const at :0
+  [4] QCalendarBackend::dateTimeToString(QStringView, QDateTime const&, QDate, QTime, QLocale const&) const at :0
+  [5] QCalendar::dateTimeToString(QStringView, QDateTime const&, QDate, QTime, QLocale const&) const at :0
+  [6] QLocale::toString(QDateTime const&, QStringView, QCalendar) const at :0
+  [7] QDateTime::toString(QStringView, QCalendar) const at :0
+  [8] QDateTime::toString(QString const&, QCalendar) const at /private/f_resinsight_build/resbuild/qt/6.6.3/gcc_64/include/QtCore/qdatetime.h:360
+  [9] Rim3dOverlayInfoConfig::resultInfoText(RigHistogramData const&, RimEclipseView*, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dOverlayInfoConfig.cpp:524
+  [10] Rim3dOverlayInfoConfig::resultInfoText(RigHistogramData const&) at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dOverlayInfoConfig.cpp:220
+  [11] Rim3dOverlayInfoConfig::updateEclipse3DInfo(RimEclipseView*) at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dOverlayInfoConfig.cpp:940
+  [12] Rim3dOverlayInfoConfig::update3DInfo() at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dOverlayInfoConfig.cpp:807
+  [13] RimEclipseView::onUpdateDisplayModelForCurrentTimeStep() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp:901
+  [14] Rim3dView::updateDisplayModelForCurrentTimeStepAndRedraw() at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:673
+  [15] RiuViewer::setCurrentFrame(int) at ResInsight/ApplicationLibCode/UserInterface/RiuViewer.cpp:1008
+  [16] RimEclipseView::onCreateDisplayModel() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp:791
+  [17] Rim3dView::createDisplayModelAndRedraw() at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:718
+  [18] RiaViewRedrawScheduler::updateAndRedrawScheduledViews() at ResInsight/ApplicationLibCode/Application/RiaViewRedrawScheduler.cpp:93
+  [19]  at :0
+  [20] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [21] QObject::event(QEvent*) at :0
+  [22] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [23] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [24] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [25] QTimerInfoList::activateTimers() at :0
+  [26]  at :0
+  [27] g_main_context_dispatch at :0
+  [28] g_main_context_iterate.isra.20 at :0
+  [29] g_main_context_iteration at :0
+  [30] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [31] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [32] QCoreApplication::exec() at :0
+  [33] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [34] __libc_start_main at :0
+  [35] _start at :0
+  [36]  at :0
+"
+2026-05-28T18:04:30.017Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] QWidgetPrivate::shouldPaintOnScreen() const at :0
+  [4] QWidgetRepaintManager::markNeedsFlush(QWidget*, QRegion const&, QPoint const&) at :0
+  [5] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [6] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [7] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [8] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [9] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [10] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [11] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [12] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [13] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [14] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [15] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [16] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [17] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [18] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [19] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [20] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [21] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [22] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [23] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [24] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [25] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [26] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [27] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [28] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [29] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [30] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [31] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [32] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [33] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [34] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [35] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [36] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [37] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [38] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [39] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [40] QWidgetRepaintManager::paintAndFlush() at :0
+  [41] QWidget::event(QEvent*) at :0
+  [42] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [43] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [44] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [45] QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*) at :0
+  [46]  at :0
+  [47] g_main_context_dispatch at :0
+  [48] g_main_context_iterate.isra.20 at :0
+  [49] g_main_context_iteration at :0
+  [50] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [51] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [52] QCoreApplication::exec() at :0
+  [53] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [54] __libc_start_main at :0
+  [55] _start at :0
+  [56]  at :0
+"
+2026-05-28T16:12:14.6Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __libc_poll at :0
+  [4] g_main_context_iterate.isra.20 at :0
+  [5] g_main_context_iteration at :0
+  [6] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [7] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [8]  at :0
+  [9] QMenu::exec(QPoint const&, QAction*) at :0
+  [10] RiuSummaryPlot::showContextMenu(QPoint) at ResInsight/ApplicationLibCode/UserInterface/RiuSummaryPlot.cpp:210
+  [11]  at :0
+  [12] QWidget::customContextMenuRequested(QPoint const&) at :0
+  [13] QWidget::event(QEvent*) at :0
+  [14] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [15] QApplication::notify(QObject*, QEvent*) at :0
+  [16] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [17] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [18]  at :0
+  [19]  at :0
+  [20] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [21] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [22] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [23] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [24] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [25]  at :0
+  [26] g_main_context_dispatch at :0
+  [27] g_main_context_iterate.isra.20 at :0
+  [28] g_main_context_iteration at :0
+  [29] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [30] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [31] QCoreApplication::exec() at :0
+  [32] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [33] __libc_start_main at :0
+  [34] _start at :0
+  [35]  at :0
+"
+2026-05-28T09:13:45.176Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] std::terminate() at :0
+  [10] __cxa_rethrow at :0
+  [11] main at ResInsight/ApplicationExeCode/RiaMain.cpp:232
+  [12] __libc_start_main at :0
+  [13] _start at :0
+  [14]  at :0
+"
+2026-05-28T09:06:55.276Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] QEventLoop::exit(int) at :0
+  [4] QMenu::~QMenu() at :0
+  [5] RiuPlotMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp:107
+  [6]  at :0
+  [7] QWidget::customContextMenuRequested(QPoint const&) at :0
+  [8] QWidget::event(QEvent*) at :0
+  [9] QFrame::event(QEvent*) at :0
+  [10] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [11] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [12] QApplication::notify(QObject*, QEvent*) at :0
+  [13] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [14] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [15]  at :0
+  [16]  at :0
+  [17] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [18] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [19] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [20] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [21] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [22]  at :0
+  [23] g_main_context_dispatch at :0
+  [24] g_main_context_iterate.isra.20 at :0
+  [25] g_main_context_iteration at :0
+  [26] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [27] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [28] QCoreApplication::exec() at :0
+  [29] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [30] __libc_start_main at :0
+  [31] _start at :0
+  [32]  at :0
+"
+2026-05-28T09:04:15.068Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] std::terminate() at :0
+  [10] __cxa_rethrow at :0
+  [11] main at ResInsight/ApplicationExeCode/RiaMain.cpp:232
+  [12] __libc_start_main at :0
+  [13] _start at :0
+  [14]  at :0
+"
+2026-05-28T08:59:52.304Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] std::terminate() at :0
+  [10] __cxa_rethrow at :0
+  [11] main at ResInsight/ApplicationExeCode/RiaMain.cpp:232
+  [12] __libc_start_main at :0
+  [13] _start at :0
+  [14]  at :0
+"
+2026-05-28T08:38:44.52Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
+  [6] RimGeoMechPropertyFilter::computeResultValueRange() at ResInsight/ApplicationLibCode/ProjectDataModel/CellFilters/RimGeoMechPropertyFilter.cpp:300
+  [7] RimGeoMechPropertyFilterCollection::loadAndInitializePropertyFilters() at ResInsight/ApplicationLibCode/ProjectDataModel/CellFilters/RimGeoMechPropertyFilterCollection.cpp:62
+  [8] RimViewController::updateDuplicatedPropertyFilters() at ResInsight/ApplicationLibCode/ProjectDataModel/RimViewController.cpp:540
+  [9] caf::PdmUiFieldHandle::notifyFieldChanged(QVariant const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiFieldHandle.cpp:74
+  [10] caf::PdmFieldUiCap<caf::PdmField<bool> >::setValueFromUiEditor(QVariant const&, bool) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafInternalPdmUiFieldCapability.inl:110
+  [11] caf::CmdFieldChangeExec::redo() at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFieldChangeExec.cpp:139
+  [12] QUndoStack::push(QUndoCommand*) at :0
+  [13] caf::CmdUiCommandSystemImpl::fieldChangedCommand(std::vector<caf::PdmFieldHandle*, std::allocator<caf::PdmFieldHandle*> > const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdUiCommandSystemImpl.cpp:146
+  [14] caf::PdmUiCommandSystemProxy::setUiValueToField(caf::PdmUiFieldHandle*, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiCommandSystemProxy.cpp:113
+  [15] caf::PdmUiCheckBoxEditor::slotClicked(bool) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiCheckBoxEditor.cpp:127
+  [16]  at :0
+  [17] QAbstractButton::clicked(bool) at :0
+  [18]  at :0
+  [19]  at :0
+  [20] QAbstractButton::mouseReleaseEvent(QMouseEvent*) at :0
+  [21] QWidget::event(QEvent*) at :0
+  [22] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [23] QApplication::notify(QObject*, QEvent*) at :0
+  [24] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [25] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [26] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [27]  at :0
+  [28]  at :0
+  [29] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [30] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [31] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [32] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [33] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [34]  at :0
+  [35] g_main_context_dispatch at :0
+  [36] g_main_context_iterate.isra.20 at :0
+  [37] g_main_context_iteration at :0
+  [38] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [39] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [40] QCoreApplication::exec() at :0
+  [41] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [42] __libc_start_main at :0
+  [43] _start at :0
+  [44]  at :0
+"
+2026-05-28T07:31:55.884Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
+  [6] cvf::StructGridInterface::oppositeFace(cvf::StructGridInterface::FaceType) at ResInsight/Fwk/AppFwk/CommonCode/cvfStructGrid.cpp:199
+  [7] RigCombMultResultAccessor::cellFaceScalar(unsigned long, cvf::StructGridInterface::FaceType) const at ResInsight/ApplicationLibCode/ReservoirDataModel/ResultAccessors/RigCombMultResultAccessor.cpp:77
+  [8] RiuResultTextBuilder::cellResultTextAndValueText(RimEclipseResultDefinition*) at ResInsight/ApplicationLibCode/UserInterface/RiuResultTextBuilder.cpp:1106
+  [9] RiuResultTextBuilder::cellResultText(std::vector<RimEclipseResultDefinition*, std::allocator<RimEclipseResultDefinition*> > const&, bool) at ResInsight/ApplicationLibCode/UserInterface/RiuResultTextBuilder.cpp:998
+  [10] RiuResultTextBuilder::gridResultText() at ResInsight/ApplicationLibCode/UserInterface/RiuResultTextBuilder.cpp:490
+  [11] RiuResultTextBuilder::mainResultText() at ResInsight/ApplicationLibCode/UserInterface/RiuResultTextBuilder.cpp:171
+  [12] RiuSelectionChangedHandler::updateResultInfo(RiuSelectionItem const*) const at ResInsight/ApplicationLibCode/UserInterface/RiuSelectionChangedHandler.cpp:389
+  [13] RiuSelectionChangedHandler::handleItemAppended(RiuSelectionItem const*) const at ResInsight/ApplicationLibCode/UserInterface/RiuSelectionChangedHandler.cpp:132
+  [14] RiuCellAndNncPickEventHandler::handle3dPickEvent(Ric3dPickEvent const&) at ResInsight/ApplicationLibCode/UserInterface/RiuCellAndNncPickEventHandler.cpp:459
+  [15] RiuViewerCommands::handlePickAction(int, int, QFlags<Qt::KeyboardModifier>) at ResInsight/ApplicationLibCode/UserInterface/RiuViewerCommands.cpp:702
+  [16] QWidget::event(QEvent*) at :0
+  [17] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [18] QApplication::notify(QObject*, QEvent*) at :0
+  [19] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [20] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [21] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [22]  at :0
+  [23]  at :0
+  [24] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [25] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [26] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [27] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [28] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [29]  at :0
+  [30] g_main_context_dispatch at :0
+  [31] g_main_context_iterate.isra.20 at :0
+  [32] g_main_context_iteration at :0
+  [33] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [34] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [35] QCoreApplication::exec() at :0
+  [36] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [37] __libc_start_main at :0
+  [38] _start at :0
+  [39]  at :0
+"
+2026-05-28T07:05:11.473Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] std::terminate() at :0
+  [10] __cxa_rethrow at :0
+  [11] main at ResInsight/ApplicationExeCode/RiaMain.cpp:232
+  [12] __libc_start_main at :0
+  [13] _start at :0
+  [14]  at :0
+"
+2026-05-27T18:54:46.868Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] QObjectPrivate::maybeSignalConnected(unsigned int) const at :0
+  [4]  at :0
+  [5] QComboBox::textActivated(QString const&) at :0
+  [6]  at :0
+  [7]  at :0
+  [8]  at :0
+  [9] QComboBoxPrivateContainer::itemSelected(QModelIndex const&) at :0
+  [10] QComboBoxPrivateContainer::eventFilter(QObject*, QEvent*) at :0
+  [11] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [12] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [13] QApplication::notify(QObject*, QEvent*) at :0
+  [14] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [15] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [16] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [17]  at :0
+  [18]  at :0
+  [19] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [20] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [21] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [22] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [23] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [24]  at :0
+  [25] g_main_context_dispatch at :0
+  [26] g_main_context_iterate.isra.20 at :0
+  [27] g_main_context_iteration at :0
+  [28] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [29] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [30] QCoreApplication::exec() at :0
+  [31] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [32] __libc_start_main at :0
+  [33] _start at :0
+  [34]  at :0
+"
+2026-05-27T18:51:53.243Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] std::terminate() at :0
+  [10] __cxa_rethrow at :0
+  [11] main at ResInsight/ApplicationExeCode/RiaMain.cpp:232
+  [12] __libc_start_main at :0
+  [13] _start at :0
+  [14]  at :0
+"
+2026-05-27T18:25:41.905Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] QObjectPrivate::maybeSignalConnected(unsigned int) const at :0
+  [4]  at :0
+  [5] QComboBox::textActivated(QString const&) at :0
+  [6]  at :0
+  [7]  at :0
+  [8]  at :0
+  [9] QComboBoxPrivateContainer::itemSelected(QModelIndex const&) at :0
+  [10] QComboBoxPrivateContainer::eventFilter(QObject*, QEvent*) at :0
+  [11] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [12] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [13] QApplication::notify(QObject*, QEvent*) at :0
+  [14] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [15] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [16] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [17]  at :0
+  [18]  at :0
+  [19] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [20] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [21] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [22] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [23] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [24]  at :0
+  [25] g_main_context_dispatch at :0
+  [26] g_main_context_iterate.isra.20 at :0
+  [27] g_main_context_iteration at :0
+  [28] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [29] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [30] QCoreApplication::exec() at :0
+  [31] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [32] __libc_start_main at :0
+  [33] _start at :0
+  [34]  at :0
+"
+2026-05-27T17:05:01.563Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] ecl_grid_alloc_EGRID__ at ResInsight/ThirdParty/Ert/lib/ecl/ecl_grid.cpp:3085
+  [4] ecl_grid_alloc_EGRID_all_grids at ResInsight/ThirdParty/Ert/lib/ecl/ecl_grid.cpp:3106
+  [5] RifReaderEclipseOutput::loadAllGrids() const at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp:1161
+  [6] RifReaderEclipseOutput::open(QString const&, RigEclipseCaseData*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp:389
+  [7] RimEclipseResultCase::importGridAndResultMetaData(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultCase.cpp:261
+  [8] RiaImportEclipseCaseTools::openEclipseCaseShowTimeStepFilterImpl(QString const&, bool, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:372
+  [9] RiaImportEclipseCaseTools::openEclipseCasesFromFile(QList<QString> const&, bool, std::map<QString, int, std::less<QString>, std::allocator<std::pair<QString const, int> > >*, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:107
+  [10] RicImportGeneralDataFeature::openEclipseCaseFromFileNames(QList<QString> const&, bool, std::vector<int, std::allocator<int> >&, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:362
+  [11] RicImportEclipseCaseFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/EclipseCommands/RicImportEclipseCaseFeature.cpp:72
+  [12] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+  [13]  at :0
+  [14] QAction::triggered(bool) at :0
+  [15] QAction::activate(QAction::ActionEvent) at :0
+  [16]  at :0
+  [17]  at :0
+  [18] QWidget::event(QEvent*) at :0
+  [19] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [20] QApplication::notify(QObject*, QEvent*) at :0
+  [21] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [22] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [23] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [24]  at :0
+  [25]  at :0
+  [26] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [27] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [28] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [29] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [30] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [31]  at :0
+  [32] g_main_context_dispatch at :0
+  [33] g_main_context_iterate.isra.20 at :0
+  [34] g_main_context_iteration at :0
+  [35] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [36] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [37] QCoreApplication::exec() at :0
+  [38] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [39] __libc_start_main at :0
+  [40] _start at :0
+  [41]  at :0
+"
+2026-05-27T16:52:03.928Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] std::terminate() at :0
+  [10] __cxa_rethrow at :0
+  [11] main at ResInsight/ApplicationExeCode/RiaMain.cpp:232
+  [12] __libc_start_main at :0
+  [13] _start at :0
+  [14]  at :0
+"
+2026-05-27T12:02:44.232Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] std::terminate() at :0
+  [10] __cxa_rethrow at :0
+  [11] main at ResInsight/ApplicationExeCode/RiaMain.cpp:232
+  [12] __libc_start_main at :0
+  [13] _start at :0
+  [14]  at :0
+"
+2026-05-27T11:32:09.606Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] std::terminate() at :0
+  [10] __cxa_rethrow at :0
+  [11] main at ResInsight/ApplicationExeCode/RiaMain.cpp:232
+  [12] __libc_start_main at :0
+  [13] _start at :0
+  [14]  at :0
+"
+2026-05-27T10:59:13.448Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] ecl_kw_get_data_type at ResInsight/ThirdParty/Ert/lib/ecl/ecl_kw.cpp:1776
+  [4] ecl_file_kw_assert_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_kw.cpp:211
+  [5] ecl_file_kw_load_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_kw.cpp:244
+  [6] ecl_file_view_get_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_view.cpp:149
+  [7] RifEclipseOutputFileTools::keywordData(ecl_file_struct const*, QString const&, unsigned long, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseOutputFileTools.cpp:305
+  [8] RifEclipseUnifiedRestartFileAccess::results(QString const&, unsigned long, unsigned long, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseUnifiedRestartFileAccess.cpp:248
+  [9] RifReaderEclipseOutput::dynamicResult(QString const&, RiaDefines::PorosityModelType, unsigned long, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp:1070
+  [10] RigCaseCellResultsData::findOrLoadKnownScalarResult(RigEclipseResultAddress const&) at ResInsight/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp:1538
+  [11] RigCaseCellResultsData::findOrLoadKnownScalarResult(RigEclipseResultAddress const&) at ResInsight/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp:1473
+  [12] RigCaseCellResultsData::ensureKnownResultLoaded(RigEclipseResultAddress const&) at ResInsight/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp:1264
+  [13] RimEclipseResultDefinition::loadResult() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:1134
+  [14] RimEclipseCellColors::loadResult() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCellColors.cpp:260
+  [15] RimEclipseResultDefinition::loadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:533
+  [16] RimEclipseResultDefinition::fieldChangedByUi(caf::PdmFieldHandle const*, QVariant const&, QVariant const&) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:305
+  [17] RimEclipseCellColors::fieldChangedByUi(caf::PdmFieldHandle const*, QVariant const&, QVariant const&) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCellColors.cpp:90
+  [18] caf::PdmUiFieldHandle::notifyFieldChanged(QVariant const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiFieldHandle.cpp:74
+  [19] caf::PdmFieldUiCap<caf::PdmField<QString> >::setValueFromUiEditor(QVariant const&, bool) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafInternalPdmUiFieldCapability.inl:110
+  [20] caf::PdmUiCommandSystemProxy::setUiValueToField(caf::PdmUiFieldHandle*, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiCommandSystemProxy.cpp:122
+  [21] caf::PdmUiTreeSelectionQModel::setData(QModelIndex const&, QVariant const&, int) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionQModel.cpp:482
+  [22] QSortFilterProxyModel::setData(QModelIndex const&, QVariant const&, int) at :0
+  [23] QStyledItemDelegate::editorEvent(QEvent*, QAbstractItemModel*, QStyleOptionViewItem const&, QModelIndex const&) at :0
+  [24]  at :0
+  [25] QAbstractItemView::edit(QModelIndex const&, QAbstractItemView::EditTrigger, QEvent*) at :0
+  [26] QAbstractItemView::mouseReleaseEvent(QMouseEvent*) at :0
+  [27] QWidget::event(QEvent*) at :0
+  [28] QFrame::event(QEvent*) at :0
+  [29] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [30] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [31] QApplication::notify(QObject*, QEvent*) at :0
+  [32] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [33] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [34] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [35]  at :0
+  [36]  at :0
+  [37] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [38] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [39] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [40] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [41] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [42]  at :0
+  [43] g_main_context_dispatch at :0
+  [44] g_main_context_iterate.isra.20 at :0
+  [45] g_main_context_iteration at :0
+  [46] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [47] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [48] QCoreApplication::exec() at :0
+  [49] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [50] __libc_start_main at :0
+  [51] _start at :0
+  [52]  at :0
+"
+2026-05-27T08:54:31.405Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] std::terminate() at :0
+  [10] __cxa_rethrow at :0
+  [11] main at ResInsight/ApplicationExeCode/RiaMain.cpp:232
+  [12] __libc_start_main at :0
+  [13] _start at :0
+  [14]  at :0
+"
+2026-05-27T08:26:30.756Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] caf::PdmUiObjectHandle::uiOrdering(QString const&, caf::PdmUiOrdering&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiObjectHandle.cpp:40
+  [4] RimContourMapProjection::defineUiOrdering(QString, caf::PdmUiOrdering&) at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimContourMapProjection.cpp:616
+  [5] RimEclipseContourMapProjection::defineUiOrdering(QString, caf::PdmUiOrdering&) at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapProjection.cpp:333
+  [6] caf::PdmUiObjectHandle::uiOrdering(QString const&, caf::PdmUiOrdering&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiObjectHandle.cpp:40
+  [7] caf::PdmUiFormLayoutObjectEditor::configureAndUpdateUi(QString const&) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiFormLayoutObjectEditor.cpp:670
+  [8] caf::PdmUiEditorHandle::updateUi(QString const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiEditorHandle.cpp:66
+  [9] caf::PdmUiPropertyView::showProperties(caf::PdmObjectHandle*) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiPropertyView.cpp:213
+  [10] RiuMainWindow::selectedObjectsChanged() at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:1530
+  [11]  at :0
+  [12] caf::PdmUiTreeView::slotOnSelectionChanged() at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeView.cpp:154
+  [13]  at :0
+  [14]  at :0
+  [15] QItemSelectionModel::selectionChanged(QItemSelection const&, QItemSelection const&) at :0
+  [16] QItemSelectionModel::emitSelectionChanged(QItemSelection const&, QItemSelection const&) at :0
+  [17] QItemSelectionModel::select(QItemSelection const&, QFlags<QItemSelectionModel::SelectionFlag>) at :0
+  [18] QTreeViewPrivate::select(QModelIndex const&, QModelIndex const&, QFlags<QItemSelectionModel::SelectionFlag>) at :0
+  [19] QTreeView::setSelection(QRect const&, QFlags<QItemSelectionModel::SelectionFlag>) at :0
+  [20] QAbstractItemView::mousePressEvent(QMouseEvent*) at :0
+  [21] QWidget::event(QEvent*) at :0
+  [22] QFrame::event(QEvent*) at :0
+  [23] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [24] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [25] QApplication::notify(QObject*, QEvent*) at :0
+  [26] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [27] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [28] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [29]  at :0
+  [30]  at :0
+  [31] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [32] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [33] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [34] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [35] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [36]  at :0
+  [37] g_main_context_dispatch at :0
+  [38] g_main_context_iterate.isra.20 at :0
+  [39] g_main_context_iteration at :0
+  [40] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [41] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [42] QCoreApplication::exec() at :0
+  [43] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [44] __libc_start_main at :0
+  [45] _start at :0
+  [46]  at :0
+"
+2026-05-26T13:23:28.149Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] H5::H5Location::createGroup(char const*, unsigned long) const at :0
+  [4] H5::H5Location::createGroup(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, unsigned long) const at :0
+  [5] RifHdf5Exporter::createGroup(H5::Group*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) at ResInsight/ApplicationLibCode/FileInterface/RifHdf5Exporter.cpp:117
+  [6] RifHdf5SummaryExporter::writeGeneralSection(RifHdf5Exporter&, Opm::EclIO::ESmry&) at ResInsight/ApplicationLibCode/FileInterface/RifHdf5SummaryExporter.cpp:167
+  [7] RifHdf5SummaryExporter::ensureHdf5FileIsCreated(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool, unsigned long&) at ResInsight/ApplicationLibCode/FileInterface/RifHdf5SummaryExporter.cpp:141
+  [8] RifReaderEclipseSummary::open(QString const&, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseSummary.cpp:107
+  [9] RifSummaryReaderAggregator::createReadersAndImportMetaData(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/FileInterface/RifSummaryReaderAggregator.cpp:156
+  [10] RimFileSummaryCase::findRelatedFilesAndCreateReader(QString const&, bool, RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:221
+  [11] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:110
+  [12] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+  [13] gomp_thread_start at :0
+  [14] start_thread at :0
+  [15] __GI___clone at :0
+  [16]  at :0
+"
+2026-05-26T13:15:12.175Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] QDateTime::isValid() const at :0
+  [4] QDateTime::equals(QDateTime const&) const at :0
+  [5] operator==(QDateTime const&, QDateTime const&) at /private/f_resinsight_build/resbuild/qt/6.6.3/gcc_64/include/QtCore/qdatetime.h:526
+  [6] RimWellConnectivityTable::isTimeStepInCase(QDateTime const&) const at ResInsight/ApplicationLibCode/ProjectDataModel/Flow/RimWellConnectivityTable.cpp:1040
+  [7] RimWellConnectivityTable::setValidSingleTimeStepForCase() at ResInsight/ApplicationLibCode/ProjectDataModel/Flow/RimWellConnectivityTable.cpp:1004
+  [8] RimWellConnectivityTable::setValidTimeStepSelectionsForCase() at ResInsight/ApplicationLibCode/ProjectDataModel/Flow/RimWellConnectivityTable.cpp:990
+  [9] RimWellConnectivityTable::fieldChangedByUi(caf::PdmFieldHandle const*, QVariant const&, QVariant const&) at ResInsight/ApplicationLibCode/ProjectDataModel/Flow/RimWellConnectivityTable.cpp:297
+  [10] caf::PdmUiFieldHandle::notifyFieldChanged(QVariant const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiFieldHandle.cpp:74
+  [11] caf::PdmFieldUiCap<caf::PdmPtrField<RimEclipseResultCase*> >::setValueFromUiEditor(QVariant const&, bool) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafInternalPdmUiFieldCapability.inl:110
+  [12] caf::CmdFieldChangeExec::redo() at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFieldChangeExec.cpp:139
+  [13] QUndoStack::push(QUndoCommand*) at :0
+  [14] caf::CmdUiCommandSystemImpl::fieldChangedCommand(std::vector<caf::PdmFieldHandle*, std::allocator<caf::PdmFieldHandle*> > const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdUiCommandSystemImpl.cpp:146
+  [15] caf::PdmUiCommandSystemProxy::setUiValueToField(caf::PdmUiFieldHandle*, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiCommandSystemProxy.cpp:113
+  [16] caf::PdmUiComboBoxEditor::slotIndexActivated(int) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiComboBoxEditor.cpp:455
+  [17]  at :0
+  [18] QComboBox::activated(int) at :0
+  [19]  at :0
+  [20]  at :0
+  [21]  at :0
+  [22] QComboBoxPrivateContainer::itemSelected(QModelIndex const&) at :0
+  [23] QComboBoxPrivateContainer::eventFilter(QObject*, QEvent*) at :0
+  [24] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [25] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [26] QApplication::notify(QObject*, QEvent*) at :0
+  [27] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [28] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [29] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [30]  at :0
+  [31]  at :0
+  [32] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [33] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [34] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [35] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [36] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [37]  at :0
+  [38] g_main_context_dispatch at :0
+  [39] g_main_context_iterate.isra.20 at :0
+  [40] g_main_context_iteration at :0
+  [41] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [42] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [43] QCoreApplication::exec() at :0
+  [44] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [45] __libc_start_main at :0
+  [46] _start at :0
+  [47]  at :0
+"
+2026-05-26T12:36:49.791Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] std::terminate() at :0
+  [10] __cxa_rethrow at :0
+  [11] main at ResInsight/ApplicationExeCode/RiaMain.cpp:232
+  [12] __libc_start_main at :0
+  [13] _start at :0
+  [14]  at :0
+"
+2026-05-26T12:34:51.666Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] RimEclipseCase::eclipseCaseData() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCase.cpp:179
+  [4] RigSimulationWellCenterLineCalculator::calculateWellPipeStaticCenterline(RimSimWellInView const*, std::vector<std::vector<cvf::Vector3<double>, std::allocator<cvf::Vector3<double> > >, std::allocator<std::vector<cvf::Vector3<double>, std::allocator<cvf::Vector3<double> > > > >&, std::vector<std::vector<RigWellResultPoint, std::allocator<RigWellResultPoint> >, std::allocator<std::vector<RigWellResultPoint, std::allocator<RigWellResultPoint> > > >&) at ResInsight/ApplicationLibCode/ReservoirDataModel/Well/RigSimulationWellCenterLineCalculator.cpp:132
+  [5] RigSimulationWellCenterLineCalculator::calculateWellPipeStaticCenterline(RimSimWellInView const*) at ResInsight/ApplicationLibCode/ReservoirDataModel/Well/RigSimulationWellCenterLineCalculator.cpp:51
+  [6] RimSimWellInView::wellBranchesForVisualization() const at ResInsight/ApplicationLibCode/ProjectDataModel/RimSimWellInView.cpp:190
+  [7] RivSimWellPipesPartMgr::buildWellPipeParts(caf::DisplayCoordTransform const*, bool, double, int, unsigned long) at ResInsight/ApplicationLibCode/ModelVisualization/RivSimWellPipesPartMgr.cpp:169
+  [8] RivSimWellPipesPartMgr::appendDynamicGeometryPartsToModel(cvf::ModelBasicList*, unsigned long, caf::DisplayCoordTransform const*) at ResInsight/ApplicationLibCode/ModelVisualization/RivSimWellPipesPartMgr.cpp:98
+  [9] RivReservoirSimWellsPartMgr::appendDynamicGeometryPartsToModel(cvf::ModelBasicList*, unsigned long) at ResInsight/ApplicationLibCode/ModelVisualization/RivReservoirSimWellsPartMgr.cpp:110
+  [10] RimEclipseView::appendWellsAndFracturesToModel() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp:1093
+  [11] RimEclipseView::onUpdateDisplayModelForCurrentTimeStep() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp:897
+  [12] Rim3dView::updateDisplayModelForCurrentTimeStepAndRedraw() at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:673
+  [13] RiuViewer::setCurrentFrame(int) at ResInsight/ApplicationLibCode/UserInterface/RiuViewer.cpp:1008
+  [14] RiuViewer::slotSetCurrentFrame(int) at ResInsight/ApplicationLibCode/UserInterface/RiuViewer.cpp:348
+  [15]  at :0
+  [16] caf::FrameAnimationControl::changeFrame(int) at ResInsight/cmakebuild/Fwk/AppFwk/cafAnimControl/cafAnimControl_autogen/EWIEGA46WW/moc_cafFrameAnimationControl.cpp:321
+  [17]  at :0
+  [18] QAction::triggered(bool) at :0
+  [19] QAction::activate(QAction::ActionEvent) at :0
+  [20]  at :0
+  [21] QAbstractButton::mouseReleaseEvent(QMouseEvent*) at :0
+  [22] QToolButton::mouseReleaseEvent(QMouseEvent*) at :0
+  [23] QWidget::event(QEvent*) at :0
+  [24] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [25] QApplication::notify(QObject*, QEvent*) at :0
+  [26] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [27] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [28] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [29]  at :0
+  [30]  at :0
+  [31] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [32] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [33] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [34] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [35] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [36]  at :0
+  [37] g_main_context_dispatch at :0
+  [38] g_main_context_iterate.isra.20 at :0
+  [39] g_main_context_iteration at :0
+  [40] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [41] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [42] QCoreApplication::exec() at :0
+  [43] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [44] __libc_start_main at :0
+  [45] _start at :0
+  [46]  at :0
+"
+2026-05-26T12:14:42.923Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] std::terminate() at :0
+  [10] __cxa_rethrow at :0
+  [11] main at ResInsight/ApplicationExeCode/RiaMain.cpp:232
+  [12] __libc_start_main at :0
+  [13] _start at :0
+  [14]  at :0
+"
+2026-05-26T10:35:07.307Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] std::terminate() at :0
+  [10] __cxa_rethrow at :0
+  [11] main at ResInsight/ApplicationExeCode/RiaMain.cpp:232
+  [12] __libc_start_main at :0
+  [13] _start at :0
+  [14]  at :0
+"
+2026-05-26T08:16:04.63Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] std::terminate() at :0
+  [10] __cxa_rethrow at :0
+  [11] main at ResInsight/ApplicationExeCode/RiaMain.cpp:232
+  [12] __libc_start_main at :0
+  [13] _start at :0
+  [14]  at :0
+"
+2026-05-26T08:15:21.447Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] std::terminate() at :0
+  [10] __cxa_rethrow at :0
+  [11] main at ResInsight/ApplicationExeCode/RiaMain.cpp:232
+  [12] __libc_start_main at :0
+  [13] _start at :0
+  [14]  at :0
+"
+2026-05-26T08:14:36.764Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] std::terminate() at :0
+  [10] __cxa_rethrow at :0
+  [11] main at ResInsight/ApplicationExeCode/RiaMain.cpp:232
+  [12] __libc_start_main at :0
+  [13] _start at :0
+  [14]  at :0
+"
+2026-05-26T07:35:50.673Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] RimEclipseCase::eclipseCaseData() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCase.cpp:179
+  [4] RigSimulationWellCenterLineCalculator::calculateWellPipeStaticCenterline(RimSimWellInView const*, std::vector<std::vector<cvf::Vector3<double>, std::allocator<cvf::Vector3<double> > >, std::allocator<std::vector<cvf::Vector3<double>, std::allocator<cvf::Vector3<double> > > > >&, std::vector<std::vector<RigWellResultPoint, std::allocator<RigWellResultPoint> >, std::allocator<std::vector<RigWellResultPoint, std::allocator<RigWellResultPoint> > > >&) at ResInsight/ApplicationLibCode/ReservoirDataModel/Well/RigSimulationWellCenterLineCalculator.cpp:132
+  [5] RigSimulationWellCenterLineCalculator::calculateWellPipeStaticCenterline(RimSimWellInView const*) at ResInsight/ApplicationLibCode/ReservoirDataModel/Well/RigSimulationWellCenterLineCalculator.cpp:51
+  [6] RimSimWellInView::wellBranchesForVisualization() const at ResInsight/ApplicationLibCode/ProjectDataModel/RimSimWellInView.cpp:190
+  [7] RivSimWellPipesPartMgr::buildWellPipeParts(caf::DisplayCoordTransform const*, bool, double, int, unsigned long) at ResInsight/ApplicationLibCode/ModelVisualization/RivSimWellPipesPartMgr.cpp:169
+  [8] RivSimWellPipesPartMgr::appendDynamicGeometryPartsToModel(cvf::ModelBasicList*, unsigned long, caf::DisplayCoordTransform const*) at ResInsight/ApplicationLibCode/ModelVisualization/RivSimWellPipesPartMgr.cpp:98
+  [9] RivReservoirSimWellsPartMgr::appendDynamicGeometryPartsToModel(cvf::ModelBasicList*, unsigned long) at ResInsight/ApplicationLibCode/ModelVisualization/RivReservoirSimWellsPartMgr.cpp:110
+  [10] RimEclipseView::appendWellsAndFracturesToModel() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp:1093
+  [11] RimEclipseView::onUpdateDisplayModelForCurrentTimeStep() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp:897
+  [12] Rim3dView::updateDisplayModelForCurrentTimeStepAndRedraw() at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:673
+  [13] RiuViewer::setCurrentFrame(int) at ResInsight/ApplicationLibCode/UserInterface/RiuViewer.cpp:1008
+  [14] RiuViewer::slotSetCurrentFrame(int) at ResInsight/ApplicationLibCode/UserInterface/RiuViewer.cpp:348
+  [15]  at :0
+  [16] caf::FrameAnimationControl::changeFrame(int) at ResInsight/cmakebuild/Fwk/AppFwk/cafAnimControl/cafAnimControl_autogen/EWIEGA46WW/moc_cafFrameAnimationControl.cpp:321
+  [17]  at :0
+  [18] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [19] QObject::event(QEvent*) at :0
+  [20] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [21] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [22] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [23] QTimerInfoList::activateTimers() at :0
+  [24]  at :0
+  [25] g_main_context_dispatch at :0
+  [26] g_main_context_iterate.isra.20 at :0
+  [27] g_main_context_iteration at :0
+  [28] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [29] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [30] QCoreApplication::exec() at :0
+  [31] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [32] __libc_start_main at :0
+  [33] _start at :0
+  [34]  at :0
+"
+2026-05-26T04:14:11.7Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] internal_fallocate at :0
+  [4] g_main_context_iterate.isra.20 at :0
+  [5] g_main_context_iteration at :0
+  [6] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [7] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [8] QCoreApplication::exec() at :0
+  [9] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [10] __libc_start_main at :0
+  [11] _start at :0
+  [12]  at :0
+"
+2026-05-26T04:14:11.7Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] internal_fallocate at :0
+  [4] g_main_context_iterate.isra.20 at :0
+  [5] g_main_context_iteration at :0
+  [6] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [7] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [8] QCoreApplication::exec() at :0
+  [9] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [10] __libc_start_main at :0
+  [11] _start at :0
+  [12]  at :0
+"
+2026-05-25T21:44:13.418Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] caf::PdmFieldUiCap<caf::PdmField<QDateTime> >::setValueFromUiEditor(QVariant const&, bool) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafInternalPdmUiFieldCapability.inl:30
+  [6] caf::CmdFieldChangeExec::redo() at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFieldChangeExec.cpp:139
+  [7] QUndoStack::push(QUndoCommand*) at :0
+  [8] caf::CmdUiCommandSystemImpl::fieldChangedCommand(std::vector<caf::PdmFieldHandle*, std::allocator<caf::PdmFieldHandle*> > const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdUiCommandSystemImpl.cpp:146
+  [9] caf::PdmUiCommandSystemProxy::setUiValueToField(caf::PdmUiFieldHandle*, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiCommandSystemProxy.cpp:113
+  [10] caf::PdmUiComboBoxEditor::slotIndexActivated(int) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiComboBoxEditor.cpp:455
+  [11]  at :0
+  [12] QComboBox::activated(int) at :0
+  [13]  at :0
+  [14]  at :0
+  [15]  at :0
+  [16] QComboBoxPrivateContainer::itemSelected(QModelIndex const&) at :0
+  [17] QComboBoxPrivateContainer::eventFilter(QObject*, QEvent*) at :0
+  [18] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [19] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [20] QApplication::notify(QObject*, QEvent*) at :0
+  [21] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [22] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [23] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [24]  at :0
+  [25]  at :0
+  [26] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [27] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [28] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [29] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [30] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [31]  at :0
+  [32] g_main_context_dispatch at :0
+  [33] g_main_context_iterate.isra.20 at :0
+  [34] g_main_context_iteration at :0
+  [35] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [36] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [37] QCoreApplication::exec() at :0
+  [38] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [39] __libc_start_main at :0
+  [40] _start at :0
+  [41]  at :0
+"
+2026-05-25T19:56:45.084Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] std::terminate() at :0
+  [10] __cxa_rethrow at :0
+  [11] main at ResInsight/ApplicationExeCode/RiaMain.cpp:232
+  [12] __libc_start_main at :0
+  [13] _start at :0
+  [14]  at :0
+"
+2026-05-25T18:29:50.059Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] ecl_grid_alloc_EGRID__ at ResInsight/ThirdParty/Ert/lib/ecl/ecl_grid.cpp:3085
+  [4] ecl_grid_alloc_EGRID_all_grids at ResInsight/ThirdParty/Ert/lib/ecl/ecl_grid.cpp:3106
+  [5] RifReaderEclipseOutput::loadAllGrids() const at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp:1161
+  [6] RifReaderEclipseOutput::open(QString const&, RigEclipseCaseData*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp:389
+  [7] RimEclipseResultCase::importGridAndResultMetaData(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultCase.cpp:261
+  [8] RiaImportEclipseCaseTools::openEclipseCaseShowTimeStepFilterImpl(QString const&, bool, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:372
+  [9] RiaImportEclipseCaseTools::openEclipseCasesFromFile(QList<QString> const&, bool, std::map<QString, int, std::less<QString>, std::allocator<std::pair<QString const, int> > >*, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:107
+  [10] RicImportGeneralDataFeature::openEclipseCaseFromFileNames(QList<QString> const&, bool, std::vector<int, std::allocator<int> >&, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:362
+  [11] RicImportEclipseCaseFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/EclipseCommands/RicImportEclipseCaseFeature.cpp:72
+  [12] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+  [13]  at :0
+  [14] QAction::triggered(bool) at :0
+  [15] QAction::activate(QAction::ActionEvent) at :0
+  [16]  at :0
+  [17]  at :0
+  [18] QWidget::event(QEvent*) at :0
+  [19] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [20] QApplication::notify(QObject*, QEvent*) at :0
+  [21] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [22] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [23] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [24]  at :0
+  [25]  at :0
+  [26] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [27] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [28] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [29] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [30] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [31]  at :0
+  [32] g_main_context_dispatch at :0
+  [33] g_main_context_iterate.isra.20 at :0
+  [34] g_main_context_iteration at :0
+  [35] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [36] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [37] QCoreApplication::exec() at :0
+  [38] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [39] __libc_start_main at :0
+  [40] _start at :0
+  [41]  at :0
+"
+2026-05-25T16:15:11.708Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __libc_poll at :0
+  [4] g_main_context_iterate.isra.20 at :0
+  [5] g_main_context_iteration at :0
+  [6] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [7] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [8] QCoreApplication::exec() at :0
+  [9] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [10] __libc_start_main at :0
+  [11] _start at :0
+  [12]  at :0
+"
+2026-05-25T14:11:16.015Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] caf::TickMarkGenerator::roundUpToLog_1_2_5_10(double) at ResInsight/Fwk/AppFwk/CommonCode/cafTickMarkGenerator.h:74
+  [6] caf::OverlayScaleLegend::updateFromCamera(cvf::Camera const*) at ResInsight/Fwk/AppFwk/cafVizExtensions/cafOverlayScaleLegend.cpp:762
+  [7] RiuViewer::optimizeClippingPlanes() at ResInsight/ApplicationLibCode/UserInterface/RiuViewer.cpp:1062
+  [8] caf::Viewer::paintGL() at ResInsight/Fwk/AppFwk/cafViewer/cafViewer.cpp:884
+  [9]  at :0
+  [10] QWidget::event(QEvent*) at :0
+  [11] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [12] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [13] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [14] QWidgetPrivate::sendPaintEvent(QRegion const&) at :0
+  [15] QOpenGLWidget::resizeEvent(QResizeEvent*) at :0
+  [16] QWidget::event(QEvent*) at :0
+  [17] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [18] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [19] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [20] QWidgetPrivate::setGeometry_sys(int, int, int, int, bool) at :0
+  [21] QWidget::setGeometry(QRect const&) at :0
+  [22] QWidgetItem::setGeometry(QRect const&) at :0
+  [23] QBoxLayout::setGeometry(QRect const&) at :0
+  [24] QLayoutPrivate::doResize() at :0
+  [25] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [26] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [27] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [28] QWidgetPrivate::setGeometry_sys(int, int, int, int, bool) at :0
+  [29] QWidget::setGeometry(QRect const&) at :0
+  [30] QWidgetItem::setGeometry(QRect const&) at :0
+  [31] QBoxLayout::setGeometry(QRect const&) at :0
+  [32] QLayoutPrivate::doResize() at :0
+  [33] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [34] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [35] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [36] QWidgetPrivate::setGeometry_sys(int, int, int, int, bool) at :0
+  [37] QWidget::resize(QSize const&) at :0
+  [38] QMdiArea::resizeEvent(QResizeEvent*) at :0
+  [39] QWidget::event(QEvent*) at :0
+  [40] QFrame::event(QEvent*) at :0
+  [41] QMdiArea::viewportEvent(QEvent*) at :0
+  [42] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [43] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [44] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [45] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [46] QWidgetPrivate::setGeometry_sys(int, int, int, int, bool) at :0
+  [47] QWidget::setGeometry(QRect const&) at :0
+  [48]  at :0
+  [49] QAbstractScrollArea::event(QEvent*) at :0
+  [50] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [51] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [52] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [53] QWidgetPrivate::setGeometry_sys(int, int, int, int, bool) at :0
+  [54] QWidget::setGeometry(QRect const&) at :0
+  [55] QWidgetItem::setGeometry(QRect const&) at :0
+  [56] QBoxLayout::setGeometry(QRect const&) at :0
+  [57] QLayoutPrivate::doResize() at :0
+  [58] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [59] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [60] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [61] QWidgetPrivate::setGeometry_sys(int, int, int, int, bool) at :0
+  [62] QWidget::setGeometry(QRect const&) at :0
+  [63] QWidgetItem::setGeometry(QRect const&) at :0
+  [64] QBoxLayout::setGeometry(QRect const&) at :0
+  [65] QLayoutPrivate::doResize() at :0
+  [66] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [67] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [68] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [69] QWidgetPrivate::setGeometry_sys(int, int, int, int, bool) at :0
+  [70] QWidget::setGeometry(QRect const&) at :0
+  [71]  at :0
+  [72]  at :0
+  [73] QWidget::event(QEvent*) at :0
+  [74] QFrame::event(QEvent*) at :0
+  [75] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [76] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [77] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [78] QWidgetPrivate::setGeometry_sys(int, int, int, int, bool) at :0
+  [79] QWidget::setGeometry(QRect const&) at :0
+  [80]  at :0
+  [81]  at :0
+  [82] QWidget::event(QEvent*) at :0
+  [83] QFrame::event(QEvent*) at :0
+  [84] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [85] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [86] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [87] QWidgetPrivate::setGeometry_sys(int, int, int, int, bool) at :0
+  [88] QWidget::setGeometry(QRect const&) at :0
+  [89]  at :0
+  [90]  at :0
+  [91] QWidget::event(QEvent*) at :0
+  [92] QFrame::event(QEvent*) at :0
+  [93] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [94] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [95] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [96] QWidgetPrivate::setGeometry_sys(int, int, int, int, bool) at :0
+  [97] QWidget::setGeometry(QRect const&) at :0
+  [98] QWidgetItem::setGeometry(QRect const&) at :0
+  [99]  at :0
+  [100] QGridLayout::setGeometry(QRect const&) at :0
+  [101] QLayoutPrivate::doResize() at :0
+  [102] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [103] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [104] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [105] QWidgetPrivate::setGeometry_sys(int, int, int, int, bool) at :0
+  [106] QWidget::setGeometry(QRect const&) at :0
+  [107] QWidget::qt_metacall(QMetaObject::Call, int, void**) at :0
+  [108] QFrame::qt_metacall(QMetaObject::Call, int, void**) at :0
+  [109] ads::CDockContainerWidget::qt_metacall(QMetaObject::Call, int, void**) at ResInsight/cmakebuild/ThirdParty/qtadvanceddocking/src/qtadvanceddocking-qt6_autogen/EWIEGA46WW/moc_DockContainerWidget.cpp:212
+  [110] ads::CDockManager::qt_metacall(QMetaObject::Call, int, void**) at ResInsight/cmakebuild/ThirdParty/qtadvanceddocking/src/qtadvanceddocking-qt6_autogen/EWIEGA46WW/moc_DockManager.cpp:480
+  [111] QPropertyAnimation::updateCurrentValue(QVariant const&) at :0
+  [112]  at :0
+  [113] QPropertyAnimation::updateState(QAbstractAnimation::State, QAbstractAnimation::State) at :0
+  [114] QAbstractAnimationPrivate::setState(QAbstractAnimation::State) at :0
+  [115]  at :0
+  [116]  at :0
+  [117]  at :0
+  [118]  at :0
+  [119] QLayoutPrivate::doResize() at :0
+  [120] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [121] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [122] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [123]  at :0
+  [124]  at :0
+  [125] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [126] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [127] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [128] QGuiApplicationPrivate::processGeometryChangeEvent(QWindowSystemInterfacePrivate::GeometryChangeEvent*) at :0
+  [129] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [130]  at :0
+  [131] g_main_context_dispatch at :0
+  [132] g_main_context_iterate.isra.20 at :0
+  [133] g_main_context_iteration at :0
+  [134] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [135] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [136] QCoreApplication::exec() at :0
+  [137] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [138] __libc_start_main at :0
+  [139] _start at :0
+  [140]  at :0
+"
+2026-05-24T19:51:04.001Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] GOMP_parallel at :0
+  [10] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:257
+  [11] RicExportFractureCompletionsImpl::generateCompdatValues(RimEclipseCase*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:169
+  [12] RicExportFractureCompletionsImpl::generateCompdatValuesForWellPath(RimWellPath*, RimEclipseCase*, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:94
+  [13] RicWellPathExportCompletionDataFeatureImpl::exportCompletions(std::vector<RimWellPath*, std::allocator<RimWellPath*> > const&, RicExportCompletionDataSettingsUi const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportCompletionDataFeatureImpl.cpp:227
+  [14] RicfExportWellPathCompletions::execute() at ResInsight/ApplicationLibCode/CommandFileInterface/RicfExportWellPathCompletions.cpp:184
+  [15] RiaGrpcCommandService::Execute(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) at ResInsight/GrpcInterface/RiaGrpcCommandService.cpp:92
+  [16] grpc::Status std::__invoke_impl<grpc::Status, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*>(std::__invoke_memfun_ref, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*&&, rips::CommandParams const*&&, rips::CommandReply*&&) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/invoke.h:67
+  [17] std::function<grpc::Status (RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*)>::operator()(RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:591
+  [18] RiaGrpcServerImpl::processAllQueuedRequests() at ResInsight/GrpcInterface/RiaGrpcServer.cpp:197
+  [19] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:115
+  [20] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:33
+  [21]  at :0
+  [22] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [23] QObject::event(QEvent*) at :0
+  [24] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [25] QTimerInfoList::activateTimers() at :0
+  [26]  at :0
+  [27] g_main_context_dispatch at :0
+  [28] g_main_context_iterate.isra.20 at :0
+  [29] g_main_context_iteration at :0
+  [30] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [31] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [32] QCoreApplication::exec() at :0
+  [33] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [34] __libc_start_main at :0
+  [35] _start at :0
+  [36]  at :0
+"
+2026-05-24T19:51:03.037Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] __GI___clone at :0
+  [12]  at :0
+"
+2026-05-24T19:51:02.589Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] __GI___clone at :0
+  [12]  at :0
+"
+2026-05-24T19:51:01.973Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] __GI___clone at :0
+  [12]  at :0
+"
+2026-05-24T19:51:01.421Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] __GI___clone at :0
+  [12]  at :0
+"
+2026-05-24T19:51:01.194Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] __GI___clone at :0
+  [12]  at :0
+"
+2026-05-24T19:51:01.194Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] __GI___clone at :0
+  [12]  at :0
+"
+2026-05-24T19:51:01.194Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] __GI___clone at :0
+  [12]  at :0
+"
+2026-05-24T19:51:01.194Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] __GI___clone at :0
+  [12]  at :0
+"
+2026-05-24T18:20:29.324Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] GOMP_parallel at :0
+  [10] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:257
+  [11] RicExportFractureCompletionsImpl::generateCompdatValues(RimEclipseCase*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:169
+  [12] RicExportFractureCompletionsImpl::generateCompdatValuesForWellPath(RimWellPath*, RimEclipseCase*, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:94
+  [13] RicWellPathExportCompletionDataFeatureImpl::exportCompletions(std::vector<RimWellPath*, std::allocator<RimWellPath*> > const&, RicExportCompletionDataSettingsUi const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportCompletionDataFeatureImpl.cpp:227
+  [14] RicfExportWellPathCompletions::execute() at ResInsight/ApplicationLibCode/CommandFileInterface/RicfExportWellPathCompletions.cpp:184
+  [15] RiaGrpcCommandService::Execute(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) at ResInsight/GrpcInterface/RiaGrpcCommandService.cpp:92
+  [16] grpc::Status std::__invoke_impl<grpc::Status, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*>(std::__invoke_memfun_ref, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*&&, rips::CommandParams const*&&, rips::CommandReply*&&) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/invoke.h:67
+  [17] std::function<grpc::Status (RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*)>::operator()(RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:591
+  [18] RiaGrpcServerImpl::processAllQueuedRequests() at ResInsight/GrpcInterface/RiaGrpcServer.cpp:197
+  [19] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:115
+  [20] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:33
+  [21]  at :0
+  [22] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [23] QObject::event(QEvent*) at :0
+  [24] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [25] QTimerInfoList::activateTimers() at :0
+  [26]  at :0
+  [27] g_main_context_dispatch at :0
+  [28] g_main_context_iterate.isra.20 at :0
+  [29] g_main_context_iteration at :0
+  [30] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [31] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [32] QCoreApplication::exec() at :0
+  [33] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [34] __libc_start_main at :0
+  [35] _start at :0
+  [36]  at :0
+"
+2026-05-24T18:20:29.168Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] __GI___clone at :0
+  [12]  at :0
+"
+2026-05-24T18:20:29.05Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] __GI___clone at :0
+  [12]  at :0
+"
+2026-05-24T18:20:28.933Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] __GI___clone at :0
+  [12]  at :0
+"
+2026-05-24T18:20:28.814Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] __GI___clone at :0
+  [12]  at :0
+"
+2026-05-24T18:20:28.763Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] __GI___clone at :0
+  [12]  at :0
+"
+2026-05-24T18:15:06.828Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] __GI___clone at :0
+  [12]  at :0
+"
+2026-05-24T18:15:06.707Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] __GI___clone at :0
+  [12]  at :0
+"
+2026-05-24T18:15:06.59Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] __GI___clone at :0
+  [12]  at :0
+"
+2026-05-24T18:15:06.467Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] __GI___clone at :0
+  [12]  at :0
+"
+2026-05-24T18:15:06.348Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] __GI___clone at :0
+  [12]  at :0
+"
+2026-05-24T18:15:06.231Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] __GI___clone at :0
+  [12]  at :0
+"
+2026-05-24T18:15:06.13Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] GOMP_parallel at :0
+  [10] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:257
+  [11] RicExportFractureCompletionsImpl::generateCompdatValues(RimEclipseCase*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:169
+  [12] RicExportFractureCompletionsImpl::generateCompdatValuesForWellPath(RimWellPath*, RimEclipseCase*, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:94
+  [13] RicWellPathExportCompletionDataFeatureImpl::exportCompletions(std::vector<RimWellPath*, std::allocator<RimWellPath*> > const&, RicExportCompletionDataSettingsUi const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportCompletionDataFeatureImpl.cpp:227
+  [14] RicfExportWellPathCompletions::execute() at ResInsight/ApplicationLibCode/CommandFileInterface/RicfExportWellPathCompletions.cpp:184
+  [15] RiaGrpcCommandService::Execute(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) at ResInsight/GrpcInterface/RiaGrpcCommandService.cpp:92
+  [16] grpc::Status std::__invoke_impl<grpc::Status, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*>(std::__invoke_memfun_ref, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*&&, rips::CommandParams const*&&, rips::CommandReply*&&) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/invoke.h:67
+  [17] std::function<grpc::Status (RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*)>::operator()(RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:591
+  [18] RiaGrpcServerImpl::processAllQueuedRequests() at ResInsight/GrpcInterface/RiaGrpcServer.cpp:197
+  [19] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:115
+  [20] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:33
+  [21]  at :0
+  [22] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [23] QObject::event(QEvent*) at :0
+  [24] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [25] QTimerInfoList::activateTimers() at :0
+  [26]  at :0
+  [27] g_main_context_dispatch at :0
+  [28] g_main_context_iterate.isra.20 at :0
+  [29] g_main_context_iteration at :0
+  [30] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [31] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [32] QCoreApplication::exec() at :0
+  [33] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [34] __libc_start_main at :0
+  [35] _start at :0
+  [36]  at :0
+"
+2026-05-24T18:15:06.108Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] __GI___clone at :0
+  [12]  at :0
+"
+2026-05-24T18:15:06.067Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] __GI___clone at :0
+  [12]  at :0
+"
+2026-05-24T18:14:46.337Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] GOMP_parallel at :0
+  [10] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:257
+  [11] RicExportFractureCompletionsImpl::generateCompdatValues(RimEclipseCase*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:169
+  [12] RicExportFractureCompletionsImpl::generateCompdatValuesForWellPath(RimWellPath*, RimEclipseCase*, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:94
+  [13] RicWellPathExportCompletionDataFeatureImpl::exportCompletions(std::vector<RimWellPath*, std::allocator<RimWellPath*> > const&, RicExportCompletionDataSettingsUi const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportCompletionDataFeatureImpl.cpp:227
+  [14] RicfExportWellPathCompletions::execute() at ResInsight/ApplicationLibCode/CommandFileInterface/RicfExportWellPathCompletions.cpp:184
+  [15] RiaGrpcCommandService::Execute(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) at ResInsight/GrpcInterface/RiaGrpcCommandService.cpp:92
+  [16] grpc::Status std::__invoke_impl<grpc::Status, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*>(std::__invoke_memfun_ref, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*&&, rips::CommandParams const*&&, rips::CommandReply*&&) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/invoke.h:67
+  [17] std::function<grpc::Status (RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*)>::operator()(RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:591
+  [18] RiaGrpcServerImpl::processAllQueuedRequests() at ResInsight/GrpcInterface/RiaGrpcServer.cpp:197
+  [19] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:115
+  [20] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:33
+  [21]  at :0
+  [22] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [23] QObject::event(QEvent*) at :0
+  [24] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [25] QTimerInfoList::activateTimers() at :0
+  [26]  at :0
+  [27] g_main_context_dispatch at :0
+  [28] g_main_context_iterate.isra.20 at :0
+  [29] g_main_context_iteration at :0
+  [30] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [31] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [32] QCoreApplication::exec() at :0
+  [33] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [34] __libc_start_main at :0
+  [35] _start at :0
+  [36]  at :0
+"
+2026-05-24T18:14:46.172Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] __GI___clone at :0
+  [12]  at :0
+"
+2026-05-24T18:14:46.051Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] __GI___clone at :0
+  [12]  at :0
+"
+2026-05-24T18:14:45.931Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] __GI___clone at :0
+  [12]  at :0
+"
+2026-05-24T18:14:45.803Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] __GI___clone at :0
+  [12]  at :0
+"
+2026-05-24T18:14:45.68Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] __GI___clone at :0
+  [12]  at :0
+"
+2026-05-24T18:14:45.561Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] __GI___clone at :0
+  [12]  at :0
+"
+2026-05-24T18:14:45.442Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] __GI___clone at :0
+  [12]  at :0
+"
+2026-05-24T18:14:45.391Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] __GI___clone at :0
+  [12]  at :0
+"
+2026-05-24T18:14:44.643Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] __GI___clone at :0
+  [12]  at :0
+"
+2026-05-24T18:14:44.521Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] __GI___clone at :0
+  [12]  at :0
+"
+2026-05-24T18:14:44.489Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] GOMP_parallel at :0
+  [10] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:257
+  [11] RicExportFractureCompletionsImpl::generateCompdatValues(RimEclipseCase*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:169
+  [12] RicExportFractureCompletionsImpl::generateCompdatValuesForWellPath(RimWellPath*, RimEclipseCase*, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:94
+  [13] RicWellPathExportCompletionDataFeatureImpl::exportCompletions(std::vector<RimWellPath*, std::allocator<RimWellPath*> > const&, RicExportCompletionDataSettingsUi const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportCompletionDataFeatureImpl.cpp:227
+  [14] RicfExportWellPathCompletions::execute() at ResInsight/ApplicationLibCode/CommandFileInterface/RicfExportWellPathCompletions.cpp:184
+  [15] RiaGrpcCommandService::Execute(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) at ResInsight/GrpcInterface/RiaGrpcCommandService.cpp:92
+  [16] grpc::Status std::__invoke_impl<grpc::Status, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*>(std::__invoke_memfun_ref, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*&&, rips::CommandParams const*&&, rips::CommandReply*&&) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/invoke.h:67
+  [17] std::function<grpc::Status (RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*)>::operator()(RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:591
+  [18] RiaGrpcServerImpl::processAllQueuedRequests() at ResInsight/GrpcInterface/RiaGrpcServer.cpp:197
+  [19] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:115
+  [20] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:33
+  [21]  at :0
+  [22] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [23] QObject::event(QEvent*) at :0
+  [24] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [25] QTimerInfoList::activateTimers() at :0
+  [26]  at :0
+  [27] g_main_context_dispatch at :0
+  [28] g_main_context_iterate.isra.20 at :0
+  [29] g_main_context_iteration at :0
+  [30] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [31] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [32] QCoreApplication::exec() at :0
+  [33] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [34] __libc_start_main at :0
+  [35] _start at :0
+  [36]  at :0
+"
+2026-05-24T18:14:44.265Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] __GI___clone at :0
+  [12]  at :0
+"
+2026-05-24T18:14:44.137Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] __GI___clone at :0
+  [12]  at :0
+"
+2026-05-24T18:14:44.015Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] __GI___clone at :0
+  [12]  at :0
+"
+2026-05-24T18:14:44.004Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] __GI___clone at :0
+  [12]  at :0
+"
+2026-05-24T18:14:44.004Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] __GI___clone at :0
+  [12]  at :0
+"
+2026-05-24T18:14:44.004Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] __GI___clone at :0
+  [12]  at :0
+"
+2026-05-24T17:33:32.183Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] GOMP_parallel at :0
+  [10] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:257
+  [11] RicExportFractureCompletionsImpl::generateCompdatValues(RimEclipseCase*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:169
+  [12] RicExportFractureCompletionsImpl::generateCompdatValuesForWellPath(RimWellPath*, RimEclipseCase*, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:94
+  [13] RicWellPathExportCompletionDataFeatureImpl::exportCompletions(std::vector<RimWellPath*, std::allocator<RimWellPath*> > const&, RicExportCompletionDataSettingsUi const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportCompletionDataFeatureImpl.cpp:227
+  [14] RicfExportWellPathCompletions::execute() at ResInsight/ApplicationLibCode/CommandFileInterface/RicfExportWellPathCompletions.cpp:184
+  [15] RiaGrpcCommandService::Execute(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) at ResInsight/GrpcInterface/RiaGrpcCommandService.cpp:92
+  [16] grpc::Status std::__invoke_impl<grpc::Status, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*>(std::__invoke_memfun_ref, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*&&, rips::CommandParams const*&&, rips::CommandReply*&&) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/invoke.h:67
+  [17] std::function<grpc::Status (RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*)>::operator()(RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:591
+  [18] RiaGrpcServerImpl::processAllQueuedRequests() at ResInsight/GrpcInterface/RiaGrpcServer.cpp:197
+  [19] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:115
+  [20] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:33
+  [21]  at :0
+  [22] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [23] QObject::event(QEvent*) at :0
+  [24] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [25] QTimerInfoList::activateTimers() at :0
+  [26]  at :0
+  [27] g_main_context_dispatch at :0
+  [28] g_main_context_iterate.isra.20 at :0
+  [29] g_main_context_iteration at :0
+  [30] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [31] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [32] QCoreApplication::exec() at :0
+  [33] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [34] __libc_start_main at :0
+  [35] _start at :0
+  [36]  at :0
+"
+2026-05-24T17:33:32.023Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] __GI___clone at :0
+  [12]  at :0
+"
+2026-05-24T17:33:31.962Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] __GI___clone at :0
+  [12]  at :0
+"
+2026-05-24T17:33:27.571Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] __GI___clone at :0
+  [12]  at :0
+"
+2026-05-24T17:33:27.453Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] __GI___clone at :0
+  [12]  at :0
+"
+2026-05-24T17:33:27.451Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] GOMP_parallel at :0
+  [10] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:257
+  [11] RicExportFractureCompletionsImpl::generateCompdatValues(RimEclipseCase*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:169
+  [12] RicExportFractureCompletionsImpl::generateCompdatValuesForWellPath(RimWellPath*, RimEclipseCase*, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:94
+  [13] RicWellPathExportCompletionDataFeatureImpl::exportCompletions(std::vector<RimWellPath*, std::allocator<RimWellPath*> > const&, RicExportCompletionDataSettingsUi const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportCompletionDataFeatureImpl.cpp:227
+  [14] RicfExportWellPathCompletions::execute() at ResInsight/ApplicationLibCode/CommandFileInterface/RicfExportWellPathCompletions.cpp:184
+  [15] RiaGrpcCommandService::Execute(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) at ResInsight/GrpcInterface/RiaGrpcCommandService.cpp:92
+  [16] grpc::Status std::__invoke_impl<grpc::Status, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*>(std::__invoke_memfun_ref, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*&&, rips::CommandParams const*&&, rips::CommandReply*&&) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/invoke.h:67
+  [17] std::function<grpc::Status (RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*)>::operator()(RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:591
+  [18] RiaGrpcServerImpl::processAllQueuedRequests() at ResInsight/GrpcInterface/RiaGrpcServer.cpp:197
+  [19] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:115
+  [20] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:33
+  [21]  at :0
+  [22] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [23] QObject::event(QEvent*) at :0
+  [24] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [25] QTimerInfoList::activateTimers() at :0
+  [26]  at :0
+  [27] g_main_context_dispatch at :0
+  [28] g_main_context_iterate.isra.20 at :0
+  [29] g_main_context_iteration at :0
+  [30] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [31] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [32] QCoreApplication::exec() at :0
+  [33] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [34] __libc_start_main at :0
+  [35] _start at :0
+  [36]  at :0
+"
+2026-05-24T17:33:27.389Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] __GI___clone at :0
+  [12]  at :0
+"
+2026-05-24T17:14:54.386Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] __GI___clone at :0
+  [12]  at :0
+"
+2026-05-24T17:14:54.369Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] GOMP_parallel at :0
+  [10] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:257
+  [11] RicExportFractureCompletionsImpl::generateCompdatValues(RimEclipseCase*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:169
+  [12] RicExportFractureCompletionsImpl::generateCompdatValuesForWellPath(RimWellPath*, RimEclipseCase*, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:94
+  [13] RicWellPathExportCompletionDataFeatureImpl::exportCompletions(std::vector<RimWellPath*, std::allocator<RimWellPath*> > const&, RicExportCompletionDataSettingsUi const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportCompletionDataFeatureImpl.cpp:227
+  [14] RicfExportWellPathCompletions::execute() at ResInsight/ApplicationLibCode/CommandFileInterface/RicfExportWellPathCompletions.cpp:184
+  [15] RiaGrpcCommandService::Execute(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) at ResInsight/GrpcInterface/RiaGrpcCommandService.cpp:92
+  [16] grpc::Status std::__invoke_impl<grpc::Status, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*>(std::__invoke_memfun_ref, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*&&, rips::CommandParams const*&&, rips::CommandReply*&&) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/invoke.h:67
+  [17] std::function<grpc::Status (RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*)>::operator()(RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:591
+  [18] RiaGrpcServerImpl::processAllQueuedRequests() at ResInsight/GrpcInterface/RiaGrpcServer.cpp:197
+  [19] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:115
+  [20] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:33
+  [21]  at :0
+  [22] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [23] QObject::event(QEvent*) at :0
+  [24] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [25] QTimerInfoList::activateTimers() at :0
+  [26]  at :0
+  [27] g_main_context_dispatch at :0
+  [28] g_main_context_iterate.isra.20 at :0
+  [29] g_main_context_iteration at :0
+  [30] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [31] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [32] QCoreApplication::exec() at :0
+  [33] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [34] __libc_start_main at :0
+  [35] _start at :0
+  [36]  at :0
+"
+2026-05-24T17:14:54.264Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] __GI___clone at :0
+  [12]  at :0
+"
+2026-05-24T17:14:54.252Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] __GI___clone at :0
+  [12]  at :0
+"
+2026-05-24T17:14:54.252Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] __GI___clone at :0
+  [12]  at :0
+"
+2026-05-24T17:13:48.128Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] GOMP_parallel at :0
+  [10] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:257
+  [11] RicExportFractureCompletionsImpl::generateCompdatValues(RimEclipseCase*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:169
+  [12] RicExportFractureCompletionsImpl::generateCompdatValuesForWellPath(RimWellPath*, RimEclipseCase*, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:94
+  [13] RicWellPathExportCompletionDataFeatureImpl::exportCompletions(std::vector<RimWellPath*, std::allocator<RimWellPath*> > const&, RicExportCompletionDataSettingsUi const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportCompletionDataFeatureImpl.cpp:227
+  [14] RicfExportWellPathCompletions::execute() at ResInsight/ApplicationLibCode/CommandFileInterface/RicfExportWellPathCompletions.cpp:184
+  [15] RiaGrpcCommandService::Execute(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) at ResInsight/GrpcInterface/RiaGrpcCommandService.cpp:92
+  [16] grpc::Status std::__invoke_impl<grpc::Status, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*>(std::__invoke_memfun_ref, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*&&, rips::CommandParams const*&&, rips::CommandReply*&&) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/invoke.h:67
+  [17] std::function<grpc::Status (RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*)>::operator()(RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:591
+  [18] RiaGrpcServerImpl::processAllQueuedRequests() at ResInsight/GrpcInterface/RiaGrpcServer.cpp:197
+  [19] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:115
+  [20] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:33
+  [21]  at :0
+  [22] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [23] QObject::event(QEvent*) at :0
+  [24] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [25] QTimerInfoList::activateTimers() at :0
+  [26]  at :0
+  [27] g_main_context_dispatch at :0
+  [28] g_main_context_iterate.isra.20 at :0
+  [29] g_main_context_iteration at :0
+  [30] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [31] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [32] QCoreApplication::exec() at :0
+  [33] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [34] __libc_start_main at :0
+  [35] _start at :0
+  [36]  at :0
+"
+2026-05-24T17:13:47.91Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] __GI___clone at :0
+  [12]  at :0
+"
+2026-05-24T17:13:47.812Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] __GI___clone at :0
+  [12]  at :0
+"
+2026-05-24T17:13:47.796Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] __GI___clone at :0
+  [12]  at :0
+"
+2026-05-24T17:13:47.794Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] __GI___clone at :0
+  [12]  at :0
+"
+2026-05-24T17:13:47.794Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] __GI___clone at :0
+  [12]  at :0
+"
+2026-05-24T17:10:59.31Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] GOMP_parallel at :0
+  [10] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:257
+  [11] RicExportFractureCompletionsImpl::generateCompdatValues(RimEclipseCase*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:169
+  [12] RicExportFractureCompletionsImpl::generateCompdatValuesForWellPath(RimWellPath*, RimEclipseCase*, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:94
+  [13] RicWellPathExportCompletionDataFeatureImpl::exportCompletions(std::vector<RimWellPath*, std::allocator<RimWellPath*> > const&, RicExportCompletionDataSettingsUi const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportCompletionDataFeatureImpl.cpp:227
+  [14] RicfExportWellPathCompletions::execute() at ResInsight/ApplicationLibCode/CommandFileInterface/RicfExportWellPathCompletions.cpp:184
+  [15] RiaGrpcCommandService::Execute(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) at ResInsight/GrpcInterface/RiaGrpcCommandService.cpp:92
+  [16] grpc::Status std::__invoke_impl<grpc::Status, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*>(std::__invoke_memfun_ref, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*&&, rips::CommandParams const*&&, rips::CommandReply*&&) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/invoke.h:67
+  [17] std::function<grpc::Status (RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*)>::operator()(RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:591
+  [18] RiaGrpcServerImpl::processAllQueuedRequests() at ResInsight/GrpcInterface/RiaGrpcServer.cpp:197
+  [19] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:115
+  [20] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:33
+  [21]  at :0
+  [22] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [23] QObject::event(QEvent*) at :0
+  [24] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [25] QTimerInfoList::activateTimers() at :0
+  [26]  at :0
+  [27] g_main_context_dispatch at :0
+  [28] g_main_context_iterate.isra.20 at :0
+  [29] g_main_context_iteration at :0
+  [30] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [31] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [32] QCoreApplication::exec() at :0
+  [33] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [34] __libc_start_main at :0
+  [35] _start at :0
+  [36]  at :0
+"
+2026-05-24T17:10:59.223Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] __GI___clone at :0
+  [12]  at :0
+"
+2026-05-24T17:10:59.223Z,2026.02.1,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] RigTransmissibilityCondenser::calculateCondensedTransmissibilities() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:336
+  [6] RigTransmissibilityCondenser::externalCells() at ResInsight/ApplicationLibCode/ReservoirDataModel/Completions/RigTransmissibilityCondenser.cpp:110
+  [7] RicExportFractureCompletionsImpl::calculateMatrixToWellTransmissibilities(RigTransmissibilityCondenser&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:710
+  [8] RicExportFractureCompletionsImpl::generateCompdatValuesConst(RimEclipseCase const*, QString const&, RigWellPath const*, std::vector<RimFracture const*, std::allocator<RimFracture const*> > const&, std::vector<RicWellPathFractureReportItem, std::allocator<RicWellPathFractureReportItem> >*, QTextStream*, RicExportFractureCompletionsImpl::PressureDepletionParameters) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportFractureCompletionsImpl.cpp:305
+  [9] gomp_thread_start at :0
+  [10] start_thread at :0
+  [11] __GI___clone at :0
+  [12]  at :0
+"
+2026-05-24T15:49:01.125Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] QWidgetPrivate::shouldPaintOnScreen() const at :0
+  [4] QWidgetRepaintManager::markNeedsFlush(QWidget*, QRegion const&, QPoint const&) at :0
+  [5] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [6] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [7] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [8] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [9] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [10] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [11] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [12] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [13] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [14] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [15] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [16] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [17] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [18] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [19] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [20] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [21] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [22] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [23] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [24] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [25] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [26] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [27] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [28] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [29] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [30] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [31] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [32] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [33] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [34] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [35] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [36] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [37] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [38] QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [39] QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) at :0
+  [40] QWidgetRepaintManager::paintAndFlush() at :0
+  [41] QWidget::event(QEvent*) at :0
+  [42] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [43] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [44] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [45] QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*) at :0
+  [46]  at :0
+  [47] g_main_context_dispatch at :0
+  [48] g_main_context_iterate.isra.20 at :0
+  [49] g_main_context_iteration at :0
+  [50] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [51] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [52] QCoreApplication::exec() at :0
+  [53] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [54] __libc_start_main at :0
+  [55] _start at :0
+  [56]  at :0
+"
+2026-05-23T22:42:23.646Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] __cxa_call_terminate at :0
+  [10] __gxx_personality_v0 at :0
+  [11] _Unwind_RaiseException_Phase2 at :0
+  [12] _Unwind_Resume at :0
+  [13] Opm::EclIO::ESmry::dates() const at ResInsight/ThirdParty/custom-opm-common/opm-common/opm/io/eclipse/ESmry.cpp:1457
+  [14] RifHdf5SummaryExporter::writeGeneralSection(RifHdf5Exporter&, Opm::EclIO::ESmry&) at ResInsight/ApplicationLibCode/FileInterface/RifHdf5SummaryExporter.cpp:165
+  [15] RifHdf5SummaryExporter::ensureHdf5FileIsCreated(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool, unsigned long&) at ResInsight/ApplicationLibCode/FileInterface/RifHdf5SummaryExporter.cpp:141
+  [16] RifReaderEclipseSummary::open(QString const&, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseSummary.cpp:107
+  [17] RifSummaryReaderAggregator::createReadersAndImportMetaData(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/FileInterface/RifSummaryReaderAggregator.cpp:156
+  [18] RimFileSummaryCase::findRelatedFilesAndCreateReader(QString const&, bool, RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:221
+  [19] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:110
+  [20] RimFileSummaryCase::createSummaryReaderInterface() at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:129
+  [21] RiaSummaryTools::reloadSummaryCaseAndUpdateConnectedPlots(RimSummaryCase*) at ResInsight/ApplicationLibCode/Application/Tools/Summary/RiaSummaryTools.cpp:409
+  [22] RicReloadSummaryCaseFeature::reloadSelectedCasesAndUpdate() at ResInsight/ApplicationLibCode/Commands/RicReloadSummaryCaseFeature.cpp:148
+  [23] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+  [24]  at :0
+  [25] QAction::triggered(bool) at :0
+  [26] QAction::activate(QAction::ActionEvent) at :0
+  [27]  at :0
+  [28]  at :0
+  [29] QWidget::event(QEvent*) at :0
+  [30] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [31] QApplication::notify(QObject*, QEvent*) at :0
+  [32] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [33] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [34] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [35]  at :0
+  [36]  at :0
+  [37] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [38] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [39] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [40] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [41] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [42]  at :0
+  [43] g_main_context_dispatch at :0
+  [44] g_main_context_iterate.isra.20 at :0
+  [45] g_main_context_iteration at :0
+  [46] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [47] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [48]  at :0
+  [49] QMenu::exec(QPoint const&, QAction*) at :0
+  [50] RiuPlotMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp:1058
+  [51]  at :0
+  [52] QWidget::customContextMenuRequested(QPoint const&) at :0
+  [53] QWidget::event(QEvent*) at :0
+  [54] QFrame::event(QEvent*) at :0
+  [55] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [56] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [57] QApplication::notify(QObject*, QEvent*) at :0
+  [58] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [59] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [60]  at :0
+  [61]  at :0
+  [62] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [63] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [64] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [65] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [66] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [67]  at :0
+  [68] g_main_context_dispatch at :0
+  [69] g_main_context_iterate.isra.20 at :0
+  [70] g_main_context_iteration at :0
+  [71] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [72] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [73] QCoreApplication::exec() at :0
+  [74] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [75] __libc_start_main at :0
+  [76] _start at :0
+  [77]  at :0
+"
+2026-05-23T09:14:14.466Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] QArrayDataPointer<char16_t>::QArrayDataPointer(QArrayDataPointer<char16_t> const&) at /private/f_resinsight_build/resbuild/qt/6.6.3/gcc_64/include/QtCore/qarraydatapointer.h:38
+  [4] RimCase::gridFileName() const at ResInsight/ApplicationLibCode/ProjectDataModel/RimCase.cpp:136
+  [5] RimReloadCaseTools::findSummaryCaseFromEclipseResultCase(RimEclipseResultCase const*) at ResInsight/ApplicationLibCode/ProjectDataModel/RimReloadCaseTools.cpp:196
+  [6] RimReloadCaseTools::reloadEclipseData(RimEclipseCase*, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimReloadCaseTools.cpp:100
+  [7] RicReloadCaseFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/RicReloadCaseFeature.cpp:62
+  [8] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+  [9]  at :0
+  [10] QAction::triggered(bool) at :0
+  [11] QAction::activate(QAction::ActionEvent) at :0
+  [12]  at :0
+  [13]  at :0
+  [14] QWidget::event(QEvent*) at :0
+  [15] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [16] QApplication::notify(QObject*, QEvent*) at :0
+  [17] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [18] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [19] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [20]  at :0
+  [21]  at :0
+  [22] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [23] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [24] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [25] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [26] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [27]  at :0
+  [28] g_main_context_dispatch at :0
+  [29] g_main_context_iterate.isra.20 at :0
+  [30] g_main_context_iteration at :0
+  [31] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [32] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [33]  at :0
+  [34] QMenu::exec(QPoint const&, QAction*) at :0
+  [35] RiuMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:2056
+  [36]  at :0
+  [37] QWidget::customContextMenuRequested(QPoint const&) at :0
+  [38] QWidget::event(QEvent*) at :0
+  [39] QFrame::event(QEvent*) at :0
+  [40] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [41] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [42] QApplication::notify(QObject*, QEvent*) at :0
+  [43] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [44] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [45]  at :0
+  [46]  at :0
+  [47] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [48] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [49] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [50] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [51] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [52]  at :0
+  [53] g_main_context_dispatch at :0
+  [54] g_main_context_iterate.isra.20 at :0
+  [55] g_main_context_iteration at :0
+  [56] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [57] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [58] QCoreApplication::exec() at :0
+  [59] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [60] __libc_start_main at :0
+  [61] _start at :0
+  [62]  at :0
+"
+2026-05-22T12:57:01.525Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3]  at :0
+  [4] QComboBox::textActivated(QString const&) at :0
+  [5]  at :0
+  [6]  at :0
+  [7]  at :0
+  [8] QComboBoxPrivateContainer::itemSelected(QModelIndex const&) at :0
+  [9] QComboBoxPrivateContainer::eventFilter(QObject*, QEvent*) at :0
+  [10] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [11] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [12] QApplication::notify(QObject*, QEvent*) at :0
+  [13] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [14] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [15] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [16]  at :0
+  [17]  at :0
+  [18] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [19] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [20] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [21] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [22] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [23]  at :0
+  [24] g_main_context_dispatch at :0
+  [25] g_main_context_iterate.isra.20 at :0
+  [26] g_main_context_iteration at :0
+  [27] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [28] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [29] QCoreApplication::exec() at :0
+  [30] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [31] __libc_start_main at :0
+  [32] _start at :0
+  [33]  at :0
+"
+2026-05-22T12:52:15.394Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] QObjectPrivate::maybeSignalConnected(unsigned int) const at :0
+  [4]  at :0
+  [5] QComboBox::textActivated(QString const&) at :0
+  [6]  at :0
+  [7]  at :0
+  [8]  at :0
+  [9] QComboBoxPrivateContainer::itemSelected(QModelIndex const&) at :0
+  [10] QComboBoxPrivateContainer::eventFilter(QObject*, QEvent*) at :0
+  [11] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [12] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [13] QApplication::notify(QObject*, QEvent*) at :0
+  [14] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [15] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [16] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [17]  at :0
+  [18]  at :0
+  [19] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [20] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [21] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [22] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [23] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [24]  at :0
+  [25] g_main_context_dispatch at :0
+  [26] g_main_context_iterate.isra.20 at :0
+  [27] g_main_context_iteration at :0
+  [28] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [29] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [30] QCoreApplication::exec() at :0
+  [31] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [32] __libc_start_main at :0
+  [33] _start at :0
+  [34]  at :0
+"
+2026-05-22T12:34:32.68Z,2026.02.3-dev.01,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __libc_poll at :0
+  [4] g_main_context_iterate.isra.20 at :0
+  [5] g_main_context_iteration at :0
+  [6] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [7] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [8] QCoreApplication::exec() at :0
+  [9] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [10] __libc_start_main at :0
+  [11] _start at :0
+  [12]  at :0
+"
+2026-05-22T11:05:16.226Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] std::terminate() at :0
+  [10] __cxa_rethrow at :0
+  [11] main at ResInsight/ApplicationExeCode/RiaMain.cpp:232
+  [12] __libc_start_main at :0
+  [13] _start at :0
+  [14]  at :0
+"
+2026-05-22T10:49:44.2Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] RigFemPartResultsCollection::stepListIndexToTimeStepAndDataFrameIndex(int) const at ResInsight/ApplicationLibCode/GeoMech/GeoMechDataModel/RigFemPartResultsCollection.cpp:999
+  [4] RimGeoMechView::onClampCurrentTimestep() at ResInsight/ApplicationLibCode/ProjectDataModel/GeoMech/RimGeoMechView.cpp:817
+  [5] Rim3dView::createDisplayModelAndRedraw() at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:714
+  [6] RiaViewRedrawScheduler::updateAndRedrawScheduledViews() at ResInsight/ApplicationLibCode/Application/RiaViewRedrawScheduler.cpp:93
+  [7]  at :0
+  [8] QTimer::timeout(QTimer::QPrivateSignal) at :0
+  [9] QObject::event(QEvent*) at :0
+  [10] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [11] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [12] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [13] QTimerInfoList::activateTimers() at :0
+  [14]  at :0
+  [15] g_main_context_dispatch at :0
+  [16] g_main_context_iterate.isra.20 at :0
+  [17] g_main_context_iteration at :0
+  [18] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [19] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [20] QCoreApplication::exec() at :0
+  [21] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [22] __libc_start_main at :0
+  [23] _start at :0
+  [24]  at :0
+"
+2026-05-22T10:47:01.455Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] std::terminate() at :0
+  [10] __cxa_rethrow at :0
+  [11] main at ResInsight/ApplicationExeCode/RiaMain.cpp:232
+  [12] __libc_start_main at :0
+  [13] _start at :0
+  [14]  at :0
+"
+2026-05-21T16:38:21.375Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] ecl_kw_get_data_type at ResInsight/ThirdParty/Ert/lib/ecl/ecl_kw.cpp:1776
+  [4] ecl_file_kw_assert_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_kw.cpp:211
+  [5] ecl_file_kw_load_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_kw.cpp:244
+  [6] ecl_file_view_get_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_view.cpp:149
+  [7] RifEclipseOutputFileTools::keywordData(ecl_file_struct const*, QString const&, unsigned long, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseOutputFileTools.cpp:305
+  [8] RifEclipseUnifiedRestartFileAccess::results(QString const&, unsigned long, unsigned long, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseUnifiedRestartFileAccess.cpp:248
+  [9] RifReaderEclipseOutput::dynamicResult(QString const&, RiaDefines::PorosityModelType, unsigned long, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp:1070
+  [10] RigCaseCellResultsData::findOrLoadKnownScalarResult(RigEclipseResultAddress const&) at ResInsight/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp:1538
+  [11] RigCaseCellResultsData::ensureKnownResultLoaded(RigEclipseResultAddress const&) at ResInsight/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp:1264
+  [12] RimEclipseResultDefinition::loadResult() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:1134
+  [13] RimEclipseCellColors::loadResult() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCellColors.cpp:260
+  [14] RimEclipseResultDefinition::loadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:533
+  [15] RimEclipseResultDefinition::fieldChangedByUi(caf::PdmFieldHandle const*, QVariant const&, QVariant const&) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:305
+  [16] RimEclipseCellColors::fieldChangedByUi(caf::PdmFieldHandle const*, QVariant const&, QVariant const&) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCellColors.cpp:90
+  [17] caf::PdmUiFieldHandle::notifyFieldChanged(QVariant const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiFieldHandle.cpp:74
+  [18] caf::PdmFieldUiCap<caf::PdmField<QString> >::setValueFromUiEditor(QVariant const&, bool) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafInternalPdmUiFieldCapability.inl:110
+  [19] caf::PdmUiCommandSystemProxy::setUiValueToField(caf::PdmUiFieldHandle*, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiCommandSystemProxy.cpp:122
+  [20] caf::PdmUiTreeSelectionQModel::setData(QModelIndex const&, QVariant const&, int) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionQModel.cpp:482
+  [21] QSortFilterProxyModel::setData(QModelIndex const&, QVariant const&, int) at :0
+  [22] caf::PdmUiTreeSelectionEditor::currentChanged(QModelIndex const&) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionEditor.cpp:812
+  [23] caf::PdmUiTreeSelectionEditor::slotClicked(QModelIndex const&) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionEditor.cpp:759
+  [24]  at :0
+  [25] QAbstractItemView::clicked(QModelIndex const&) at :0
+  [26] QAbstractItemView::mouseReleaseEvent(QMouseEvent*) at :0
+  [27] QWidget::event(QEvent*) at :0
+  [28] QFrame::event(QEvent*) at :0
+  [29] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [30] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [31] QApplication::notify(QObject*, QEvent*) at :0
+  [32] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [33] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [34] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [35]  at :0
+  [36]  at :0
+  [37] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [38] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [39] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [40] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [41] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [42]  at :0
+  [43] g_main_context_dispatch at :0
+  [44] g_main_context_iterate.isra.20 at :0
+  [45] g_main_context_iteration at :0
+  [46] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [47] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [48] QCoreApplication::exec() at :0
+  [49] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [50] __libc_start_main at :0
+  [51] _start at :0
+  [52]  at :0
+"
+2026-05-21T13:25:29.283Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] at :0
+  [6]  at :0
+  [7]  at :0
+  [8] __cxxabiv1::__terminate(void (*)()) at :0
+  [9] std::terminate() at :0
+  [10] __cxa_rethrow at :0
+  [11] main at ResInsight/ApplicationExeCode/RiaMain.cpp:232
+  [12] __libc_start_main at :0
+  [13] _start at :0
+  [14]  at :0
+"
+2026-05-21T12:17:08.955Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3]  at :0
+  [4] QComboBox::textActivated(QString const&) at :0
+  [5]  at :0
+  [6]  at :0
+  [7]  at :0
+  [8] QComboBoxPrivateContainer::itemSelected(QModelIndex const&) at :0
+  [9] QComboBoxPrivateContainer::eventFilter(QObject*, QEvent*) at :0
+  [10] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [11] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [12] QApplication::notify(QObject*, QEvent*) at :0
+  [13] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [14] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [15] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [16]  at :0
+  [17]  at :0
+  [18] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [19] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [20] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [21] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [22] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [23]  at :0
+  [24] g_main_context_dispatch at :0
+  [25] g_main_context_iterate.isra.20 at :0
+  [26] g_main_context_iteration at :0
+  [27] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [28] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [29] QCoreApplication::exec() at :0
+  [30] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [31] __libc_start_main at :0
+  [32] _start at :0
+  [33]  at :0
+"
+2026-05-21T12:04:19.478Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3]  at :0
+  [4] QComboBox::textActivated(QString const&) at :0
+  [5]  at :0
+  [6]  at :0
+  [7]  at :0
+  [8] QComboBoxPrivateContainer::itemSelected(QModelIndex const&) at :0
+  [9] QComboBoxPrivateContainer::eventFilter(QObject*, QEvent*) at :0
+  [10] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [11] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [12] QApplication::notify(QObject*, QEvent*) at :0
+  [13] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [14] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [15] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [16]  at :0
+  [17]  at :0
+  [18] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [19] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [20] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [21] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [22] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [23]  at :0
+  [24] g_main_context_dispatch at :0
+  [25] g_main_context_iterate.isra.20 at :0
+  [26] g_main_context_iteration at :0
+  [27] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [28] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [29] QCoreApplication::exec() at :0
+  [30] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [31] __libc_start_main at :0
+  [32] _start at :0
+  [33]  at :0
+"
+2026-05-21T11:50:13.645Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] Rim3dView::scaleZ() const at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:1242
+  [4] RimViewController::updateCameraLink() at ResInsight/ApplicationLibCode/ProjectDataModel/RimViewController.cpp:559
+  [5] RimViewController::fieldChangedByUi(caf::PdmFieldHandle const*, QVariant const&, QVariant const&) at ResInsight/ApplicationLibCode/ProjectDataModel/RimViewController.cpp:167
+  [6] caf::PdmUiFieldHandle::notifyFieldChanged(QVariant const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiFieldHandle.cpp:74
+  [7] caf::PdmField<bool>::setValueWithFieldChanged(bool const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmDataValueField.h:299
+  [8] RicToggleItemsFeatureImpl::setObjectToggleStateForSelection(RicToggleItemsFeatureImpl::SelectionToggleType) at ResInsight/ApplicationLibCode/Commands/ToggleCommands/RicToggleItemsFeatureImpl.cpp:137
+  [9] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+  [10]  at :0
+  [11] QAction::triggered(bool) at :0
+  [12] QAction::activate(QAction::ActionEvent) at :0
+  [13]  at :0
+  [14]  at :0
+  [15] QWidget::event(QEvent*) at :0
+  [16] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [17] QApplication::notify(QObject*, QEvent*) at :0
+  [18] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [19] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [20] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [21]  at :0
+  [22]  at :0
+  [23] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [24] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [25] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [26] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [27] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [28]  at :0
+  [29] g_main_context_dispatch at :0
+  [30] g_main_context_iterate.isra.20 at :0
+  [31] g_main_context_iteration at :0
+  [32] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [33] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [34]  at :0
+  [35] QMenu::exec(QPoint const&, QAction*) at :0
+  [36] RiuMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:2056
+  [37]  at :0
+  [38] QWidget::customContextMenuRequested(QPoint const&) at :0
+  [39] QWidget::event(QEvent*) at :0
+  [40] QFrame::event(QEvent*) at :0
+  [41] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [42] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [43] QApplication::notify(QObject*, QEvent*) at :0
+  [44] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [45] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [46]  at :0
+  [47]  at :0
+  [48] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [49] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [50] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [51] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [52] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [53]  at :0
+  [54] g_main_context_dispatch at :0
+  [55] g_main_context_iterate.isra.20 at :0
+  [56] g_main_context_iteration at :0
+  [57] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [58] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [59] QCoreApplication::exec() at :0
+  [60] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [61] __libc_start_main at :0
+  [62] _start at :0
+  [63]  at :0
+"
+2026-05-21T09:39:53.897Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] ecl_kw_get_data_type at ResInsight/ThirdParty/Ert/lib/ecl/ecl_kw.cpp:1776
+  [4] ecl_file_kw_assert_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_kw.cpp:211
+  [5] ecl_file_kw_load_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_kw.cpp:244
+  [6] ecl_file_view_get_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_view.cpp:149
+  [7] RifEclipseOutputFileTools::keywordData(ecl_file_struct const*, QString const&, unsigned long, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseOutputFileTools.cpp:305
+  [8] RifEclipseUnifiedRestartFileAccess::results(QString const&, unsigned long, unsigned long, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseUnifiedRestartFileAccess.cpp:248
+  [9] RifReaderEclipseOutput::dynamicResult(QString const&, RiaDefines::PorosityModelType, unsigned long, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp:1070
+  [10] RigCaseCellResultsData::findOrLoadKnownScalarResult(RigEclipseResultAddress const&) at ResInsight/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp:1538
+  [11] RigCaseCellResultsData::ensureKnownResultLoaded(RigEclipseResultAddress const&) at ResInsight/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp:1264
+  [12] RimEclipseResultDefinition::loadResult() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:1134
+  [13] RimEclipseCellColors::loadResult() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCellColors.cpp:260
+  [14] RimEclipseResultDefinition::loadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:533
+  [15] RimEclipseResultDefinition::fieldChangedByUi(caf::PdmFieldHandle const*, QVariant const&, QVariant const&) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:305
+  [16] RimEclipseCellColors::fieldChangedByUi(caf::PdmFieldHandle const*, QVariant const&, QVariant const&) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCellColors.cpp:90
+  [17] caf::PdmUiFieldHandle::notifyFieldChanged(QVariant const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiFieldHandle.cpp:74
+  [18] caf::PdmFieldUiCap<caf::PdmField<QString> >::setValueFromUiEditor(QVariant const&, bool) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafInternalPdmUiFieldCapability.inl:110
+  [19] caf::PdmUiCommandSystemProxy::setUiValueToField(caf::PdmUiFieldHandle*, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiCommandSystemProxy.cpp:122
+  [20] caf::PdmUiTreeSelectionQModel::setData(QModelIndex const&, QVariant const&, int) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionQModel.cpp:482
+  [21] QSortFilterProxyModel::setData(QModelIndex const&, QVariant const&, int) at :0
+  [22] QStyledItemDelegate::editorEvent(QEvent*, QAbstractItemModel*, QStyleOptionViewItem const&, QModelIndex const&) at :0
+  [23]  at :0
+  [24] QAbstractItemView::edit(QModelIndex const&, QAbstractItemView::EditTrigger, QEvent*) at :0
+  [25] QAbstractItemView::mouseReleaseEvent(QMouseEvent*) at :0
+  [26] QWidget::event(QEvent*) at :0
+  [27] QFrame::event(QEvent*) at :0
+  [28] QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) at :0
+  [29] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [30] QApplication::notify(QObject*, QEvent*) at :0
+  [31] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [32] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [33] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [34]  at :0
+  [35]  at :0
+  [36] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [37] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [38] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [39] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [40] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [41]  at :0
+  [42] g_main_context_dispatch at :0
+  [43] g_main_context_iterate.isra.20 at :0
+  [44] g_main_context_iteration at :0
+  [45] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [46] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [47] QCoreApplication::exec() at :0
+  [48] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [49] __libc_start_main at :0
+  [50] _start at :0
+  [51]  at :0
+"
+2026-05-21T08:47:21.019Z,2026.02.2,"  [0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+  [1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+  [2]  at :0
+  [3] __GI_raise at :0
+  [4] __GI_abort at :0
+  [5] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
+  [6] cvf::GeometryUtils::tesselatePatchAsTriangles(unsigned int, unsigned int, unsigned int, bool, cvf::Array<unsigned int>*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfGeometryUtils.cpp:774
+  [7] RigContourMapTrianglesGenerator::generateTrianglesWithVertexValues(RigContourMapGrid const&, RigContourMapProjection const&, std::vector<std::vector<RigContourPolygonsTools::ContourPolygon, std::allocator<RigContourPolygonsTools::ContourPolygon> >, std::allocator<std::vector<RigContourPolygonsTools::ContourPolygon, std::allocator<RigContourPolygonsTools::ContourPolygon> > > > const&, std::vector<double, std::allocator<double> > const&, std::vector<double, std::allocator<double> > const&, bool, double) at ResInsight/ApplicationLibCode/ReservoirDataModel/ContourMap/RigContourMapTrianglesGenerator.cpp:46
+  [8] RimContourMapProjection::generateGeometryIfNecessary() at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimContourMapProjection.cpp:211
+  [9] RimEclipseContourMapView::updateGeometry() at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapView.cpp:291
+  [10] Rim3dView::updateDisplayModelForCurrentTimeStepAndRedraw() at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:673
+  [11] RiuViewer::setCurrentFrame(int) at ResInsight/ApplicationLibCode/UserInterface/RiuViewer.cpp:1008
+  [12] RimEclipseView::onCreateDisplayModel() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp:791
+  [13] RimEclipseContourMapView::onCreateDisplayModel() at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapView.cpp:205
+  [14] Rim3dView::createDisplayModelAndRedraw() at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:718
+  [15] RicNewStatisticsContourMapViewFeature::createAndAddView(RimStatisticsContourMap*) at ResInsight/ApplicationLibCode/Commands/RicNewStatisticsContourMapViewFeature.cpp:124
+  [16] RimStatisticsContourMap::fieldChangedByUi(caf::PdmFieldHandle const*, QVariant const&, QVariant const&) at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimStatisticsContourMap.cpp:280
+  [17] caf::PdmUiFieldHandle::notifyFieldChanged(QVariant const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiFieldHandle.cpp:74
+  [18] caf::PdmFieldUiCap<caf::PdmField<bool> >::setValueFromUiEditor(QVariant const&, bool) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafInternalPdmUiFieldCapability.inl:110
+  [19] caf::PdmUiCommandSystemProxy::setUiValueToField(caf::PdmUiFieldHandle*, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiCommandSystemProxy.cpp:122
+  [20] caf::PdmUiPushButtonEditor::slotClicked(bool) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiPushButtonEditor.cpp:199
+  [21]  at :0
+  [22] QAbstractButton::clicked(bool) at :0
+  [23]  at :0
+  [24]  at :0
+  [25] QAbstractButton::mouseReleaseEvent(QMouseEvent*) at :0
+  [26] QWidget::event(QEvent*) at :0
+  [27] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [28] QApplication::notify(QObject*, QEvent*) at :0
+  [29] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [30] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [31] QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) at :0
+  [32]  at :0
+  [33]  at :0
+  [34] QApplicationPrivate::notify_helper(QObject*, QEvent*) at :0
+  [35] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+  [36] QCoreApplication::notifyInternal2(QObject*, QEvent*) at :0
+  [37] QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) at :0
+  [38] QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [39]  at :0
+  [40] g_main_context_dispatch at :0
+  [41] g_main_context_iterate.isra.20 at :0
+  [42] g_main_context_iteration at :0
+  [43] QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [44] QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) at :0
+  [45] QCoreApplication::exec() at :0
+  [46] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+  [47] __libc_start_main at :0
+  [48] _start at :0
+  [49]  at :0
+"

--- a/stacktrace-reports/incoming-csvs.md
+++ b/stacktrace-reports/incoming-csvs.md
@@ -19,3 +19,4 @@ Every raw weekly crash-report CSV received from the telemetry pipeline. Each row
 | 2026-05-29 | [2026-05-29-query_data.csv](./csv/2026-05-29-query_data.csv) |        133 |            38 | [2026-05-29](./reports/2026-05-29.md) |
 | 2026-06-05 | [2026-06-05-query_data.csv](./csv/2026-06-05-query_data.csv) |        195 |            63 | [2026-06-05](./reports/2026-06-05.md) |
 | 2026-06-12 | [2026-06-12-query_data.csv](./csv/2026-06-12-query_data.csv) |        216 |            63 | [2026-06-12](./reports/2026-06-12.md) |
+| 2026-06-20 | [2026-06-20-query_data.csv](./csv/2026-06-20-query_data.csv) |        223 |            73 | [2026-06-20](./reports/2026-06-20.md) |

--- a/stacktrace-reports/index.md
+++ b/stacktrace-reports/index.md
@@ -10,6 +10,7 @@ Per-week deduplicated stacktrace analyses, newest first. Each report lists uniqu
 
 | Week       | Report                                | Total rows | Unique stacks |
 |------------|---------------------------------------|-----------:|--------------:|
+| 2026-06-20 | [2026-06-20](./reports/2026-06-20.md) |        223 |            73 |
 | 2026-06-12 | [2026-06-12](./reports/2026-06-12.md) |        216 |            63 |
 | 2026-06-05 | [2026-06-05](./reports/2026-06-05.md) |        195 |            63 |
 | 2026-05-29 | [2026-05-29](./reports/2026-05-29.md) |        133 |            38 |

--- a/stacktrace-reports/registry.json
+++ b/stacktrace-reports/registry.json
@@ -1,7 +1,7 @@
 {
   "signatures": {
     "0014df24edd7": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": {
         "number": 14193,
@@ -33,6 +33,14 @@
           "last_seen": "2026-06-01T21:47:26.942Z"
         },
         "2026-06-12": {
+          "count": 1,
+          "first_seen": "2026-06-01T21:47:26.942Z",
+          "last_seen": "2026-06-01T21:47:26.942Z",
+          "versions": {
+            "2026.02.2": 1
+          }
+        },
+        "2026-06-20": {
           "count": 1,
           "first_seen": "2026-06-01T21:47:26.942Z",
           "last_seen": "2026-06-01T21:47:26.942Z",
@@ -83,7 +91,7 @@
       }
     },
     "0138c261c5c0": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": {
         "number": 14174,
@@ -124,6 +132,14 @@
           "last_seen": "2026-06-03T13:27:47.881Z"
         },
         "2026-06-12": {
+          "count": 1,
+          "first_seen": "2026-06-03T13:27:47.881Z",
+          "last_seen": "2026-06-03T13:27:47.881Z",
+          "versions": {
+            "2026.02.2": 1
+          }
+        },
+        "2026-06-20": {
           "count": 1,
           "first_seen": "2026-06-03T13:27:47.881Z",
           "last_seen": "2026-06-03T13:27:47.881Z",
@@ -198,7 +214,7 @@
       }
     },
     "041e8de8fa69": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "Already fixed on dev. setValidTimeStepRangeForCase's isTimeStepInCase lambda called std::find( m_case->timeStepDates().cbegin(), m_case->timeStepDates().cend(), ... ). RimCase::timeStepDates() returns std::vector<QDateTime> by value, so cbegin()/cend() in separate invocations produced iterators into two different temporaries; passing the mismatched iterators to std::find is UB and walked off freed memory, crashing in the lambda (operator()). PR #14156 (merged 2026-06-08, issue #14155) snapshots timeStepDates() into a single local vector. All field hits (2026-05-18..2026-06-01) predate the fix.",
       "opm_issue": {
         "number": 14155,
@@ -259,6 +275,14 @@
           "versions": {
             "2026.02.2": 2
           }
+        },
+        "2026-06-20": {
+          "count": 1,
+          "first_seen": "2026-06-01T11:02:54.109Z",
+          "last_seen": "2026-06-01T11:02:54.109Z",
+          "versions": {
+            "2026.02.2": 1
+          }
         }
       }
     },
@@ -304,7 +328,7 @@
       }
     },
     "0822c8001a77": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": null,
       "pr": null,
@@ -349,6 +373,14 @@
           "last_seen": "2026-06-02T20:12:32.053Z"
         },
         "2026-06-12": {
+          "count": 1,
+          "first_seen": "2026-06-02T20:12:32.053Z",
+          "last_seen": "2026-06-02T20:12:32.053Z",
+          "versions": {
+            "2026.02.2": 1
+          }
+        },
+        "2026-06-20": {
           "count": 1,
           "first_seen": "2026-06-02T20:12:32.053Z",
           "last_seen": "2026-06-02T20:12:32.053Z",
@@ -489,7 +521,7 @@
       }
     },
     "0aef424f6e69": {
-      "last_updated": "2026-06-11",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": null,
       "pr": null,
@@ -507,7 +539,7 @@
         "[52] RiuPlotMainWindow::updateMultiPlotToolBar() at ResInsight/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp:758",
         "[53] RimMultiPlot::fieldChangedByUi(caf::PdmFieldHandle const*, QVariant const&, QVariant const&) at ResInsight/ApplicationLibCode/ProjectDataModel/RimMultiPlot.cpp:696",
         "[54] caf::PdmUiFieldHandle::notifyFieldChanged(QVariant const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiFieldHandle.cpp:74",
-        "[55] caf::PdmFieldUiCap<caf::PdmField<caf::AppEnum<RiaDefines::ColumnCount> > >::setValueFromUiEditor(QVariant const&, bool) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafInternalPdmUiFieldCapability.inl:110",
+        "[55] caf::PdmFieldUiCap<caf::PdmField<caf::AppEnum<RiaDefines::RowCount> > >::setValueFromUiEditor(QVariant const&, bool) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafInternalPdmUiFieldCapability.inl:110",
         "[56] caf::CmdFieldChangeExec::redo() at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFieldChangeExec.cpp:139",
         "[58] caf::CmdUiCommandSystemImpl::fieldChangedCommand(std::vector<caf::PdmFieldHandle*, std::allocator<caf::PdmFieldHandle*> > const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdUiCommandSystemImpl.cpp:146",
         "[59] caf::PdmUiCommandSystemProxy::setUiValueToField(caf::PdmUiFieldHandle*, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiCommandSystemProxy.cpp:113",
@@ -547,11 +579,19 @@
           "count": 1,
           "first_seen": "2026-05-13T07:07:27.269Z",
           "last_seen": "2026-05-13T07:07:27.269Z"
+        },
+        "2026-06-20": {
+          "count": 1,
+          "first_seen": "2026-06-16T20:38:28.725Z",
+          "last_seen": "2026-06-16T20:38:28.725Z",
+          "versions": {
+            "2026.02.2": 1
+          }
         }
       }
     },
     "0babe89e0b6b": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": null,
       "pr": null,
@@ -605,6 +645,14 @@
           "versions": {
             "2026.02.2": 1
           }
+        },
+        "2026-06-20": {
+          "count": 1,
+          "first_seen": "2026-06-05T08:48:40.24Z",
+          "last_seen": "2026-06-05T08:48:40.24Z",
+          "versions": {
+            "2026.02.2": 1
+          }
         }
       }
     },
@@ -652,7 +700,7 @@
       }
     },
     "14b589b099a7": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": null,
       "pr": null,
@@ -706,11 +754,19 @@
           "versions": {
             "2026.02.2": 1
           }
+        },
+        "2026-06-20": {
+          "count": 1,
+          "first_seen": "2026-06-02T20:12:31.767Z",
+          "last_seen": "2026-06-02T20:12:31.767Z",
+          "versions": {
+            "2026.02.2": 1
+          }
         }
       }
     },
     "167ae9f4735f": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": null,
       "pr": null,
@@ -750,11 +806,19 @@
           "versions": {
             "2026.02.2": 1
           }
+        },
+        "2026-06-20": {
+          "count": 1,
+          "first_seen": "2026-06-11T08:43:10.483Z",
+          "last_seen": "2026-06-11T08:43:10.483Z",
+          "versions": {
+            "2026.02.2": 1
+          }
         }
       }
     },
     "17047ab66779": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": {
         "number": 14118,
@@ -773,14 +837,17 @@
         "[8] RimEclipseCase::openReservoirCase() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCase.cpp:1060",
         "[9] RimEclipseView::onLoadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp:1188",
         "[10] RimViewWindow::loadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimViewWindow.cpp:88",
-        "[11] RiaApplication::loadProject(QString const&, RiaApplication::ProjectLoadAction, RiaProjectModifier*) at ResInsight/ApplicationLibCode/Application/RiaApplication.cpp:782",
-        "[12] RicOpenProjectFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/ApplicationCommands/RicOpenProjectFeature.cpp:50",
-        "[13] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176",
-        "[22] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823",
+        "[11] RimEclipseViewCollection::addView(RimEclipseCase*) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseViewCollection.cpp:112",
+        "[12] RicNewViewFeature::createReservoirView(RimEclipseCase*, RimGeoMechCase*, RimEclipseViewCollection*) at ResInsight/ApplicationLibCode/Commands/RicNewViewFeature.cpp:134",
+        "[13] RicNewViewFeature::addReservoirView(RimEclipseCase*, RimGeoMechCase*, RimEclipseViewCollection*) at ResInsight/ApplicationLibCode/Commands/RicNewViewFeature.cpp:47",
+        "[14] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176",
+        "[23] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823",
         "[29] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823",
-        "[35] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823",
-        "[46] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226",
-        "[47] __libc_start_main at :0"
+        "[41] RiuMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:2056",
+        "[49] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823",
+        "[54] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823",
+        "[65] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226",
+        "[66] __libc_start_main at :0"
       ],
       "signature_frames": [
         "RifReaderEclipseOutput::loadAllGrids",
@@ -814,6 +881,14 @@
           "last_seen": "2026-05-20T19:23:04.542Z",
           "versions": {
             "2026.02.2": 3
+          }
+        },
+        "2026-06-20": {
+          "count": 1,
+          "first_seen": "2026-06-15T15:40:28.364Z",
+          "last_seen": "2026-06-15T15:40:28.364Z",
+          "versions": {
+            "2026.02.2": 1
           }
         }
       }
@@ -877,7 +952,7 @@
       }
     },
     "19c925331f59": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": {
         "number": 14213,
@@ -925,11 +1000,19 @@
           "versions": {
             "2026.02.2": 1
           }
+        },
+        "2026-06-20": {
+          "count": 1,
+          "first_seen": "2026-05-26T13:23:28.149Z",
+          "last_seen": "2026-05-26T13:23:28.149Z",
+          "versions": {
+            "2026.02.2": 1
+          }
         }
       }
     },
     "1a992e729555": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": {
         "number": 14118,
@@ -947,8 +1030,8 @@
         "[7] RimEclipseResultCase::importGridAndResultMetaData(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultCase.cpp:261",
         "[8] RiaImportEclipseCaseTools::openEclipseCaseShowTimeStepFilterImpl(QString const&, bool, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:372",
         "[9] RiaImportEclipseCaseTools::openEclipseCasesFromFile(QList<QString> const&, bool, std::map<QString, int, std::less<QString>, std::allocator<std::pair<QString const, int> > >*, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:107",
-        "[10] RiaImportEclipseCaseTools::openEclipseCasesFromFile(QList<QString> const&, bool, std::map<QString, int, std::less<QString>, std::allocator<std::pair<QString const, int> > >*, bool) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:77",
-        "[11] RicImportEclipseCasesFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/EclipseCommands/RicImportEclipseCasesFeature.cpp:67",
+        "[10] RicImportGeneralDataFeature::openEclipseCaseFromFileNames(QList<QString> const&, bool, std::vector<int, std::allocator<int> >&, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:362",
+        "[11] RicImportEclipseCaseFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/EclipseCommands/RicImportEclipseCaseFeature.cpp:72",
         "[12] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176",
         "[21] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823",
         "[27] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823",
@@ -997,6 +1080,14 @@
           "last_seen": "2026-06-12T13:55:53.447Z",
           "versions": {
             "2026.02.2": 5
+          }
+        },
+        "2026-06-20": {
+          "count": 6,
+          "first_seen": "2026-05-25T18:29:50.059Z",
+          "last_seen": "2026-06-15T10:48:18.228Z",
+          "versions": {
+            "2026.02.2": 6
           }
         }
       }
@@ -1123,7 +1214,7 @@
       }
     },
     "1b944453f634": {
-      "last_updated": "2026-06-11",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": {
         "number": 13928,
@@ -1134,28 +1225,16 @@
       "representative_stack": [
         "[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147",
         "[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227",
+        "[3] ecl_kw_get_data_type at ResInsight/ThirdParty/Ert/lib/ecl/ecl_kw.cpp:1776",
+        "[4] ecl_file_kw_assert_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_kw.cpp:211",
+        "[5] ecl_file_kw_load_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_kw.cpp:244",
+        "[6] ecl_file_view_get_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_view.cpp:149",
         "[7] RifEclipseSummaryTools::getRestartRelativeFilePathResdata(QString const&) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseSummaryTools.cpp:336",
-        "[8] RifEclipseSummaryTools::getRestartFileNames(QString const&, bool, std::vector<QString, std::allocator<QString> >&) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseSummaryTools.cpp:225",
+        "[8] RifEclipseSummaryTools::getRestartFileNames(QString const&, bool, std::vector<QString, std::allocator<QString> >&) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseSummaryTools.cpp:220",
         "[9] RifEclipseSummaryTools::getRestartFileNames(QString const&, std::vector<QString, std::allocator<QString> >&) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseSummaryTools.cpp:164",
         "[10] operator() at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:190",
         "[11] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:110",
-        "[12] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567",
-        "[14] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:561",
-        "[15] RimSummaryCaseMainCollection::loadSummaryCaseData(std::vector<RimSummaryCase*, std::allocator<RimSummaryCase*> > const&, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:457",
-        "[16] RimSummaryCaseMainCollection::createSummaryCasesFromFileInfos(std::vector<RifSummaryCaseFileResultInfo, std::allocator<RifSummaryCaseFileResultInfo> > const&, bool, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:712",
-        "[17] RiaEnsembleImportTools::createSummaryCasesFromFiles(QList<QString> const&, RiaEnsembleImportTools::CreateConfig) at ResInsight/ApplicationLibCode/Application/Tools/Ensemble/RiaEnsembleImportTools.cpp:82",
-        "[18] RimSummaryFileSetEnsemble::createSummaryCasesFromEnsembleFileSet(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/Ensemble/RimSummaryFileSetEnsemble.cpp:168",
-        "[19] RimSummaryFileSetEnsemble::onFileSetChanged(caf::SignalEmitter const*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/Ensemble/RimSummaryFileSetEnsemble.cpp:134",
-        "[20] std::function<void (caf::SignalEmitter const*)>::operator()(caf::SignalEmitter const*) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:591",
-        "[21] RicReloadSummaryCaseFeature::reloadSelectedCasesAndUpdate() at ResInsight/ApplicationLibCode/Commands/RicReloadSummaryCaseFeature.cpp:142",
-        "[22] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176",
-        "[31] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823",
-        "[37] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823",
-        "[49] RiuPlotMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp:1058",
-        "[57] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823",
-        "[62] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823",
-        "[73] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226",
-        "[74] __libc_start_main at :0"
+        "[12] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567"
       ],
       "signature_frames": [
         "RifEclipseSummaryTools::getRestartRelativeFilePathResdata",
@@ -1182,11 +1261,19 @@
           "count": 8,
           "first_seen": "2026-04-13T22:25:33.036Z",
           "last_seen": "2026-04-26T18:46:04.205Z"
+        },
+        "2026-06-20": {
+          "count": 3,
+          "first_seen": "2026-06-15T10:32:04.243Z",
+          "last_seen": "2026-06-17T10:18:08.147Z",
+          "versions": {
+            "2026.02.2": 3
+          }
         }
       }
     },
     "1dc7071e0402": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": {
         "number": 14140,
@@ -1254,11 +1341,19 @@
           "versions": {
             "2026.02.2": 2
           }
+        },
+        "2026-06-20": {
+          "count": 1,
+          "first_seen": "2026-05-27T10:59:13.448Z",
+          "last_seen": "2026-05-27T10:59:13.448Z",
+          "versions": {
+            "2026.02.2": 1
+          }
         }
       }
     },
     "1ed408783b46": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": {
         "number": 14150,
@@ -1297,6 +1392,14 @@
           "last_seen": "2026-06-02T20:12:32.83Z"
         },
         "2026-06-12": {
+          "count": 5,
+          "first_seen": "2026-06-02T20:12:31.249Z",
+          "last_seen": "2026-06-02T20:12:32.83Z",
+          "versions": {
+            "2026.02.2": 5
+          }
+        },
+        "2026-06-20": {
           "count": 5,
           "first_seen": "2026-06-02T20:12:31.249Z",
           "last_seen": "2026-06-02T20:12:32.83Z",
@@ -1416,7 +1519,7 @@
       }
     },
     "232f8faaea5f": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": {
         "number": 14179,
@@ -1465,6 +1568,14 @@
           "last_seen": "2026-06-02T20:12:31.674Z"
         },
         "2026-06-12": {
+          "count": 1,
+          "first_seen": "2026-06-02T20:12:31.674Z",
+          "last_seen": "2026-06-02T20:12:31.674Z",
+          "versions": {
+            "2026.02.2": 1
+          }
+        },
+        "2026-06-20": {
           "count": 1,
           "first_seen": "2026-06-02T20:12:31.674Z",
           "last_seen": "2026-06-02T20:12:31.674Z",
@@ -1526,7 +1637,7 @@
       }
     },
     "29e769992730": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": {
         "number": 14185,
@@ -1580,11 +1691,19 @@
           "versions": {
             "2026.02.2": 1
           }
+        },
+        "2026-06-20": {
+          "count": 1,
+          "first_seen": "2026-06-04T13:25:41.152Z",
+          "last_seen": "2026-06-04T13:25:41.152Z",
+          "versions": {
+            "2026.02.2": 1
+          }
         }
       }
     },
     "2a00a6e3aa2e": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": {
         "number": 14155,
@@ -1635,11 +1754,19 @@
           "versions": {
             "2026.02.2": 2
           }
+        },
+        "2026-06-20": {
+          "count": 2,
+          "first_seen": "2026-06-02T19:57:19.87Z",
+          "last_seen": "2026-06-02T22:18:46.523Z",
+          "versions": {
+            "2026.02.2": 2
+          }
         }
       }
     },
     "2b80f5a0a843": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": {
         "number": 14174,
@@ -1674,6 +1801,14 @@
           "last_seen": "2026-05-28T09:06:55.276Z"
         },
         "2026-06-12": {
+          "count": 1,
+          "first_seen": "2026-05-28T09:06:55.276Z",
+          "last_seen": "2026-05-28T09:06:55.276Z",
+          "versions": {
+            "2026.02.2": 1
+          }
+        },
+        "2026-06-20": {
           "count": 1,
           "first_seen": "2026-05-28T09:06:55.276Z",
           "last_seen": "2026-05-28T09:06:55.276Z",
@@ -1780,6 +1915,45 @@
         }
       }
     },
+    "2ffbf9034d82": {
+      "last_updated": "2026-06-20",
+      "notes": "",
+      "opm_issue": null,
+      "pr": null,
+      "representative_stack": [
+        "[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:167",
+        "[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:263",
+        "[5] RimEclipsePropertyFilterCollection* caf::PdmObjectHandle::firstAncestorOrThisOfTypeAsserted<RimEclipsePropertyFilterCollection>() const at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmObjectHandle.h:249",
+        "[7] RicEclipsePropertyFilterInsertFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/EclipseCommands/RicEclipsePropertyFilterInsertFeature.cpp:58",
+        "[8] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176",
+        "[17] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1831",
+        "[23] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1831",
+        "[35] RiuMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:2092",
+        "[43] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1831",
+        "[48] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1831",
+        "[59] main at ResInsight/ApplicationExeCode/RiaMain.cpp:258",
+        "[60] __libc_start_main at :0"
+      ],
+      "signature_frames": [
+        "RimEclipsePropertyFilterCollection* caf::PdmObjectHandle::firstAncestorOrThisOfTypeAsserted<RimEclipsePropertyFilterCollection>",
+        "RicEclipsePropertyFilterInsertFeature::onActionTriggered",
+        "caf::CmdFeature::actionTriggered",
+        "RiuMainWindow::customMenuRequested"
+      ],
+      "signature_id": "2ffbf9034d82",
+      "status": "new",
+      "top_frame": "RimEclipsePropertyFilterCollection* caf::PdmObjectHandle::firstAncestorOrThisOfTypeAsserted<RimEclipsePropertyFilterCollection>",
+      "weeks": {
+        "2026-06-20": {
+          "count": 1,
+          "first_seen": "2026-06-19T10:45:44.403Z",
+          "last_seen": "2026-06-19T10:45:44.403Z",
+          "versions": {
+            "2026.06.0": 1
+          }
+        }
+      }
+    },
     "301aefc06fb9": {
       "last_updated": "2026-06-11",
       "notes": "",
@@ -1819,7 +1993,7 @@
       }
     },
     "309928562adc": {
-      "last_updated": "2026-06-11",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": {
         "number": 14011,
@@ -1875,6 +2049,14 @@
           "count": 1,
           "first_seen": "2026-05-12T08:51:32.058Z",
           "last_seen": "2026-05-12T08:51:32.058Z"
+        },
+        "2026-06-20": {
+          "count": 1,
+          "first_seen": "2026-06-16T13:04:51.343Z",
+          "last_seen": "2026-06-16T13:04:51.343Z",
+          "versions": {
+            "2026.02.2": 1
+          }
         }
       }
     },
@@ -2084,7 +2266,7 @@
       }
     },
     "359dda73050e": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": null,
       "pr": null,
@@ -2132,6 +2314,14 @@
           "last_seen": "2026-06-02T20:12:31.674Z"
         },
         "2026-06-12": {
+          "count": 1,
+          "first_seen": "2026-06-02T20:12:31.674Z",
+          "last_seen": "2026-06-02T20:12:31.674Z",
+          "versions": {
+            "2026.02.2": 1
+          }
+        },
+        "2026-06-20": {
           "count": 1,
           "first_seen": "2026-06-02T20:12:31.674Z",
           "last_seen": "2026-06-02T20:12:31.674Z",
@@ -2192,7 +2382,7 @@
       }
     },
     "36fe75d940bb": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": {
         "number": 14140,
@@ -2251,11 +2441,19 @@
           "versions": {
             "2026.02.2": 1
           }
+        },
+        "2026-06-20": {
+          "count": 1,
+          "first_seen": "2026-05-29T06:57:22.879Z",
+          "last_seen": "2026-05-29T06:57:22.879Z",
+          "versions": {
+            "2026.02.2": 1
+          }
         }
       }
     },
     "388aa68f79e0": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": {
         "number": 14112,
@@ -2302,6 +2500,14 @@
           "last_seen": "2026-06-03T13:27:53.25Z"
         },
         "2026-06-12": {
+          "count": 7,
+          "first_seen": "2026-05-27T08:26:30.756Z",
+          "last_seen": "2026-06-03T13:27:53.25Z",
+          "versions": {
+            "2026.02.2": 7
+          }
+        },
+        "2026-06-20": {
           "count": 7,
           "first_seen": "2026-05-27T08:26:30.756Z",
           "last_seen": "2026-06-03T13:27:53.25Z",
@@ -2360,7 +2566,7 @@
       }
     },
     "3b96a7b3aace": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": {
         "number": 14179,
@@ -2410,6 +2616,14 @@
           "last_seen": "2026-06-02T20:12:32.867Z"
         },
         "2026-06-12": {
+          "count": 1,
+          "first_seen": "2026-06-02T20:12:32.867Z",
+          "last_seen": "2026-06-02T20:12:32.867Z",
+          "versions": {
+            "2026.02.2": 1
+          }
+        },
+        "2026-06-20": {
           "count": 1,
           "first_seen": "2026-06-02T20:12:32.867Z",
           "last_seen": "2026-06-02T20:12:32.867Z",
@@ -2467,7 +2681,7 @@
       }
     },
     "3ca67b66b036": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": null,
       "pr": null,
@@ -2511,6 +2725,14 @@
           "last_seen": "2026-05-26T13:15:12.175Z"
         },
         "2026-06-12": {
+          "count": 1,
+          "first_seen": "2026-05-26T13:15:12.175Z",
+          "last_seen": "2026-05-26T13:15:12.175Z",
+          "versions": {
+            "2026.02.2": 1
+          }
+        },
+        "2026-06-20": {
           "count": 1,
           "first_seen": "2026-05-26T13:15:12.175Z",
           "last_seen": "2026-05-26T13:15:12.175Z",
@@ -2577,7 +2799,7 @@
       }
     },
     "44b82d1da85c": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": {
         "number": 14116,
@@ -2628,11 +2850,19 @@
           "versions": {
             "2026.02.2": 4
           }
+        },
+        "2026-06-20": {
+          "count": 1,
+          "first_seen": "2026-05-22T10:49:44.2Z",
+          "last_seen": "2026-05-22T10:49:44.2Z",
+          "versions": {
+            "2026.02.2": 1
+          }
         }
       }
     },
     "46812e746c40": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": {
         "number": 14140,
@@ -2665,6 +2895,14 @@
       "top_frame": "caf::PdmFieldUiCap<caf::PdmField<QString> >::setValueFromUiEditor",
       "weeks": {
         "2026-06-12": {
+          "count": 1,
+          "first_seen": "2026-06-11T10:55:17.861Z",
+          "last_seen": "2026-06-11T10:55:17.861Z",
+          "versions": {
+            "2026.06.0-RC_3": 1
+          }
+        },
+        "2026-06-20": {
           "count": 1,
           "first_seen": "2026-06-11T10:55:17.861Z",
           "last_seen": "2026-06-11T10:55:17.861Z",
@@ -2718,7 +2956,7 @@
       }
     },
     "4b301f2f6aca": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": {
         "number": 14213,
@@ -2776,20 +3014,27 @@
           "versions": {
             "2026.02.2": 2
           }
+        },
+        "2026-06-20": {
+          "count": 2,
+          "first_seen": "2026-05-23T22:42:23.646Z",
+          "last_seen": "2026-06-12T14:04:49.292Z",
+          "versions": {
+            "2026.02.2": 2
+          }
         }
       }
     },
     "4b98ba7f3609": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": null,
       "pr": null,
       "representative_stack": [
-        "[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147",
-        "[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227",
-        "[56] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823",
-        "[66] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226",
-        "[67] __libc_start_main at :0"
+        "[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:167",
+        "[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:263",
+        "[11] main at ResInsight/ApplicationExeCode/RiaMain.cpp:264",
+        "[12] __libc_start_main at :0"
       ],
       "signature_frames": [],
       "signature_id": "4b98ba7f3609",
@@ -2844,11 +3089,21 @@
             "2026.02.2": 83,
             "2026.02.3-dev.01": 1
           }
+        },
+        "2026-06-20": {
+          "count": 87,
+          "first_seen": "2026-05-21T12:04:19.478Z",
+          "last_seen": "2026-06-18T12:59:43.828Z",
+          "versions": {
+            "2026.02.2": 81,
+            "2026.02.3-dev.01": 1,
+            "2026.06.0": 5
+          }
         }
       }
     },
     "4bcea50aa6e1": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": {
         "number": 14140,
@@ -2920,6 +3175,14 @@
           "last_seen": "2026-06-01T12:43:51.841Z"
         },
         "2026-06-12": {
+          "count": 3,
+          "first_seen": "2026-05-29T14:06:22.726Z",
+          "last_seen": "2026-06-08T12:09:14.349Z",
+          "versions": {
+            "2026.02.2": 3
+          }
+        },
+        "2026-06-20": {
           "count": 3,
           "first_seen": "2026-05-29T14:06:22.726Z",
           "last_seen": "2026-06-08T12:09:14.349Z",
@@ -3195,7 +3458,7 @@
       }
     },
     "513ad4d820c5": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": {
         "number": 14146,
@@ -3254,11 +3517,19 @@
           "versions": {
             "2026.02.2": 2
           }
+        },
+        "2026-06-20": {
+          "count": 2,
+          "first_seen": "2026-05-25T14:11:16.015Z",
+          "last_seen": "2026-06-02T07:05:17.144Z",
+          "versions": {
+            "2026.02.2": 2
+          }
         }
       }
     },
     "532ae6ef21f2": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": null,
       "pr": null,
@@ -3297,6 +3568,14 @@
           "last_seen": "2026-05-25T21:44:13.418Z"
         },
         "2026-06-12": {
+          "count": 1,
+          "first_seen": "2026-05-25T21:44:13.418Z",
+          "last_seen": "2026-05-25T21:44:13.418Z",
+          "versions": {
+            "2026.02.2": 1
+          }
+        },
+        "2026-06-20": {
           "count": 1,
           "first_seen": "2026-05-25T21:44:13.418Z",
           "last_seen": "2026-05-25T21:44:13.418Z",
@@ -3357,7 +3636,7 @@
       }
     },
     "5bb150db338d": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": {
         "number": 14007,
@@ -3421,6 +3700,14 @@
           "last_seen": "2026-06-10T21:56:05.631Z",
           "versions": {
             "2026.02.2": 4
+          }
+        },
+        "2026-06-20": {
+          "count": 3,
+          "first_seen": "2026-05-29T08:17:06.473Z",
+          "last_seen": "2026-06-10T21:56:05.631Z",
+          "versions": {
+            "2026.02.2": 3
           }
         }
       }
@@ -3599,26 +3886,26 @@
       }
     },
     "64f0d600d3f1": {
-      "last_updated": "2026-06-11",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": null,
       "pr": null,
       "representative_stack": [
-        "[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147",
-        "[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227",
-        "[3] caf::PdmUiFieldHandle::enableAutoValue(bool, bool) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiFieldHandle.cpp:163",
+        "[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:167",
+        "[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:263",
+        "[3] caf::PdmUiFieldHandle::enableAutoValue(bool, bool) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiFieldHandle.cpp:164",
         "[4] caf::PdmUiLineEditor::slotEditingFinished() at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiLineEditor.cpp:355",
-        "[9] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823",
-        "[18] caf::PdmUiFormLayoutObjectEditor::cleanupBeforeSettingPdmObject() at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiFormLayoutObjectEditor.cpp:595",
+        "[9] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1831",
+        "[18] caf::PdmUiFormLayoutObjectEditor::cleanupBeforeSettingPdmObject() at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiFormLayoutObjectEditor.cpp:607",
         "[19] caf::PdmUiObjectEditorHandle::setPdmObject(caf::PdmObjectHandle*) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiObjectEditorHandle.cpp:66",
         "[20] caf::PdmUiPropertyView::showProperties(caf::PdmObjectHandle*) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiPropertyView.cpp:211",
-        "[21] RiuPlotMainWindow::selectedObjectsChanged(caf::PdmUiTreeView*, caf::PdmUiPropertyView*) at ResInsight/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp:951",
+        "[21] RiuPlotMainWindow::selectedObjectsChanged(caf::PdmUiTreeView*, caf::PdmUiPropertyView*) at ResInsight/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp:962",
         "[23] caf::PdmUiTreeView::slotOnSelectionChanged() at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeView.cpp:154",
         "[37] caf::PdmUiTreeViewQModel::updateSubTreeRecursive(QModelIndex const&, caf::PdmUiTreeOrdering*, caf::PdmUiTreeOrdering*, bool) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeViewQModel.cpp:268",
         "[38] caf::PdmUiTreeViewQModel::updateSubTree(caf::PdmUiItem*, bool) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeViewQModel.cpp:202",
         "[39] caf::PdmUiTreeViewEditor::updateMySubTree(caf::PdmUiItem*, bool) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeViewEditor.cpp:332",
-        "[40] caf::PdmUiEditorHandle::updateUi() at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiEditorHandle.cpp:82",
-        "[41] caf::PdmUiItem::updateConnectedEditors() const at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiItem.cpp:491",
+        "[40] caf::PdmUiEditorHandle::updateUi() at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiEditorHandle.cpp:84",
+        "[41] caf::PdmUiItem::updateConnectedEditors() const at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiItem.cpp:493",
         "[42] RimEnsembleCurveSetCollection::onChildDeleted(caf::PdmChildArrayFieldHandle*, std::vector<caf::PdmObjectHandle*, std::allocator<caf::PdmObjectHandle*> >&) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimEnsembleCurveSetCollection.cpp:333",
         "[43] RicDeleteItemExec::redo() at ResInsight/ApplicationLibCode/Commands/RicDeleteItemExec.cpp:71",
         "[44] RicDeleteItemFeature::deleteObject(caf::PdmObject*) at ResInsight/ApplicationLibCode/Commands/RicDeleteItemFeature.cpp:128",
@@ -3626,11 +3913,11 @@
         "[46] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176",
         "[47] RiuTreeViewEventFilter::activateFirstEnabledFeature(std::vector<caf::CmdFeature*, std::allocator<caf::CmdFeature*> > const&) at ResInsight/ApplicationLibCode/UserInterface/RiuTreeViewEventFilter.cpp:95",
         "[48] RiuTreeViewEventFilter::activateFeatureFromKeyEvent(QKeyEvent*) at ResInsight/ApplicationLibCode/UserInterface/RiuTreeViewEventFilter.cpp:73",
-        "[49] RiuPlotMainWindow::keyPressEvent(QKeyEvent*) at ResInsight/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp:319",
-        "[53] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823",
-        "[57] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823",
-        "[67] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226",
-        "[68] __libc_start_main at :0"
+        "[49] RiuPlotMainWindow::keyPressEvent(QKeyEvent*) at ResInsight/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp:322",
+        "[53] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1831",
+        "[57] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1831",
+        "[68] main at ResInsight/ApplicationExeCode/RiaMain.cpp:258",
+        "[69] __libc_start_main at :0"
       ],
       "signature_frames": [
         "caf::PdmUiFieldHandle::enableAutoValue",
@@ -3647,6 +3934,14 @@
           "count": 1,
           "first_seen": "2026-05-05T00:06:43.868Z",
           "last_seen": "2026-05-05T00:06:43.868Z"
+        },
+        "2026-06-20": {
+          "count": 1,
+          "first_seen": "2026-06-18T13:25:23.569Z",
+          "last_seen": "2026-06-18T13:25:23.569Z",
+          "versions": {
+            "2026.06.0": 1
+          }
         }
       }
     },
@@ -3703,7 +3998,7 @@
       }
     },
     "694afb4bae44": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": null,
       "pr": null,
@@ -3747,6 +4042,14 @@
           "last_seen": "2026-05-28T08:38:44.52Z"
         },
         "2026-06-12": {
+          "count": 1,
+          "first_seen": "2026-05-28T08:38:44.52Z",
+          "last_seen": "2026-05-28T08:38:44.52Z",
+          "versions": {
+            "2026.02.2": 1
+          }
+        },
+        "2026-06-20": {
           "count": 1,
           "first_seen": "2026-05-28T08:38:44.52Z",
           "last_seen": "2026-05-28T08:38:44.52Z",
@@ -3806,7 +4109,7 @@
       }
     },
     "69ff9a60f1fa": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": null,
       "pr": null,
@@ -3843,6 +4146,14 @@
       "top_frame": "RigStimPlanFractureDefinition::~RigStimPlanFractureDefinition",
       "weeks": {
         "2026-06-12": {
+          "count": 2,
+          "first_seen": "2026-06-10T22:21:19.134Z",
+          "last_seen": "2026-06-10T22:21:19.311Z",
+          "versions": {
+            "2026.02.2": 2
+          }
+        },
+        "2026-06-20": {
           "count": 2,
           "first_seen": "2026-06-10T22:21:19.134Z",
           "last_seen": "2026-06-10T22:21:19.311Z",
@@ -3892,7 +4203,7 @@
       }
     },
     "6cb07aef59cb": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": null,
       "pr": null,
@@ -3941,11 +4252,19 @@
           "versions": {
             "2026.02.2": 1
           }
+        },
+        "2026-06-20": {
+          "count": 1,
+          "first_seen": "2026-05-28T18:04:48.924Z",
+          "last_seen": "2026-05-28T18:04:48.924Z",
+          "versions": {
+            "2026.02.2": 1
+          }
         }
       }
     },
     "6e43c5539b5e": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": null,
       "pr": null,
@@ -3984,6 +4303,14 @@
           "last_seen": "2026-06-02T20:12:31.727Z"
         },
         "2026-06-12": {
+          "count": 1,
+          "first_seen": "2026-06-02T20:12:31.727Z",
+          "last_seen": "2026-06-02T20:12:31.727Z",
+          "versions": {
+            "2026.02.2": 1
+          }
+        },
+        "2026-06-20": {
           "count": 1,
           "first_seen": "2026-06-02T20:12:31.727Z",
           "last_seen": "2026-06-02T20:12:31.727Z",
@@ -4034,7 +4361,7 @@
       }
     },
     "6ff11cb88796": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": {
         "number": 14178,
@@ -4079,6 +4406,14 @@
           "last_seen": "2026-06-04T10:43:28.121Z"
         },
         "2026-06-12": {
+          "count": 2,
+          "first_seen": "2026-06-01T08:24:29.915Z",
+          "last_seen": "2026-06-04T10:43:28.121Z",
+          "versions": {
+            "2026.02.2": 2
+          }
+        },
+        "2026-06-20": {
           "count": 2,
           "first_seen": "2026-06-01T08:24:29.915Z",
           "last_seen": "2026-06-04T10:43:28.121Z",
@@ -4137,7 +4472,7 @@
       }
     },
     "73b3919e646c": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": null,
       "pr": null,
@@ -4202,11 +4537,19 @@
           "versions": {
             "2026.02.2": 1
           }
+        },
+        "2026-06-20": {
+          "count": 1,
+          "first_seen": "2026-06-02T20:12:32.248Z",
+          "last_seen": "2026-06-02T20:12:32.248Z",
+          "versions": {
+            "2026.02.2": 1
+          }
         }
       }
     },
     "748db0cbcda2": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": null,
       "pr": null,
@@ -4267,11 +4610,19 @@
           "versions": {
             "2026.02.2": 1
           }
+        },
+        "2026-06-20": {
+          "count": 1,
+          "first_seen": "2026-05-21T08:47:21.019Z",
+          "last_seen": "2026-05-21T08:47:21.019Z",
+          "versions": {
+            "2026.02.2": 1
+          }
         }
       }
     },
     "756f5de23e61": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": {
         "number": 14185,
@@ -4308,6 +4659,14 @@
           "last_seen": "2026-06-04T13:39:55.03Z"
         },
         "2026-06-12": {
+          "count": 2,
+          "first_seen": "2026-06-04T13:25:41.101Z",
+          "last_seen": "2026-06-04T13:39:55.03Z",
+          "versions": {
+            "2026.02.2": 2
+          }
+        },
+        "2026-06-20": {
           "count": 2,
           "first_seen": "2026-06-04T13:25:41.101Z",
           "last_seen": "2026-06-04T13:39:55.03Z",
@@ -4378,7 +4737,7 @@
       }
     },
     "76e7e40b4edc": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": {
         "number": 14168,
@@ -4446,6 +4805,14 @@
           "versions": {
             "2026.02.2": 1
           }
+        },
+        "2026-06-20": {
+          "count": 1,
+          "first_seen": "2026-06-05T12:19:36.531Z",
+          "last_seen": "2026-06-05T12:19:36.531Z",
+          "versions": {
+            "2026.02.2": 1
+          }
         }
       }
     },
@@ -4490,7 +4857,7 @@
       }
     },
     "8414fa42bb7b": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": {
         "number": 13878,
@@ -4549,11 +4916,66 @@
           "versions": {
             "2026.02.2": 1
           }
+        },
+        "2026-06-20": {
+          "count": 1,
+          "first_seen": "2026-05-21T11:50:13.645Z",
+          "last_seen": "2026-05-21T11:50:13.645Z",
+          "versions": {
+            "2026.02.2": 1
+          }
+        }
+      }
+    },
+    "87e3ad865e02": {
+      "last_updated": "2026-06-20",
+      "notes": "",
+      "opm_issue": null,
+      "pr": null,
+      "representative_stack": [
+        "[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147",
+        "[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227",
+        "[7] RimWellAllocationPlot::onLoadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/Flow/RimWellAllocationPlot.cpp:896",
+        "[8] RimViewWindow::loadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimViewWindow.cpp:88",
+        "[9] RimSimWellInViewCollection::updateWellAllocationPlots() at ResInsight/ApplicationLibCode/ProjectDataModel/RimSimWellInViewCollection.cpp:578",
+        "[10] RimEclipseView::synchronizeWellsWithResults() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp:1744",
+        "[11] RimEclipseView::onLoadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp:1218",
+        "[12] RimViewWindow::loadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimViewWindow.cpp:88",
+        "[13] RimReloadCaseTools::updateAll3dViews(RimEclipseCase*) at ResInsight/ApplicationLibCode/ProjectDataModel/RimReloadCaseTools.cpp:141",
+        "[14] RimReloadCaseTools::reloadEclipseData(RimEclipseCase*, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimReloadCaseTools.cpp:96",
+        "[15] RicReplaceCaseFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/RicReplaceCaseFeature.cpp:87",
+        "[16] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176",
+        "[25] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823",
+        "[31] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823",
+        "[43] RiuMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:2056",
+        "[51] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823",
+        "[56] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823",
+        "[67] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226",
+        "[68] __libc_start_main at :0"
+      ],
+      "signature_frames": [
+        "RimWellAllocationPlot::onLoadDataAndUpdate",
+        "RimViewWindow::loadDataAndUpdate",
+        "RimSimWellInViewCollection::updateWellAllocationPlots",
+        "RimEclipseView::synchronizeWellsWithResults",
+        "RimEclipseView::onLoadDataAndUpdate"
+      ],
+      "signature_id": "87e3ad865e02",
+      "status": "new",
+      "top_frame": "RimWellAllocationPlot::onLoadDataAndUpdate",
+      "weeks": {
+        "2026-06-20": {
+          "count": 1,
+          "first_seen": "2026-06-16T13:03:07.752Z",
+          "last_seen": "2026-06-16T13:03:07.752Z",
+          "versions": {
+            "2026.02.2": 1
+          }
         }
       }
     },
     "8d28fa20f37a": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": null,
       "pr": null,
@@ -4595,11 +5017,19 @@
           "versions": {
             "2026.02.2": 1
           }
+        },
+        "2026-06-20": {
+          "count": 1,
+          "first_seen": "2026-06-07T17:56:40.141Z",
+          "last_seen": "2026-06-07T17:56:40.141Z",
+          "versions": {
+            "2026.02.2": 1
+          }
         }
       }
     },
     "922f510a0bb7": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": {
         "number": 13930,
@@ -4660,6 +5090,14 @@
           "last_seen": "2026-06-08T21:16:36.133Z",
           "versions": {
             "2026.02.2": 5
+          }
+        },
+        "2026-06-20": {
+          "count": 1,
+          "first_seen": "2026-06-08T21:16:36.133Z",
+          "last_seen": "2026-06-08T21:16:36.133Z",
+          "versions": {
+            "2026.02.2": 1
           }
         }
       }
@@ -4841,7 +5279,7 @@
       }
     },
     "98adc191d3cf": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": {
         "number": 13878,
@@ -4884,6 +5322,14 @@
           "last_seen": "2026-06-12T13:30:59.853Z",
           "versions": {
             "2026.02.2": 2
+          }
+        },
+        "2026-06-20": {
+          "count": 3,
+          "first_seen": "2026-06-08T05:51:18.931Z",
+          "last_seen": "2026-06-16T10:49:34.724Z",
+          "versions": {
+            "2026.02.2": 3
           }
         }
       }
@@ -4996,7 +5442,7 @@
       }
     },
     "9e4139178b72": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": {
         "number": 14161,
@@ -5047,6 +5493,14 @@
           "last_seen": "2026-05-26T12:34:51.666Z"
         },
         "2026-06-12": {
+          "count": 2,
+          "first_seen": "2026-05-26T07:35:50.673Z",
+          "last_seen": "2026-05-26T12:34:51.666Z",
+          "versions": {
+            "2026.02.2": 2
+          }
+        },
+        "2026-06-20": {
           "count": 2,
           "first_seen": "2026-05-26T07:35:50.673Z",
           "last_seen": "2026-05-26T12:34:51.666Z",
@@ -5118,21 +5572,21 @@
       }
     },
     "a52535d78adc": {
-      "last_updated": "2026-06-11",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": null,
       "pr": null,
       "representative_stack": [
-        "[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147",
-        "[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227",
+        "[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:167",
+        "[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:263",
         "[5] caf::PdmFieldUiCap<caf::PdmPtrField<RimSummaryEnsemble*> >::setValueFromUiEditor(QVariant const&, bool) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafInternalPdmUiFieldCapability.inl:30",
         "[6] caf::CmdFieldChangeExec::redo() at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFieldChangeExec.cpp:139",
         "[8] caf::CmdUiCommandSystemImpl::fieldChangedCommand(std::vector<caf::PdmFieldHandle*, std::allocator<caf::PdmFieldHandle*> > const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdUiCommandSystemImpl.cpp:146",
         "[9] caf::PdmUiCommandSystemProxy::setUiValueToField(caf::PdmUiFieldHandle*, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiCommandSystemProxy.cpp:113",
         "[10] caf::PdmUiComboBoxEditor::slotIndexActivated(int) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiComboBoxEditor.cpp:455",
-        "[21] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823",
-        "[27] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823",
-        "[38] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226",
+        "[21] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1831",
+        "[27] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1831",
+        "[38] main at ResInsight/ApplicationExeCode/RiaMain.cpp:258",
         "[39] __libc_start_main at :0"
       ],
       "signature_frames": [
@@ -5155,11 +5609,20 @@
           "count": 1,
           "first_seen": "2026-04-29T15:51:53.982Z",
           "last_seen": "2026-04-29T15:51:53.982Z"
+        },
+        "2026-06-20": {
+          "count": 3,
+          "first_seen": "2026-06-17T07:33:25.7Z",
+          "last_seen": "2026-06-19T19:00:34.761Z",
+          "versions": {
+            "2026.02.2": 2,
+            "2026.06.0": 1
+          }
         }
       }
     },
     "a6749f9506ab": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": null,
       "pr": null,
@@ -5220,6 +5683,14 @@
           "last_seen": "2026-06-02T20:12:32.25Z"
         },
         "2026-06-12": {
+          "count": 1,
+          "first_seen": "2026-06-02T20:12:32.25Z",
+          "last_seen": "2026-06-02T20:12:32.25Z",
+          "versions": {
+            "2026.02.2": 1
+          }
+        },
+        "2026-06-20": {
           "count": 1,
           "first_seen": "2026-06-02T20:12:32.25Z",
           "last_seen": "2026-06-02T20:12:32.25Z",
@@ -5365,8 +5836,46 @@
         }
       }
     },
+    "b54681a6057b": {
+      "last_updated": "2026-06-20",
+      "notes": "",
+      "opm_issue": null,
+      "pr": null,
+      "representative_stack": [
+        "[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147",
+        "[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227",
+        "[5] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125",
+        "[6] cvf::Camera::setProjectionAsPerspective(double, double, double) at ResInsight/Fwk/VizFwk/LibRender/cvfCamera.cpp:206",
+        "[7] caf::Viewer::optimizeClippingPlanes() at ResInsight/Fwk/AppFwk/cafViewer/cafViewer.cpp:465",
+        "[8] caf::Viewer::paintGL() at ResInsight/Fwk/AppFwk/cafViewer/cafViewer.cpp:884",
+        "[12] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823",
+        "[46] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823",
+        "[58] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823",
+        "[64] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823",
+        "[75] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226",
+        "[76] __libc_start_main at :0"
+      ],
+      "signature_frames": [
+        "cvf::Camera::setProjectionAsPerspective",
+        "caf::Viewer::optimizeClippingPlanes",
+        "caf::Viewer::paintGL"
+      ],
+      "signature_id": "b54681a6057b",
+      "status": "new",
+      "top_frame": "cvf::Camera::setProjectionAsPerspective",
+      "weeks": {
+        "2026-06-20": {
+          "count": 1,
+          "first_seen": "2026-06-15T11:41:43.273Z",
+          "last_seen": "2026-06-15T11:41:43.273Z",
+          "versions": {
+            "2026.02.2": 1
+          }
+        }
+      }
+    },
     "b570b9f2f0e6": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": null,
       "pr": null,
@@ -5403,6 +5912,14 @@
           "last_seen": "2026-06-02T11:34:47.01Z"
         },
         "2026-06-12": {
+          "count": 1,
+          "first_seen": "2026-06-02T11:34:47.01Z",
+          "last_seen": "2026-06-02T11:34:47.01Z",
+          "versions": {
+            "2026.02.2": 1
+          }
+        },
+        "2026-06-20": {
           "count": 1,
           "first_seen": "2026-06-02T11:34:47.01Z",
           "last_seen": "2026-06-02T11:34:47.01Z",
@@ -5446,7 +5963,7 @@
       }
     },
     "b80de5fc87c2": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": {
         "number": 14185,
@@ -5498,11 +6015,19 @@
           "versions": {
             "2026.02.2": 1
           }
+        },
+        "2026-06-20": {
+          "count": 1,
+          "first_seen": "2026-06-02T20:12:32.462Z",
+          "last_seen": "2026-06-02T20:12:32.462Z",
+          "versions": {
+            "2026.02.2": 1
+          }
         }
       }
     },
     "b8bc3e3c7278": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": {
         "number": 14009,
@@ -5562,11 +6087,19 @@
           "versions": {
             "2026.02.2": 2
           }
+        },
+        "2026-06-20": {
+          "count": 2,
+          "first_seen": "2026-06-01T06:23:42.554Z",
+          "last_seen": "2026-06-05T08:44:15.848Z",
+          "versions": {
+            "2026.02.2": 2
+          }
         }
       }
     },
     "bb02459d6dfe": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": {
         "number": 11342,
@@ -5629,6 +6162,14 @@
           "last_seen": "2026-05-12T09:25:58.707Z"
         },
         "2026-06-12": {
+          "count": 2,
+          "first_seen": "2026-06-11T11:44:57.648Z",
+          "last_seen": "2026-06-11T13:04:29.981Z",
+          "versions": {
+            "2026.02.2": 2
+          }
+        },
+        "2026-06-20": {
           "count": 2,
           "first_seen": "2026-06-11T11:44:57.648Z",
           "last_seen": "2026-06-11T13:04:29.981Z",
@@ -5799,7 +6340,7 @@
       }
     },
     "c250d46477d4": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "Null deref of m_hdfFile in RifHdf5Exporter::createGroup. Constructor swallows a throwing 'new H5::H5File' (#13883 made m_hdfFile reliably null on failure but did not guard the use); createGroup(nullptr, ...) then dereferences the null m_hdfFile, and the surrounding try/catch(...) cannot catch the SIGSEGV. Fix guards the else branch with 'else if ( m_hdfFile )'. Build-verified (ApplicationLibCode target, clean).",
       "opm_issue": {
         "number": 14213,
@@ -5872,11 +6413,19 @@
           "versions": {
             "2026.02.2": 2
           }
+        },
+        "2026-06-20": {
+          "count": 1,
+          "first_seen": "2026-05-29T13:31:33.488Z",
+          "last_seen": "2026-05-29T13:31:33.488Z",
+          "versions": {
+            "2026.02.2": 1
+          }
         }
       }
     },
     "c44fc451a611": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": {
         "number": 14138,
@@ -5927,6 +6476,14 @@
           "last_seen": "2026-06-03T15:59:29.719Z"
         },
         "2026-06-12": {
+          "count": 6,
+          "first_seen": "2026-05-28T07:31:55.884Z",
+          "last_seen": "2026-06-08T11:26:22.295Z",
+          "versions": {
+            "2026.02.2": 6
+          }
+        },
+        "2026-06-20": {
           "count": 6,
           "first_seen": "2026-05-28T07:31:55.884Z",
           "last_seen": "2026-06-08T11:26:22.295Z",
@@ -6000,8 +6557,46 @@
         }
       }
     },
+    "c6d682d471e2": {
+      "last_updated": "2026-06-20",
+      "notes": "",
+      "opm_issue": null,
+      "pr": null,
+      "representative_stack": [
+        "[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:167",
+        "[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:263",
+        "[3] RiuMainWindow::subWindowList(QMdiArea::WindowOrder) at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:1185",
+        "[4] RiaSocketServer::findReservoir(int) at ResInsight/ApplicationLibCode/SocketInterface/RiaSocketServer.cpp:155",
+        "[5] RiaGetActiveCellProperty::interpretCommand(RiaSocketServer*, QList<QByteArray> const&, QDataStream&) at ResInsight/ApplicationLibCode/SocketInterface/RiaPropertyDataCommands.cpp:62",
+        "[6] RiaSocketServer::readCommandFromOctave() at ResInsight/ApplicationLibCode/SocketInterface/RiaSocketServer.cpp:231",
+        "[7] RiaSocketServer::slotReadyRead() at ResInsight/ApplicationLibCode/SocketInterface/RiaSocketServer.cpp:293",
+        "[12] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1831",
+        "[21] main at ResInsight/ApplicationExeCode/RiaMain.cpp:258",
+        "[22] __libc_start_main at :0"
+      ],
+      "signature_frames": [
+        "RiuMainWindow::subWindowList",
+        "RiaSocketServer::findReservoir",
+        "RiaGetActiveCellProperty::interpretCommand",
+        "RiaSocketServer::readCommandFromOctave",
+        "RiaSocketServer::slotReadyRead"
+      ],
+      "signature_id": "c6d682d471e2",
+      "status": "new",
+      "top_frame": "RiuMainWindow::subWindowList",
+      "weeks": {
+        "2026-06-20": {
+          "count": 1,
+          "first_seen": "2026-06-16T07:28:39.146Z",
+          "last_seen": "2026-06-16T07:28:39.146Z",
+          "versions": {
+            "2026.06.0": 1
+          }
+        }
+      }
+    },
     "c93afe9d5b9f": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": {
         "number": 14175,
@@ -6059,11 +6654,19 @@
           "versions": {
             "2026.02.2": 1
           }
+        },
+        "2026-06-20": {
+          "count": 1,
+          "first_seen": "2026-06-04T11:15:23.138Z",
+          "last_seen": "2026-06-04T11:15:23.138Z",
+          "versions": {
+            "2026.02.2": 1
+          }
         }
       }
     },
     "cd0b3b9fb17a": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": {
         "number": 14205,
@@ -6116,11 +6719,20 @@
             "2026.02.2": 6,
             "2026.02.3-dev.01": 1
           }
+        },
+        "2026-06-20": {
+          "count": 7,
+          "first_seen": "2026-05-23T09:14:14.466Z",
+          "last_seen": "2026-06-11T12:25:22.03Z",
+          "versions": {
+            "2026.02.2": 6,
+            "2026.02.3-dev.01": 1
+          }
         }
       }
     },
     "cd0b9c015ffb": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": {
         "number": 14172,
@@ -6160,6 +6772,14 @@
           "last_seen": "2026-06-04T10:38:47.12Z"
         },
         "2026-06-12": {
+          "count": 1,
+          "first_seen": "2026-06-04T10:38:47.12Z",
+          "last_seen": "2026-06-04T10:38:47.12Z",
+          "versions": {
+            "2026.02.2": 1
+          }
+        },
+        "2026-06-20": {
           "count": 1,
           "first_seen": "2026-06-04T10:38:47.12Z",
           "last_seen": "2026-06-04T10:38:47.12Z",
@@ -6208,6 +6828,47 @@
           "count": 5,
           "first_seen": "2026-03-25T10:06:48.53Z",
           "last_seen": "2026-03-25T12:55:49.978Z"
+        }
+      }
+    },
+    "d2161286a077": {
+      "last_updated": "2026-06-20",
+      "notes": "",
+      "opm_issue": {
+        "number": 14175,
+        "state": "CLOSED",
+        "url": "https://github.com/OPM/ResInsight/issues/14175"
+      },
+      "pr": null,
+      "representative_stack": [
+        "[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:167",
+        "[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:263",
+        "[5] caf::PdmUiEditorHandle::updateUi(QString const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiEditorHandle.cpp:65",
+        "[6] caf::PdmUiPropertyView::showProperties(caf::PdmObjectHandle*) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiPropertyView.cpp:213",
+        "[7] RiuMainWindow::selectedObjectsChanged() at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:1539",
+        "[9] caf::PdmUiTreeView::slotOnSelectionChanged() at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeView.cpp:154",
+        "[23] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1831",
+        "[29] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1831",
+        "[40] main at ResInsight/ApplicationExeCode/RiaMain.cpp:258",
+        "[41] __libc_start_main at :0"
+      ],
+      "signature_frames": [
+        "caf::PdmUiEditorHandle::updateUi",
+        "caf::PdmUiPropertyView::showProperties",
+        "RiuMainWindow::selectedObjectsChanged",
+        "caf::PdmUiTreeView::slotOnSelectionChanged"
+      ],
+      "signature_id": "d2161286a077",
+      "status": "resolved",
+      "top_frame": "caf::PdmUiEditorHandle::updateUi",
+      "weeks": {
+        "2026-06-20": {
+          "count": 1,
+          "first_seen": "2026-06-18T06:55:30.718Z",
+          "last_seen": "2026-06-18T06:55:30.718Z",
+          "versions": {
+            "2026.06.0": 1
+          }
         }
       }
     },
@@ -6266,7 +6927,7 @@
       }
     },
     "d6cae2bbf683": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": {
         "number": 14183,
@@ -6326,6 +6987,59 @@
           "versions": {
             "2026.02.2": 1
           }
+        },
+        "2026-06-20": {
+          "count": 1,
+          "first_seen": "2026-06-02T20:12:32.595Z",
+          "last_seen": "2026-06-02T20:12:32.595Z",
+          "versions": {
+            "2026.02.2": 1
+          }
+        }
+      }
+    },
+    "db447db3614d": {
+      "last_updated": "2026-06-20",
+      "notes": "",
+      "opm_issue": null,
+      "pr": null,
+      "representative_stack": [
+        "[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:167",
+        "[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:263",
+        "[13] ecl_file_view_iget_named_file_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_view.cpp:127",
+        "[14] ecl_file_view_iget_named_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_view.cpp:224",
+        "[15] RifEclipseOutputFileTools::findAvailablePhases(ecl_file_struct const*) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseOutputFileTools.cpp:585",
+        "[16] RifEclipseUnifiedRestartFileAccess::openFile() at ResInsight/ApplicationLibCode/FileInterface/RifEclipseUnifiedRestartFileAccess.cpp:125",
+        "[17] RifEclipseUnifiedRestartFileAccess::extractTimestepsFromEclipse() at ResInsight/ApplicationLibCode/FileInterface/RifEclipseUnifiedRestartFileAccess.cpp:152",
+        "[18] RifEclipseUnifiedRestartFileAccess::timeSteps(std::vector<QDateTime, std::allocator<QDateTime> >*, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseUnifiedRestartFileAccess.cpp:206",
+        "[19] RimEclipseResultCase::importGridAndResultMetaData(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultCase.cpp:216",
+        "[20] RiaImportEclipseCaseTools::openEclipseCaseShowTimeStepFilterImpl(QString const&, bool, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:372",
+        "[21] RiaImportEclipseCaseTools::openEclipseCasesFromFile(QList<QString> const&, bool, std::map<QString, int, std::less<QString>, std::allocator<std::pair<QString const, int> > >*, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:107",
+        "[22] RicImportGeneralDataFeature::openEclipseCaseFromFileNames(QList<QString> const&, bool, std::vector<int, std::allocator<int> >&, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:363",
+        "[23] RicImportGeneralDataFeature::openEclipseFilesFromFileNames(QList<QString> const&, bool, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:105",
+        "[24] RicImportGeneralDataFeature::openEclipseFilesFromFileNames(QList<QString> const&, bool, bool) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:56",
+        "[25] RiaGuiApplication::handleArguments(gsl::not_null<cvf::ProgramOptions*>) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:847",
+        "[26] main at ResInsight/ApplicationExeCode/RiaMain.cpp:202",
+        "[27] __libc_start_main at :0"
+      ],
+      "signature_frames": [
+        "RifEclipseOutputFileTools::findAvailablePhases",
+        "RifEclipseUnifiedRestartFileAccess::openFile",
+        "RifEclipseUnifiedRestartFileAccess::extractTimestepsFromEclipse",
+        "RifEclipseUnifiedRestartFileAccess::timeSteps",
+        "RimEclipseResultCase::importGridAndResultMetaData"
+      ],
+      "signature_id": "db447db3614d",
+      "status": "new",
+      "top_frame": "RifEclipseOutputFileTools::findAvailablePhases",
+      "weeks": {
+        "2026-06-20": {
+          "count": 1,
+          "first_seen": "2026-06-19T15:16:33.637Z",
+          "last_seen": "2026-06-19T15:16:33.637Z",
+          "versions": {
+            "2026.06.1-dev.01": 1
+          }
         }
       }
     },
@@ -6384,7 +7098,7 @@
       }
     },
     "dde121c349b6": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": {
         "number": 14140,
@@ -6478,6 +7192,15 @@
             "2026.02.2": 10,
             "2026.06.0-RC_1": 1
           }
+        },
+        "2026-06-20": {
+          "count": 10,
+          "first_seen": "2026-05-21T09:39:53.897Z",
+          "last_seen": "2026-06-11T06:21:46.27Z",
+          "versions": {
+            "2026.02.2": 9,
+            "2026.06.0-RC_1": 1
+          }
         }
       }
     },
@@ -6524,6 +7247,57 @@
           "count": 1,
           "first_seen": "2026-03-24T08:14:19.702Z",
           "last_seen": "2026-03-24T08:14:19.702Z"
+        }
+      }
+    },
+    "e16a04b3461e": {
+      "last_updated": "2026-06-20",
+      "notes": "",
+      "opm_issue": null,
+      "pr": null,
+      "representative_stack": [
+        "[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147",
+        "[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227",
+        "[5] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125",
+        "[6] cvf::DrawableText::renderText(cvf::OpenGLContext*, cvf::ShaderProgram*, cvf::MatrixState const&) at ResInsight/Fwk/VizFwk/LibRender/cvfDrawableText.cpp:376",
+        "[7] cvf::RenderEngine::render(cvf::OpenGLContext*, cvf::RenderQueue*, unsigned long, cvf::Camera const&, cvf::UniformSet const*) at ResInsight/Fwk/VizFwk/LibViewing/cvfRenderEngine.cpp:288",
+        "[8] cvf::Rendering::render(cvf::OpenGLContext*) at ResInsight/Fwk/VizFwk/LibViewing/cvfRendering.cpp:271",
+        "[9] cvf::RenderSequence::render(cvf::OpenGLContext*) at ResInsight/Fwk/VizFwk/LibViewing/cvfRenderSequence.cpp:211",
+        "[10] caf::Viewer::paintGL() at ResInsight/Fwk/AppFwk/cafViewer/cafViewer.cpp:901",
+        "[14] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823",
+        "[44] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823",
+        "[53] RiaOpenTelemetryManager::reportCrash(int, std::basic_stacktrace<std::allocator<std::stacktrace_entry> > const&, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > const&) at ResInsight/ApplicationLibCode/Application/Tools/Telemetry/RiaOpenTelemetryManager.cpp:415",
+        "[54] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:174",
+        "[55] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227",
+        "[59] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125",
+        "[60] cvf::DrawableText::renderText(cvf::OpenGLContext*, cvf::ShaderProgram*, cvf::MatrixState const&) at ResInsight/Fwk/VizFwk/LibRender/cvfDrawableText.cpp:376",
+        "[61] cvf::RenderEngine::render(cvf::OpenGLContext*, cvf::RenderQueue*, unsigned long, cvf::Camera const&, cvf::UniformSet const*) at ResInsight/Fwk/VizFwk/LibViewing/cvfRenderEngine.cpp:288",
+        "[62] cvf::Rendering::render(cvf::OpenGLContext*) at ResInsight/Fwk/VizFwk/LibViewing/cvfRendering.cpp:271",
+        "[63] cvf::RenderSequence::render(cvf::OpenGLContext*) at ResInsight/Fwk/VizFwk/LibViewing/cvfRenderSequence.cpp:211",
+        "[64] caf::Viewer::paintGL() at ResInsight/Fwk/AppFwk/cafViewer/cafViewer.cpp:901",
+        "[68] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823",
+        "[74] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823",
+        "[84] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226",
+        "[85] __libc_start_main at :0"
+      ],
+      "signature_frames": [
+        "cvf::DrawableText::renderText",
+        "cvf::RenderEngine::render",
+        "cvf::Rendering::render",
+        "cvf::RenderSequence::render",
+        "caf::Viewer::paintGL"
+      ],
+      "signature_id": "e16a04b3461e",
+      "status": "new",
+      "top_frame": "cvf::DrawableText::renderText",
+      "weeks": {
+        "2026-06-20": {
+          "count": 3,
+          "first_seen": "2026-06-15T10:41:23.874Z",
+          "last_seen": "2026-06-15T10:58:55.67Z",
+          "versions": {
+            "2026.02.2": 3
+          }
         }
       }
     },
@@ -6577,7 +7351,7 @@
       }
     },
     "e4a6d29f4a88": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": {
         "number": 14213,
@@ -6624,11 +7398,19 @@
           "versions": {
             "2026.02.2": 1
           }
+        },
+        "2026-06-20": {
+          "count": 1,
+          "first_seen": "2026-06-09T12:48:39.467Z",
+          "last_seen": "2026-06-09T12:48:39.467Z",
+          "versions": {
+            "2026.02.2": 1
+          }
         }
       }
     },
     "e934af263f7e": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": {
         "number": 14185,
@@ -6672,6 +7454,14 @@
           "last_seen": "2026-06-03T07:43:44.046Z"
         },
         "2026-06-12": {
+          "count": 7,
+          "first_seen": "2026-06-02T11:01:12.439Z",
+          "last_seen": "2026-06-03T07:43:44.046Z",
+          "versions": {
+            "2026.02.3-dev.01": 7
+          }
+        },
+        "2026-06-20": {
           "count": 7,
           "first_seen": "2026-06-02T11:01:12.439Z",
           "last_seen": "2026-06-03T07:43:44.046Z",
@@ -6768,7 +7558,7 @@
       }
     },
     "f008e6cc06cc": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": null,
       "pr": null,
@@ -6799,6 +7589,14 @@
           "last_seen": "2026-05-28T16:12:14.6Z"
         },
         "2026-06-12": {
+          "count": 1,
+          "first_seen": "2026-05-28T16:12:14.6Z",
+          "last_seen": "2026-05-28T16:12:14.6Z",
+          "versions": {
+            "2026.02.2": 1
+          }
+        },
+        "2026-06-20": {
           "count": 1,
           "first_seen": "2026-05-28T16:12:14.6Z",
           "last_seen": "2026-05-28T16:12:14.6Z",
@@ -6862,7 +7660,7 @@
       }
     },
     "f326099e1239": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": null,
       "pr": null,
@@ -6908,11 +7706,19 @@
           "versions": {
             "2026.02.2": 1
           }
+        },
+        "2026-06-20": {
+          "count": 1,
+          "first_seen": "2026-05-29T10:15:01.06Z",
+          "last_seen": "2026-05-29T10:15:01.06Z",
+          "versions": {
+            "2026.02.2": 1
+          }
         }
       }
     },
     "f37897ff8ca4": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "",
       "opm_issue": {
         "number": 14182,
@@ -6996,11 +7802,19 @@
           "versions": {
             "2026.02.2": 1
           }
+        },
+        "2026-06-20": {
+          "count": 1,
+          "first_seen": "2026-06-02T20:12:32.193Z",
+          "last_seen": "2026-06-02T20:12:32.193Z",
+          "versions": {
+            "2026.02.2": 1
+          }
         }
       }
     },
     "f3d2f3e86a63": {
-      "last_updated": "2026-06-15",
+      "last_updated": "2026-06-20",
       "notes": "Auto-link to #12756 was a false positive: that issue is an MSW import/visualization enhancement that only mentions RifReaderEclipseWell::readWellCells in prose, not a crash report. Unlinked.",
       "opm_issue": {
         "number": 14144,
@@ -7049,6 +7863,14 @@
           "last_seen": "2026-06-02T20:12:32.248Z"
         },
         "2026-06-12": {
+          "count": 3,
+          "first_seen": "2026-06-02T20:12:31.674Z",
+          "last_seen": "2026-06-02T20:12:32.248Z",
+          "versions": {
+            "2026.02.2": 3
+          }
+        },
+        "2026-06-20": {
           "count": 3,
           "first_seen": "2026-06-02T20:12:31.674Z",
           "last_seen": "2026-06-02T20:12:32.248Z",
@@ -7288,6 +8110,12 @@
       "skipped_old_version": 77,
       "total_rows": 216,
       "unique_stacks": 63
+    },
+    "2026-06-20": {
+      "csv": "2026-06-20-query_data.csv",
+      "skipped_old_version": 74,
+      "total_rows": 223,
+      "unique_stacks": 73
     }
   }
 }

--- a/stacktrace-reports/reports/2026-06-20.md
+++ b/stacktrace-reports/reports/2026-06-20.md
@@ -1,0 +1,2096 @@
+---
+title: Stacktrace report 2026-06-20
+permalink: /stacktrace-reports/reports/2026-06-20/
+layout: wide
+---
+
+# Stacktrace report 2026-06-20
+
+- **Source CSV:** [2026-06-20-query_data.csv](../csv/2026-06-20-query_data.csv)
+- **Total crash reports:** 223
+- **Unique call stacks:** 73
+- **Rows skipped (old version):** 74
+
+## Stack #1 — count 87
+
+First seen: `2026-05-21T12:04:19.478Z`  
+Last seen: `2026-06-18T12:59:43.828Z`  
+Versions: `2026.02.2` (81), `2026.06.0` (5), `2026.02.3-dev.01` (1)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:167
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:263
+[11] main at ResInsight/ApplicationExeCode/RiaMain.cpp:264
+[12] __libc_start_main at :0
+```
+
+**OPM issue:** none found
+
+## Stack #5 — count 7
+
+First seen: `2026-06-02T11:01:12.439Z`  
+Last seen: `2026-06-03T07:43:44.046Z`  
+Versions: `2026.02.3-dev.01` (7)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:167
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:263
+[5] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
+[6] RicWellPathExportMswTableData::generateCellSegments(RimEclipseCase const*, RimWellPath const*) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswTableData.cpp:702
+[7] RicWellPathExportMswTableData::extractSingleWellMsw_Legacy[abi:cxx11](RimEclipseCase*, RimWellPath*, bool, RicWellPathExportMswTableData::CompletionType, std::optional<QDateTime> const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswTableData.cpp:136
+[8] RicWellPathExportMswTableData::extractSingleWellMswData[abi:cxx11](RimEclipseCase*, RimWellPath*, bool, RicWellPathExportMswTableData::CompletionType, std::optional<QDateTime> const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswTableData.cpp:80
+[9] internal::exportSplitMswData(RicExportCompletionDataSettingsUi const&, QString const&, std::vector<RimWellPath*, std::allocator<RimWellPath*> > const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswCompletionsImpl.cpp:151
+[10] RicWellPathExportCompletionDataFeature::prepareExportSettingsAndExportCompletions(QString const&, std::vector<RimWellPath*, std::allocator<RimWellPath*> > const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportCompletionDataFeature.cpp:178
+[11] RicExportCompletionsForVisibleWellPathsFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicExportCompletionsForVisibleWellPathsFeature.cpp:75
+[12] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+[21] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1825
+[27] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1825
+[39] RiuMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:2092
+[47] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1825
+[52] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1825
+[63] main at ResInsight/ApplicationExeCode/RiaMain.cpp:229
+[64] __libc_start_main at :0
+```
+
+**OPM issue:** [#14185](https://github.com/OPM/ResInsight/issues/14185) — OPEN
+
+## Stack #13 — count 3
+
+First seen: `2026-06-17T07:33:25.7Z`  
+Last seen: `2026-06-19T19:00:34.761Z`  
+Versions: `2026.02.2` (2), `2026.06.0` (1)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:167
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:263
+[5] caf::PdmFieldUiCap<caf::PdmPtrField<RimSummaryEnsemble*> >::setValueFromUiEditor(QVariant const&, bool) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafInternalPdmUiFieldCapability.inl:30
+[6] caf::CmdFieldChangeExec::redo() at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFieldChangeExec.cpp:139
+[8] caf::CmdUiCommandSystemImpl::fieldChangedCommand(std::vector<caf::PdmFieldHandle*, std::allocator<caf::PdmFieldHandle*> > const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdUiCommandSystemImpl.cpp:146
+[9] caf::PdmUiCommandSystemProxy::setUiValueToField(caf::PdmUiFieldHandle*, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiCommandSystemProxy.cpp:113
+[10] caf::PdmUiComboBoxEditor::slotIndexActivated(int) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiComboBoxEditor.cpp:455
+[21] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1831
+[27] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1831
+[38] main at ResInsight/ApplicationExeCode/RiaMain.cpp:258
+[39] __libc_start_main at :0
+```
+
+**OPM issue:** none found
+
+## Stack #14 — count 3
+
+First seen: `2026-06-15T10:41:23.874Z`  
+Last seen: `2026-06-15T10:58:55.67Z`  
+Versions: `2026.02.2` (3)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[5] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
+[6] cvf::DrawableText::renderText(cvf::OpenGLContext*, cvf::ShaderProgram*, cvf::MatrixState const&) at ResInsight/Fwk/VizFwk/LibRender/cvfDrawableText.cpp:376
+[7] cvf::RenderEngine::render(cvf::OpenGLContext*, cvf::RenderQueue*, unsigned long, cvf::Camera const&, cvf::UniformSet const*) at ResInsight/Fwk/VizFwk/LibViewing/cvfRenderEngine.cpp:288
+[8] cvf::Rendering::render(cvf::OpenGLContext*) at ResInsight/Fwk/VizFwk/LibViewing/cvfRendering.cpp:271
+[9] cvf::RenderSequence::render(cvf::OpenGLContext*) at ResInsight/Fwk/VizFwk/LibViewing/cvfRenderSequence.cpp:211
+[10] caf::Viewer::paintGL() at ResInsight/Fwk/AppFwk/cafViewer/cafViewer.cpp:901
+[14] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[44] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[53] RiaOpenTelemetryManager::reportCrash(int, std::basic_stacktrace<std::allocator<std::stacktrace_entry> > const&, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > const&) at ResInsight/ApplicationLibCode/Application/Tools/Telemetry/RiaOpenTelemetryManager.cpp:415
+[54] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:174
+[55] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[59] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
+[60] cvf::DrawableText::renderText(cvf::OpenGLContext*, cvf::ShaderProgram*, cvf::MatrixState const&) at ResInsight/Fwk/VizFwk/LibRender/cvfDrawableText.cpp:376
+[61] cvf::RenderEngine::render(cvf::OpenGLContext*, cvf::RenderQueue*, unsigned long, cvf::Camera const&, cvf::UniformSet const*) at ResInsight/Fwk/VizFwk/LibViewing/cvfRenderEngine.cpp:288
+[62] cvf::Rendering::render(cvf::OpenGLContext*) at ResInsight/Fwk/VizFwk/LibViewing/cvfRendering.cpp:271
+[63] cvf::RenderSequence::render(cvf::OpenGLContext*) at ResInsight/Fwk/VizFwk/LibViewing/cvfRenderSequence.cpp:211
+[64] caf::Viewer::paintGL() at ResInsight/Fwk/AppFwk/cafViewer/cafViewer.cpp:901
+[68] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[74] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[84] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[85] __libc_start_main at :0
+```
+
+**OPM issue:** none found
+
+## Stack #19 — count 2
+
+First seen: `2026-06-10T22:21:19.134Z`  
+Last seen: `2026-06-10T22:21:19.311Z`  
+Versions: `2026.02.2` (2)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[6] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:228
+[14] RigStimPlanFractureDefinition::~RigStimPlanFractureDefinition() at ResInsight/ApplicationLibCode/ReservoirDataModel/RigStimPlanFractureDefinition.cpp:67
+[15] cvf::Object::release() const at ResInsight/Fwk/VizFwk/LibCore/cvfObject.inl:90
+[16] RimStimPlanFractureTemplate::~RimStimPlanFractureTemplate() at ResInsight/ApplicationLibCode/ProjectDataModel/Completions/RimStimPlanFractureTemplate.cpp:95
+[17] caf::PdmChildArrayField<RimFractureTemplate*>::deleteChildren() at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmChildArrayField.inl:181
+[18] caf::PdmChildArrayField<RimFractureTemplate*>::~PdmChildArrayField() at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmChildArrayField.inl:17
+[19] RimFractureTemplateCollection::~RimFractureTemplateCollection() at ResInsight/ApplicationLibCode/ProjectDataModel/Completions/RimFractureTemplateCollection.h:34
+[20] caf::PdmChildField<RimFractureTemplateCollection*>::~PdmChildField() at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmChildField.inl:80
+[21] RimCompletionTemplateCollection::~RimCompletionTemplateCollection() at ResInsight/ApplicationLibCode/ProjectDataModel/Completions/RimCompletionTemplateCollection.cpp:60
+[22] caf::PdmChildField<RimCompletionTemplateCollection*>::~PdmChildField() at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmChildField.inl:80
+[23] RimOilField::~RimOilField() at ResInsight/ApplicationLibCode/ProjectDataModel/RimOilField.cpp:113
+[24] caf::PdmChildArrayField<RimOilField*>::deleteChildren() at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmChildArrayField.inl:181
+[25] RimProject::close() at ResInsight/ApplicationLibCode/ProjectDataModel/RimProject.cpp:257
+[26] RiaApplication::closeProject() at ResInsight/ApplicationLibCode/Application/RiaApplication.cpp:1021
+[27] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:36
+[40] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[41] __libc_start_main at :0
+```
+
+**OPM issue:** none found
+
+## Stack #21 — count 2
+
+First seen: `2026-06-04T13:25:41.101Z`  
+Last seen: `2026-06-04T13:39:55.03Z`  
+Versions: `2026.02.2` (2)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[5] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
+[6] RicWellPathExportMswTableData::generateCellSegments(RimEclipseCase const*, RimWellPath const*) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswTableData.cpp:649
+[7] RicWellPathExportMswTableData::extractSingleWellMswData[abi:cxx11](RimEclipseCase*, RimWellPath*, bool, RicWellPathExportMswTableData::CompletionType, std::optional<QDateTime> const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswTableData.cpp:83
+[8] RimMswSegmentCollection::updateSegments(RimWellPath*, RimEclipseCase*) at ResInsight/ApplicationLibCode/ProjectDataModel/Completions/RimMswSegmentCollection.cpp:168
+[9] RimWellPathCollection::updateMswSegments() at ResInsight/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPathCollection.cpp:624
+[18] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[24] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[35] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[36] __libc_start_main at :0
+```
+
+**OPM issue:** [#14185](https://github.com/OPM/ResInsight/issues/14185) — OPEN
+
+## Stack #23 — count 2
+
+First seen: `2026-06-01T06:23:42.554Z`  
+Last seen: `2026-06-05T08:44:15.848Z`  
+Versions: `2026.02.2` (2)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[6] cvf::PrimitiveSetIndexedUInt::render(cvf::OpenGLContext*) const at ResInsight/Fwk/VizFwk/LibRender/cvfPrimitiveSetIndexedUInt.cpp:125
+[7] cvf::DrawableGeo::render(cvf::OpenGLContext*, cvf::ShaderProgram*, cvf::MatrixState const&) at ResInsight/Fwk/VizFwk/LibRender/cvfDrawableGeo.cpp:141
+[8] cvf::RenderEngine::render(cvf::OpenGLContext*, cvf::RenderQueue*, unsigned long, cvf::Camera const&, cvf::UniformSet const*) at ResInsight/Fwk/VizFwk/LibViewing/cvfRenderEngine.cpp:284
+[9] cvf::Rendering::render(cvf::OpenGLContext*) at ResInsight/Fwk/VizFwk/LibViewing/cvfRendering.cpp:271
+[10] cvf::RenderSequence::render(cvf::OpenGLContext*) at ResInsight/Fwk/VizFwk/LibViewing/cvfRenderSequence.cpp:211
+[11] caf::Viewer::paintGL() at ResInsight/Fwk/AppFwk/cafViewer/cafViewer.cpp:901
+[15] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[21] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[31] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[32] __libc_start_main at :0
+```
+
+**OPM issue:** [#14009](https://github.com/OPM/ResInsight/issues/14009) — OPEN
+
+## Stack #24 — count 2
+
+First seen: `2026-06-11T11:44:57.648Z`  
+Last seen: `2026-06-11T13:04:29.981Z`  
+Versions: `2026.02.2` (2)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[13] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:121
+[14] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+```
+
+**OPM issue:** [#11342](https://github.com/OPM/ResInsight/issues/11342) — OPEN
+
+## Stack #28 — count 1
+
+First seen: `2026-06-02T20:12:32.053Z`  
+Last seen: `2026-06-02T20:12:32.053Z`  
+Versions: `2026.02.2` (1)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[5] operator() at ResInsight/ApplicationLibCode/Application/Tools/RiaWellNameComparer.cpp:87
+[7] RiaWellNameComparer::tryMatchNameInList(QString, std::vector<QString, std::allocator<QString> > const&) at ResInsight/ApplicationLibCode/Application/Tools/RiaWellNameComparer.cpp:82
+[8] RiaWellNameComparer::tryFindMatchingSimWellName(QString) at ResInsight/ApplicationLibCode/Application/Tools/RiaWellNameComparer.cpp:40
+[9] RimWellPath::tryAssociateWithSimulationWell() at ResInsight/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPath.cpp:1107
+[10] RimEclipseCase::openReservoirCase() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCase.cpp:1152
+[11] RimEclipseResultDefinition::loadResult() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:1097
+[12] RimWellLogExtractionCurve::extractEclipseData(RimEclipseCase*, bool*) at ResInsight/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogExtractionCurve.cpp:546
+[13] RimWellLogExtractionCurve::extractData(bool*, std::optional<double> const&, std::optional<double> const&) at ResInsight/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogExtractionCurve.cpp:457
+[14] RimWellLogExtractionCurve::performDataExtraction(bool*) at ResInsight/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogExtractionCurve.cpp:433
+[15] RimWellLogExtractionCurve::onLoadDataAndUpdate(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogExtractionCurve.cpp:342
+[16] RimPlotCurve::loadDataAndUpdate(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimPlotCurve.cpp:587
+[17] RimWellLogTrack::onLoadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogTrack.cpp:1213
+[18] RimViewWindow::loadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimViewWindow.cpp:88
+[19] RimDepthTrackPlot::updatePlots() at ResInsight/ApplicationLibCode/ProjectDataModel/RimDepthTrackPlot.cpp:1248
+[20] non-virtual thunk to RimDepthTrackPlot::onLoadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimDepthTrackPlot.h:196
+[21] RimViewWindow::loadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimViewWindow.cpp:88
+[22] non-virtual thunk to RimWellLogPlotCollection::loadDataAndUpdateAllPlots() at ResInsight/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogPlotCollection.h:66
+[23] RiaPlotCollectionScheduler::performScheduledUpdates() at ResInsight/ApplicationLibCode/Application/RiaPlotCollectionScheduler.cpp:69
+[36] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[37] __libc_start_main at :0
+```
+
+**OPM issue:** none found
+
+## Stack #29 — count 1
+
+First seen: `2026-06-16T20:38:28.725Z`  
+Last seen: `2026-06-16T20:38:28.725Z`  
+Versions: `2026.02.2` (1)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[5] operator() at ResInsight/ApplicationLibCode/UserInterface/RiuMultiPlotPage.cpp:1131
+[6] RiuMultiPlotPage::alignAxes() at ResInsight/ApplicationLibCode/UserInterface/RiuMultiPlotPage.cpp:1110
+[7] RiuMultiPlotPage::performUpdate(RiaDefines::MultiPlotPageUpdateType) at ResInsight/ApplicationLibCode/UserInterface/RiuMultiPlotPage.cpp:573
+[10] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[28] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[46] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[50] caf::PdmUiToolBarEditor::clear() at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiToolBarEditor.cpp:265
+[51] caf::PdmUiToolBarEditor::setFields(std::vector<caf::PdmFieldHandle*, std::allocator<caf::PdmFieldHandle*> >&) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiToolBarEditor.cpp:246
+[52] RiuPlotMainWindow::updateMultiPlotToolBar() at ResInsight/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp:758
+[53] RimMultiPlot::fieldChangedByUi(caf::PdmFieldHandle const*, QVariant const&, QVariant const&) at ResInsight/ApplicationLibCode/ProjectDataModel/RimMultiPlot.cpp:696
+[54] caf::PdmUiFieldHandle::notifyFieldChanged(QVariant const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiFieldHandle.cpp:74
+[55] caf::PdmFieldUiCap<caf::PdmField<caf::AppEnum<RiaDefines::RowCount> > >::setValueFromUiEditor(QVariant const&, bool) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafInternalPdmUiFieldCapability.inl:110
+[56] caf::CmdFieldChangeExec::redo() at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFieldChangeExec.cpp:139
+[58] caf::CmdUiCommandSystemImpl::fieldChangedCommand(std::vector<caf::PdmFieldHandle*, std::allocator<caf::PdmFieldHandle*> > const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdUiCommandSystemImpl.cpp:146
+[59] caf::PdmUiCommandSystemProxy::setUiValueToField(caf::PdmUiFieldHandle*, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiCommandSystemProxy.cpp:113
+[60] caf::PdmUiComboBoxEditor::slotIndexActivated(int) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiComboBoxEditor.cpp:455
+[71] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[77] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[88] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[89] __libc_start_main at :0
+```
+
+**OPM issue:** none found
+
+## Stack #30 — count 1
+
+First seen: `2026-06-05T08:48:40.24Z`  
+Last seen: `2026-06-05T08:48:40.24Z`  
+Versions: `2026.02.2` (1)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[3] ecl_kw_get_data_type at ResInsight/ThirdParty/Ert/lib/ecl/ecl_kw.cpp:1776
+[4] ecl_file_kw_assert_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_kw.cpp:211
+[5] ecl_file_kw_load_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_kw.cpp:244
+[6] ecl_file_view_get_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_view.cpp:149
+[7] ecl_smspec_fread_header at ResInsight/ThirdParty/Ert/lib/ecl/ecl_smspec.cpp:1098
+[8] ecl_sum_fread at ResInsight/ThirdParty/Ert/lib/ecl/ecl_sum.cpp:213
+[9] ecl_sum_fread_alloc at ResInsight/ThirdParty/Ert/lib/ecl/ecl_sum.cpp:271
+[10] RifEclipseSummaryTools::openEclSum(QString const&, bool) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseSummaryTools.cpp:519
+[11] RifEclipseSummaryTools::getFileInfoAndTimeSteps(QString const&) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseSummaryTools.cpp:280
+[12] RicSummaryCaseRestartDialog::openDialog(QString const&, QString const&, bool, bool, bool, RicSummaryCaseRestartDialog::ImportOptions, RicSummaryCaseRestartDialog::ImportOptions, bool, RicSummaryCaseRestartDialogResult*, QWidget*) at ResInsight/ApplicationLibCode/Commands/RicSummaryCaseRestartDialog.cpp:237
+[13] RifSummaryCaseRestartSelector::determineFilesToImportByAskingUser(std::vector<RifSummaryCaseFileImportInfo, std::allocator<RifSummaryCaseFileImportInfo> > const&, bool) at ResInsight/ApplicationLibCode/FileInterface/RifSummaryCaseRestartSelector.cpp:189
+[14] RifSummaryCaseRestartSelector::determineFilesToImportFromSummaryFiles(QList<QString> const&) at ResInsight/ApplicationLibCode/FileInterface/RifSummaryCaseRestartSelector.cpp:96
+[15] RiaEnsembleImportTools::createSummaryCasesFromFiles(QList<QString> const&, RiaEnsembleImportTools::CreateConfig) at ResInsight/ApplicationLibCode/Application/Tools/Ensemble/RiaEnsembleImportTools.cpp:60
+[16] RicImportSummaryCasesFeature::createAndAddSummaryCasesFromFiles(QList<QString> const&, bool) at ResInsight/ApplicationLibCode/Commands/RicImportSummaryCasesFeature.cpp:126
+[17] RicImportGeneralDataFeature::openSummaryCaseFromFileNames(QList<QString> const&, bool) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:378
+[18] RicImportGeneralDataFeature::openEclipseFilesFromFileNames(QList<QString> const&, bool, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:122
+[19] RicImportGeneralDataFeature::openEclipseFilesFromFileNames(QList<QString> const&, bool, bool) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:55
+[20] RicImportGeneralDataFeature::openFileDialog(RiaDefines::ImportFileType) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:339
+[21] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+[31] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[37] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[48] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[49] __libc_start_main at :0
+```
+
+**OPM issue:** none found
+
+## Stack #31 — count 1
+
+First seen: `2026-06-02T20:12:31.767Z`  
+Last seen: `2026-06-02T20:12:31.767Z`  
+Versions: `2026.02.2` (1)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[6] Opm::EclIO::ESmry::getListOfArrays(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool) at ResInsight/ThirdParty/custom-opm-common/opm-common/opm/io/eclipse/ESmry.cpp:1059
+[7] Opm::EclIO::ESmry::ESmry(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool) at ResInsight/ThirdParty/custom-opm-common/opm-common/opm/io/eclipse/ESmry.cpp:561
+[8] std::__detail::_MakeUniq<Opm::EclIO::ESmry>::__single_object std::make_unique<Opm::EclIO::ESmry, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool&>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&, bool&) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/unique_ptr.h:1070
+[9] RifOpmCommonEclipseSummary::open(QString const&, bool, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/FileInterface/RifOpmCommonSummary.cpp:174
+[10] RifReaderEclipseSummary::open(QString const&, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseSummary.cpp:141
+[11] RimFileSummaryCase::findRelatedFilesAndCreateReader(QString const&, bool, RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:238
+[12] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:110
+[13] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+[15] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:561
+[16] RimSummaryCaseMainCollection::loadSummaryCaseData(std::vector<RimSummaryCase*, std::allocator<RimSummaryCase*> > const&, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:457
+[17] RimSummaryCaseMainCollection::createSummaryCasesFromFileInfos(std::vector<RifSummaryCaseFileResultInfo, std::allocator<RifSummaryCaseFileResultInfo> > const&, bool, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:712
+[18] RiaImportEclipseCaseTools::openEclipseCasesFromFile(QList<QString> const&, bool, std::map<QString, int, std::less<QString>, std::allocator<std::pair<QString const, int> > >*, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:127
+[19] RicImportGeneralDataFeature::openEclipseCaseFromFileNames(QList<QString> const&, bool, std::vector<int, std::allocator<int> >&, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:362
+[20] RicImportGeneralDataFeature::openEclipseFilesFromFileNames(QList<QString> const&, bool, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:104
+[21] RicfLoadCase::execute() at ResInsight/ApplicationLibCode/CommandFileInterface/RicfLoadCase.cpp:77
+[22] RiaGrpcCommandService::Execute(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) at ResInsight/GrpcInterface/RiaGrpcCommandService.cpp:92
+[23] grpc::Status std::__invoke_impl<grpc::Status, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*>(std::__invoke_memfun_ref, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*&&, rips::CommandParams const*&&, rips::CommandReply*&&) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/invoke.h:67
+[24] std::function<grpc::Status (RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*)>::operator()(RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:591
+[25] RiaGrpcServerImpl::processAllQueuedRequests() at ResInsight/GrpcInterface/RiaGrpcServer.cpp:200
+[26] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:115
+[27] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:33
+[40] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[41] __libc_start_main at :0
+```
+
+**OPM issue:** none found
+
+## Stack #32 — count 1
+
+First seen: `2026-06-11T08:43:10.483Z`  
+Last seen: `2026-06-11T08:43:10.483Z`  
+Versions: `2026.02.2` (1)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[4] RigFlowDiagResults::calculateDerivedResult(RigFlowDiagResultAddress const&, unsigned long) at ResInsight/ApplicationLibCode/ReservoirDataModel/RigFlowDiagResults.cpp:208
+[5] RigFlowDiagResults::findOrCalculateResult(RigFlowDiagResultAddress const&, unsigned long) at ResInsight/ApplicationLibCode/ReservoirDataModel/RigFlowDiagResults.cpp:92
+[6] RigFlowDiagStatCalc::minMaxCellScalarValues(unsigned long, double&, double&) at ResInsight/ApplicationLibCode/ReservoirDataModel/RigFlowDiagStatCalc.cpp:49
+[7] RigStatisticsDataCache::minMaxCellScalarValues(unsigned long, double&, double&) at ResInsight/ApplicationLibCode/ResultStatisticsCache/RigStatisticsDataCache.cpp:119
+[8] RimEclipseResultDefinitionTools::updateLegendForFlowDiagnostics(RimEclipseResultDefinition const*, RimRegularLegendConfig*, int) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinitionTools.cpp:422
+[9] RimEclipseResultDefinition::updateRangesForExplicitLegends(RimRegularLegendConfig*, RimTernaryLegendConfig*, int, RimEclipseView*) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:1695
+[10] RimEclipseView::updateLegendRangesTextAndVisibility(RimRegularLegendConfig*, RimTernaryLegendConfig*, QString, RimEclipseResultDefinition*, int) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp:1620
+[11] RimEclipseView::onUpdateLegends() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp:1489
+[12] RimEclipseView::onCreateDisplayModel() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp:796
+[13] Rim3dView::createDisplayModelAndRedraw() at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:718
+[14] RiaViewRedrawScheduler::updateAndRedrawScheduledViews() at ResInsight/ApplicationLibCode/Application/RiaViewRedrawScheduler.cpp:93
+[19] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[29] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[30] __libc_start_main at :0
+```
+
+**OPM issue:** none found
+
+## Stack #37 — count 1
+
+First seen: `2026-06-04T13:25:41.152Z`  
+Last seen: `2026-06-04T13:25:41.152Z`  
+Versions: `2026.02.2` (1)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[5] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
+[6] RicWellPathExportMswTableData::generateCellSegments(RimEclipseCase const*, RimWellPath const*) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswTableData.cpp:649
+[7] RicWellPathExportMswTableData::extractSingleWellMswData[abi:cxx11](RimEclipseCase*, RimWellPath*, bool, RicWellPathExportMswTableData::CompletionType, std::optional<QDateTime> const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswTableData.cpp:83
+[8] RimMswSegmentCollection::updateSegments(RimWellPath*, RimEclipseCase*) at ResInsight/ApplicationLibCode/ProjectDataModel/Completions/RimMswSegmentCollection.cpp:168
+[9] RimWellPathCollection::updateMswSegments() at ResInsight/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPathCollection.cpp:624
+[18] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[24] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[34] RiaOpenTelemetryManager::reportCrash(int, std::basic_stacktrace<std::allocator<std::stacktrace_entry> > const&, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > const&) at ResInsight/ApplicationLibCode/Application/Tools/Telemetry/RiaOpenTelemetryManager.cpp:415
+[35] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:174
+[36] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[40] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
+[41] RicWellPathExportMswTableData::generateCellSegments(RimEclipseCase const*, RimWellPath const*) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswTableData.cpp:649
+[42] RicWellPathExportMswTableData::extractSingleWellMswData[abi:cxx11](RimEclipseCase*, RimWellPath*, bool, RicWellPathExportMswTableData::CompletionType, std::optional<QDateTime> const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswTableData.cpp:83
+[43] RimMswSegmentCollection::updateSegments(RimWellPath*, RimEclipseCase*) at ResInsight/ApplicationLibCode/ProjectDataModel/Completions/RimMswSegmentCollection.cpp:168
+[44] RimWellPathCollection::updateMswSegments() at ResInsight/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPathCollection.cpp:624
+[53] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[59] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[70] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[71] __libc_start_main at :0
+```
+
+**OPM issue:** [#14185](https://github.com/OPM/ResInsight/issues/14185) — OPEN
+
+## Stack #39 — count 1
+
+First seen: `2026-06-19T10:45:44.403Z`  
+Last seen: `2026-06-19T10:45:44.403Z`  
+Versions: `2026.06.0` (1)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:167
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:263
+[5] RimEclipsePropertyFilterCollection* caf::PdmObjectHandle::firstAncestorOrThisOfTypeAsserted<RimEclipsePropertyFilterCollection>() const at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmObjectHandle.h:249
+[7] RicEclipsePropertyFilterInsertFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/EclipseCommands/RicEclipsePropertyFilterInsertFeature.cpp:58
+[8] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+[17] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1831
+[23] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1831
+[35] RiuMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:2092
+[43] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1831
+[48] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1831
+[59] main at ResInsight/ApplicationExeCode/RiaMain.cpp:258
+[60] __libc_start_main at :0
+```
+
+**OPM issue:** none found
+
+## Stack #41 — count 1
+
+First seen: `2026-06-02T20:12:31.674Z`  
+Last seen: `2026-06-02T20:12:31.674Z`  
+Versions: `2026.02.2` (1)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[3] cvf::Vector3<double>::Vector3() at ResInsight/Fwk/VizFwk/LibCore/cvfVector3.inl:69
+[4] std::vector<cvf::AABBTreeNodeLeaf, std::allocator<cvf::AABBTreeNodeLeaf> >::resize(unsigned long) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/stl_vector.h:1016
+[5] cvf::AABBTree::buildTree() at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:474
+[6] cvf::BoundingBoxTreeImpl::buildTree(std::vector<cvf::BoundingBox, std::allocator<cvf::BoundingBox> > const&, std::vector<std::vector<int, std::allocator<int> >, std::allocator<std::vector<int, std::allocator<int> > > > const&) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:816
+[7] cvf::BoundingBoxTree::buildTreeFromBoundingBoxes(std::vector<cvf::BoundingBox, std::allocator<cvf::BoundingBox> > const&, std::vector<unsigned long, std::allocator<unsigned long> > const*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:948
+[8] RigMainGrid::buildCellSearchTree() const at ResInsight/ApplicationLibCode/ReservoirDataModel/RigMainGrid.cpp:939
+[9] RigMainGrid::doBuildCellSearchTree(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*) const at ResInsight/ApplicationLibCode/ReservoirDataModel/RigMainGrid.cpp:870
+[10] RigMainGrid::computeCachedData(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*) at ResInsight/ApplicationLibCode/ReservoirDataModel/RigMainGrid.cpp:277
+[11] RimEclipseCase::computeCachedData() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCase.cpp:714
+[12] RimEclipseResultCase::importGridAndResultMetaData(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultCase.cpp:297
+[13] RiaImportEclipseCaseTools::openEclipseCaseShowTimeStepFilterImpl(QString const&, bool, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:372
+[14] RiaImportEclipseCaseTools::openEclipseCasesFromFile(QList<QString> const&, bool, std::map<QString, int, std::less<QString>, std::allocator<std::pair<QString const, int> > >*, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:107
+[15] RicImportGeneralDataFeature::openEclipseCaseFromFileNames(QList<QString> const&, bool, std::vector<int, std::allocator<int> >&, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:362
+[16] RicImportGeneralDataFeature::openEclipseFilesFromFileNames(QList<QString> const&, bool, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:104
+[17] RicfLoadCase::execute() at ResInsight/ApplicationLibCode/CommandFileInterface/RicfLoadCase.cpp:77
+[18] RiaGrpcCommandService::Execute(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) at ResInsight/GrpcInterface/RiaGrpcCommandService.cpp:92
+[19] grpc::Status std::__invoke_impl<grpc::Status, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*>(std::__invoke_memfun_ref, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*&&, rips::CommandParams const*&&, rips::CommandReply*&&) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/invoke.h:67
+[20] std::function<grpc::Status (RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*)>::operator()(RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:591
+[21] RiaGrpcServerImpl::processAllQueuedRequests() at ResInsight/GrpcInterface/RiaGrpcServer.cpp:200
+[22] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:115
+[23] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:33
+[36] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[37] __libc_start_main at :0
+```
+
+**OPM issue:** none found
+
+## Stack #44 — count 1
+
+First seen: `2026-05-26T13:15:12.175Z`  
+Last seen: `2026-05-26T13:15:12.175Z`  
+Versions: `2026.02.2` (1)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[6] RimWellConnectivityTable::isTimeStepInCase(QDateTime const&) const at ResInsight/ApplicationLibCode/ProjectDataModel/Flow/RimWellConnectivityTable.cpp:1040
+[7] RimWellConnectivityTable::setValidSingleTimeStepForCase() at ResInsight/ApplicationLibCode/ProjectDataModel/Flow/RimWellConnectivityTable.cpp:1004
+[8] RimWellConnectivityTable::setValidTimeStepSelectionsForCase() at ResInsight/ApplicationLibCode/ProjectDataModel/Flow/RimWellConnectivityTable.cpp:990
+[9] RimWellConnectivityTable::fieldChangedByUi(caf::PdmFieldHandle const*, QVariant const&, QVariant const&) at ResInsight/ApplicationLibCode/ProjectDataModel/Flow/RimWellConnectivityTable.cpp:297
+[10] caf::PdmUiFieldHandle::notifyFieldChanged(QVariant const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiFieldHandle.cpp:74
+[11] caf::PdmFieldUiCap<caf::PdmPtrField<RimEclipseResultCase*> >::setValueFromUiEditor(QVariant const&, bool) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafInternalPdmUiFieldCapability.inl:110
+[12] caf::CmdFieldChangeExec::redo() at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFieldChangeExec.cpp:139
+[14] caf::CmdUiCommandSystemImpl::fieldChangedCommand(std::vector<caf::PdmFieldHandle*, std::allocator<caf::PdmFieldHandle*> > const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdUiCommandSystemImpl.cpp:146
+[15] caf::PdmUiCommandSystemProxy::setUiValueToField(caf::PdmUiFieldHandle*, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiCommandSystemProxy.cpp:113
+[16] caf::PdmUiComboBoxEditor::slotIndexActivated(int) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiComboBoxEditor.cpp:455
+[27] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[33] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[44] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[45] __libc_start_main at :0
+```
+
+**OPM issue:** none found
+
+## Stack #47 — count 1
+
+First seen: `2026-05-25T21:44:13.418Z`  
+Last seen: `2026-05-25T21:44:13.418Z`  
+Versions: `2026.02.2` (1)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[5] caf::PdmFieldUiCap<caf::PdmField<QDateTime> >::setValueFromUiEditor(QVariant const&, bool) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafInternalPdmUiFieldCapability.inl:30
+[6] caf::CmdFieldChangeExec::redo() at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFieldChangeExec.cpp:139
+[8] caf::CmdUiCommandSystemImpl::fieldChangedCommand(std::vector<caf::PdmFieldHandle*, std::allocator<caf::PdmFieldHandle*> > const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdUiCommandSystemImpl.cpp:146
+[9] caf::PdmUiCommandSystemProxy::setUiValueToField(caf::PdmUiFieldHandle*, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiCommandSystemProxy.cpp:113
+[10] caf::PdmUiComboBoxEditor::slotIndexActivated(int) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiComboBoxEditor.cpp:455
+[21] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[27] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[38] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[39] __libc_start_main at :0
+```
+
+**OPM issue:** none found
+
+## Stack #48 — count 1
+
+First seen: `2026-06-18T13:25:23.569Z`  
+Last seen: `2026-06-18T13:25:23.569Z`  
+Versions: `2026.06.0` (1)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:167
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:263
+[3] caf::PdmUiFieldHandle::enableAutoValue(bool, bool) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiFieldHandle.cpp:164
+[4] caf::PdmUiLineEditor::slotEditingFinished() at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiLineEditor.cpp:355
+[9] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1831
+[18] caf::PdmUiFormLayoutObjectEditor::cleanupBeforeSettingPdmObject() at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiFormLayoutObjectEditor.cpp:607
+[19] caf::PdmUiObjectEditorHandle::setPdmObject(caf::PdmObjectHandle*) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiObjectEditorHandle.cpp:66
+[20] caf::PdmUiPropertyView::showProperties(caf::PdmObjectHandle*) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiPropertyView.cpp:211
+[21] RiuPlotMainWindow::selectedObjectsChanged(caf::PdmUiTreeView*, caf::PdmUiPropertyView*) at ResInsight/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp:962
+[23] caf::PdmUiTreeView::slotOnSelectionChanged() at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeView.cpp:154
+[37] caf::PdmUiTreeViewQModel::updateSubTreeRecursive(QModelIndex const&, caf::PdmUiTreeOrdering*, caf::PdmUiTreeOrdering*, bool) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeViewQModel.cpp:268
+[38] caf::PdmUiTreeViewQModel::updateSubTree(caf::PdmUiItem*, bool) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeViewQModel.cpp:202
+[39] caf::PdmUiTreeViewEditor::updateMySubTree(caf::PdmUiItem*, bool) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeViewEditor.cpp:332
+[40] caf::PdmUiEditorHandle::updateUi() at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiEditorHandle.cpp:84
+[41] caf::PdmUiItem::updateConnectedEditors() const at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiItem.cpp:493
+[42] RimEnsembleCurveSetCollection::onChildDeleted(caf::PdmChildArrayFieldHandle*, std::vector<caf::PdmObjectHandle*, std::allocator<caf::PdmObjectHandle*> >&) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimEnsembleCurveSetCollection.cpp:333
+[43] RicDeleteItemExec::redo() at ResInsight/ApplicationLibCode/Commands/RicDeleteItemExec.cpp:71
+[44] RicDeleteItemFeature::deleteObject(caf::PdmObject*) at ResInsight/ApplicationLibCode/Commands/RicDeleteItemFeature.cpp:128
+[45] RicDeleteItemFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/RicDeleteItemFeature.cpp:68
+[46] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+[47] RiuTreeViewEventFilter::activateFirstEnabledFeature(std::vector<caf::CmdFeature*, std::allocator<caf::CmdFeature*> > const&) at ResInsight/ApplicationLibCode/UserInterface/RiuTreeViewEventFilter.cpp:95
+[48] RiuTreeViewEventFilter::activateFeatureFromKeyEvent(QKeyEvent*) at ResInsight/ApplicationLibCode/UserInterface/RiuTreeViewEventFilter.cpp:73
+[49] RiuPlotMainWindow::keyPressEvent(QKeyEvent*) at ResInsight/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp:322
+[53] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1831
+[57] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1831
+[68] main at ResInsight/ApplicationExeCode/RiaMain.cpp:258
+[69] __libc_start_main at :0
+```
+
+**OPM issue:** none found
+
+## Stack #49 — count 1
+
+First seen: `2026-05-28T08:38:44.52Z`  
+Last seen: `2026-05-28T08:38:44.52Z`  
+Versions: `2026.02.2` (1)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[5] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
+[6] RimGeoMechPropertyFilter::computeResultValueRange() at ResInsight/ApplicationLibCode/ProjectDataModel/CellFilters/RimGeoMechPropertyFilter.cpp:300
+[7] RimGeoMechPropertyFilterCollection::loadAndInitializePropertyFilters() at ResInsight/ApplicationLibCode/ProjectDataModel/CellFilters/RimGeoMechPropertyFilterCollection.cpp:62
+[8] RimViewController::updateDuplicatedPropertyFilters() at ResInsight/ApplicationLibCode/ProjectDataModel/RimViewController.cpp:540
+[9] caf::PdmUiFieldHandle::notifyFieldChanged(QVariant const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiFieldHandle.cpp:74
+[10] caf::PdmFieldUiCap<caf::PdmField<bool> >::setValueFromUiEditor(QVariant const&, bool) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafInternalPdmUiFieldCapability.inl:110
+[11] caf::CmdFieldChangeExec::redo() at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFieldChangeExec.cpp:139
+[13] caf::CmdUiCommandSystemImpl::fieldChangedCommand(std::vector<caf::PdmFieldHandle*, std::allocator<caf::PdmFieldHandle*> > const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdUiCommandSystemImpl.cpp:146
+[14] caf::PdmUiCommandSystemProxy::setUiValueToField(caf::PdmUiFieldHandle*, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiCommandSystemProxy.cpp:113
+[15] caf::PdmUiCheckBoxEditor::slotClicked(bool) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiCheckBoxEditor.cpp:127
+[24] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[30] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[41] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[42] __libc_start_main at :0
+```
+
+**OPM issue:** none found
+
+## Stack #50 — count 1
+
+First seen: `2026-05-28T18:04:48.924Z`  
+Last seen: `2026-05-28T18:04:48.924Z`  
+Versions: `2026.02.2` (1)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[9] Rim3dOverlayInfoConfig::resultInfoText(RigHistogramData const&, RimEclipseView*, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dOverlayInfoConfig.cpp:524
+[10] Rim3dOverlayInfoConfig::resultInfoText(RigHistogramData const&) at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dOverlayInfoConfig.cpp:220
+[11] Rim3dOverlayInfoConfig::updateEclipse3DInfo(RimEclipseView*) at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dOverlayInfoConfig.cpp:940
+[12] Rim3dOverlayInfoConfig::update3DInfo() at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dOverlayInfoConfig.cpp:807
+[13] RimEclipseView::onUpdateDisplayModelForCurrentTimeStep() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp:901
+[14] Rim3dView::updateDisplayModelForCurrentTimeStepAndRedraw() at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:673
+[15] RiuViewer::setCurrentFrame(int) at ResInsight/ApplicationLibCode/UserInterface/RiuViewer.cpp:1008
+[16] RimEclipseView::onCreateDisplayModel() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp:791
+[17] Rim3dView::createDisplayModelAndRedraw() at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:718
+[18] RiaViewRedrawScheduler::updateAndRedrawScheduledViews() at ResInsight/ApplicationLibCode/Application/RiaViewRedrawScheduler.cpp:93
+[23] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[33] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[34] __libc_start_main at :0
+```
+
+**OPM issue:** none found
+
+## Stack #51 — count 1
+
+First seen: `2026-06-02T20:12:31.727Z`  
+Last seen: `2026-06-02T20:12:31.727Z`  
+Versions: `2026.02.2` (1)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[3] void caf::addXmlCapabilityToField<caf::PdmField<int> >(caf::PdmField<int>*) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmXml/cafInternalPdmXmlFieldCapability.h:235
+[4] RimTernaryLegendConfig::RimTernaryLegendConfig() at ResInsight/ApplicationLibCode/ProjectDataModel/RimTernaryLegendConfig.cpp:51
+[5] Rim2dIntersectionView::Rim2dIntersectionView() at ResInsight/ApplicationLibCode/ProjectDataModel/Rim2dIntersectionView.cpp:83
+[6] Rim2dIntersectionViewCollection::syncFromExistingIntersections(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Rim2dIntersectionViewCollection.cpp:97
+[7] RimIntersectionCollection::onChildAdded(caf::PdmFieldHandle*) at ResInsight/ApplicationLibCode/ProjectDataModel/Intersections/RimIntersectionCollection.cpp:430
+[8] RiaGrpcServiceInterface::emplaceChildField(caf::PdmObject*, QString const&, QString const&) at ResInsight/GrpcInterface/RiaGrpcServiceInterface.cpp:362
+[9] RiaGrpcPdmObjectService::CreateChildPdmObject(grpc::ServerContext*, rips::CreatePdmChildObjectRequest const*, rips::PdmObject*) at ResInsight/GrpcInterface/RiaGrpcPdmObjectService.cpp:514
+[10] grpc::Status std::__invoke_impl<grpc::Status, grpc::Status (RiaGrpcPdmObjectService::*&)(grpc::ServerContext*, rips::CreatePdmChildObjectRequest const*, rips::PdmObject*), RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::CreatePdmChildObjectRequest const*, rips::PdmObject*>(std::__invoke_memfun_ref, grpc::Status (RiaGrpcPdmObjectService::*&)(grpc::ServerContext*, rips::CreatePdmChildObjectRequest const*, rips::PdmObject*), RiaGrpcPdmObjectService&, grpc::ServerContext*&&, rips::CreatePdmChildObjectRequest const*&&, rips::PdmObject*&&) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/invoke.h:67
+[11] std::function<grpc::Status (RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::CreatePdmChildObjectRequest const*, rips::PdmObject*)>::operator()(RiaGrpcPdmObjectService&, grpc::ServerContext*, rips::CreatePdmChildObjectRequest const*, rips::PdmObject*) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:591
+[12] RiaGrpcServerImpl::processAllQueuedRequests() at ResInsight/GrpcInterface/RiaGrpcServer.cpp:200
+[13] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:115
+[14] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:33
+[27] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[28] __libc_start_main at :0
+```
+
+**OPM issue:** none found
+
+## Stack #52 — count 1
+
+First seen: `2026-06-02T20:12:32.248Z`  
+Last seen: `2026-06-02T20:12:32.248Z`  
+Versions: `2026.02.2` (1)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[3] ecl_grid_set_active_index at ResInsight/ThirdParty/Ert/lib/ecl/ecl_grid.cpp:1863
+[4] ecl_grid_update_index at ResInsight/ThirdParty/Ert/lib/ecl/ecl_grid.cpp:1968
+[5] RifActiveCellsReader::applyActiveCellsToAllGrids(ecl_grid_struct*, std::vector<std::vector<int, std::allocator<int> >, std::allocator<std::vector<int, std::allocator<int> > > > const&) at ResInsight/ApplicationLibCode/FileInterface/RifActiveCellsReader.cpp:144
+[6] RifReaderEclipseOutput::loadAllGrids() const at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp:1174
+[7] RifReaderEclipseOutput::open(QString const&, RigEclipseCaseData*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp:389
+[8] RimEclipseResultCase::importGridAndResultMetaData(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultCase.cpp:261
+[9] RiaImportEclipseCaseTools::openEclipseCaseShowTimeStepFilterImpl(QString const&, bool, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:372
+[10] RiaImportEclipseCaseTools::openEclipseCasesFromFile(QList<QString> const&, bool, std::map<QString, int, std::less<QString>, std::allocator<std::pair<QString const, int> > >*, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:107
+[11] RicImportGeneralDataFeature::openEclipseCaseFromFileNames(QList<QString> const&, bool, std::vector<int, std::allocator<int> >&, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:362
+[12] RicImportGeneralDataFeature::openEclipseFilesFromFileNames(QList<QString> const&, bool, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:104
+[13] RicfLoadCase::execute() at ResInsight/ApplicationLibCode/CommandFileInterface/RicfLoadCase.cpp:77
+[14] RiaGrpcCommandService::Execute(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) at ResInsight/GrpcInterface/RiaGrpcCommandService.cpp:92
+[15] grpc::Status std::__invoke_impl<grpc::Status, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*>(std::__invoke_memfun_ref, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*&&, rips::CommandParams const*&&, rips::CommandReply*&&) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/invoke.h:67
+[16] std::function<grpc::Status (RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*)>::operator()(RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:591
+[17] RiaGrpcServerImpl::processAllQueuedRequests() at ResInsight/GrpcInterface/RiaGrpcServer.cpp:200
+[18] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:115
+[19] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:33
+[32] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[33] __libc_start_main at :0
+```
+
+**OPM issue:** none found
+
+## Stack #53 — count 1
+
+First seen: `2026-05-21T08:47:21.019Z`  
+Last seen: `2026-05-21T08:47:21.019Z`  
+Versions: `2026.02.2` (1)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[5] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
+[6] cvf::GeometryUtils::tesselatePatchAsTriangles(unsigned int, unsigned int, unsigned int, bool, cvf::Array<unsigned int>*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfGeometryUtils.cpp:774
+[7] RigContourMapTrianglesGenerator::generateTrianglesWithVertexValues(RigContourMapGrid const&, RigContourMapProjection const&, std::vector<std::vector<RigContourPolygonsTools::ContourPolygon, std::allocator<RigContourPolygonsTools::ContourPolygon> >, std::allocator<std::vector<RigContourPolygonsTools::ContourPolygon, std::allocator<RigContourPolygonsTools::ContourPolygon> > > > const&, std::vector<double, std::allocator<double> > const&, std::vector<double, std::allocator<double> > const&, bool, double) at ResInsight/ApplicationLibCode/ReservoirDataModel/ContourMap/RigContourMapTrianglesGenerator.cpp:46
+[8] RimContourMapProjection::generateGeometryIfNecessary() at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimContourMapProjection.cpp:211
+[9] RimEclipseContourMapView::updateGeometry() at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapView.cpp:291
+[10] Rim3dView::updateDisplayModelForCurrentTimeStepAndRedraw() at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:673
+[11] RiuViewer::setCurrentFrame(int) at ResInsight/ApplicationLibCode/UserInterface/RiuViewer.cpp:1008
+[12] RimEclipseView::onCreateDisplayModel() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp:791
+[13] RimEclipseContourMapView::onCreateDisplayModel() at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapView.cpp:205
+[14] Rim3dView::createDisplayModelAndRedraw() at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:718
+[15] RicNewStatisticsContourMapViewFeature::createAndAddView(RimStatisticsContourMap*) at ResInsight/ApplicationLibCode/Commands/RicNewStatisticsContourMapViewFeature.cpp:124
+[16] RimStatisticsContourMap::fieldChangedByUi(caf::PdmFieldHandle const*, QVariant const&, QVariant const&) at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimStatisticsContourMap.cpp:280
+[17] caf::PdmUiFieldHandle::notifyFieldChanged(QVariant const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiFieldHandle.cpp:74
+[18] caf::PdmFieldUiCap<caf::PdmField<bool> >::setValueFromUiEditor(QVariant const&, bool) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafInternalPdmUiFieldCapability.inl:110
+[19] caf::PdmUiCommandSystemProxy::setUiValueToField(caf::PdmUiFieldHandle*, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiCommandSystemProxy.cpp:122
+[20] caf::PdmUiPushButtonEditor::slotClicked(bool) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiPushButtonEditor.cpp:199
+[29] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[35] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[46] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[47] __libc_start_main at :0
+```
+
+**OPM issue:** none found
+
+## Stack #56 — count 1
+
+First seen: `2026-06-16T13:03:07.752Z`  
+Last seen: `2026-06-16T13:03:07.752Z`  
+Versions: `2026.02.2` (1)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[7] RimWellAllocationPlot::onLoadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/Flow/RimWellAllocationPlot.cpp:896
+[8] RimViewWindow::loadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimViewWindow.cpp:88
+[9] RimSimWellInViewCollection::updateWellAllocationPlots() at ResInsight/ApplicationLibCode/ProjectDataModel/RimSimWellInViewCollection.cpp:578
+[10] RimEclipseView::synchronizeWellsWithResults() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp:1744
+[11] RimEclipseView::onLoadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp:1218
+[12] RimViewWindow::loadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimViewWindow.cpp:88
+[13] RimReloadCaseTools::updateAll3dViews(RimEclipseCase*) at ResInsight/ApplicationLibCode/ProjectDataModel/RimReloadCaseTools.cpp:141
+[14] RimReloadCaseTools::reloadEclipseData(RimEclipseCase*, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimReloadCaseTools.cpp:96
+[15] RicReplaceCaseFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/RicReplaceCaseFeature.cpp:87
+[16] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+[25] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[31] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[43] RiuMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:2056
+[51] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[56] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[67] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[68] __libc_start_main at :0
+```
+
+**OPM issue:** none found
+
+## Stack #57 — count 1
+
+First seen: `2026-06-07T17:56:40.141Z`  
+Last seen: `2026-06-07T17:56:40.141Z`  
+Versions: `2026.02.2` (1)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[3] RimEclipseResultDefinition::eclipseCase() const at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:223
+[4] RimEclipseGeometrySelectionItem::setFromSelectionItem(RiuEclipseSelectionItem const*) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseGeometrySelectionItem.cpp:67
+[5] RimGridTimeHistoryCurve::setFromSelectionItem(RiuSelectionItem const*, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimGridTimeHistoryCurve.cpp:104
+[6] RiuSelectionChangedHandler::updateGridCellCurvesFromSelection() at ResInsight/ApplicationLibCode/UserInterface/RiuSelectionChangedHandler.cpp:480
+[7] RiuSelectionChangedHandler::handleItemAppended(RiuSelectionItem const*) const at ResInsight/ApplicationLibCode/UserInterface/RiuSelectionChangedHandler.cpp:133
+[8] Riu3dSelectionManager::updateSelectedItems() at ResInsight/ApplicationLibCode/UserInterface/Riu3dSelectionManager.cpp:114
+[9] RiuTimeStepChangedHandler::handleTimeStepChanged(Rim3dView*) const at ResInsight/ApplicationLibCode/UserInterface/RiuTimeStepChangedHandler.cpp:101
+[10] Rim3dView::setCurrentTimeStep(int) at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:650
+[11] non-virtual thunk to Rim3dView::setCurrentTimeStepAndUpdate(int) at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.h:156
+[12] RiuViewer::setCurrentFrame(int) at ResInsight/ApplicationLibCode/UserInterface/RiuViewer.cpp:1008
+[13] RiuViewer::slotSetCurrentFrame(int) at ResInsight/ApplicationLibCode/UserInterface/RiuViewer.cpp:348
+[14] RiuMainWindow::slotAnimationSliderMoved(int) at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:1961
+[22] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[28] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[39] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[40] __libc_start_main at :0
+```
+
+**OPM issue:** none found
+
+## Stack #59 — count 1
+
+First seen: `2026-06-02T20:12:32.25Z`  
+Last seen: `2026-06-02T20:12:32.25Z`  
+Versions: `2026.02.2` (1)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[5] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
+[6] RimEclipseCase::~RimEclipseCase() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCase.cpp:170
+[7] RimEclipseResultCase::~RimEclipseResultCase() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultCase.cpp:585
+[8] caf::PdmChildArrayField<RimEclipseCase*>::deleteChildren() at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmChildArrayField.inl:181
+[9] RimEclipseCaseCollection::close() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCaseCollection.cpp:73
+[10] RimEclipseCaseCollection::~RimEclipseCaseCollection() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCaseCollection.cpp:63
+[11] RimEclipseCaseCollection::~RimEclipseCaseCollection() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCaseCollection.cpp:64
+[12] caf::PdmChildField<RimEclipseCaseCollection*>::~PdmChildField() at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmChildField.inl:80
+[13] RimOilField::~RimOilField() at ResInsight/ApplicationLibCode/ProjectDataModel/RimOilField.cpp:113
+[14] caf::PdmChildArrayField<RimOilField*>::deleteChildren() at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmChildArrayField.inl:181
+[15] RimProject::close() at ResInsight/ApplicationLibCode/ProjectDataModel/RimProject.cpp:257
+[16] RiaApplication::closeProject() at ResInsight/ApplicationLibCode/Application/RiaApplication.cpp:1021
+[17] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:36
+[29] RiaOpenTelemetryManager::reportCrash(int, std::basic_stacktrace<std::allocator<std::stacktrace_entry> > const&, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > const&) at ResInsight/ApplicationLibCode/Application/Tools/Telemetry/RiaOpenTelemetryManager.cpp:415
+[30] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:174
+[31] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[35] operator() at ResInsight/ApplicationLibCode/Application/Tools/RiaWellNameComparer.cpp:87
+[37] RiaWellNameComparer::tryMatchNameInList(QString, std::vector<QString, std::allocator<QString> > const&) at ResInsight/ApplicationLibCode/Application/Tools/RiaWellNameComparer.cpp:82
+[38] RiaWellNameComparer::tryFindMatchingSimWellName(QString) at ResInsight/ApplicationLibCode/Application/Tools/RiaWellNameComparer.cpp:40
+[39] RimWellPath::tryAssociateWithSimulationWell() at ResInsight/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPath.cpp:1107
+[40] RimEclipseCase::openReservoirCase() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCase.cpp:1152
+[41] RimEclipseResultDefinition::loadResult() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:1097
+[42] RimWellLogExtractionCurve::extractEclipseData(RimEclipseCase*, bool*) at ResInsight/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogExtractionCurve.cpp:546
+[43] RimWellLogExtractionCurve::extractData(bool*, std::optional<double> const&, std::optional<double> const&) at ResInsight/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogExtractionCurve.cpp:457
+[44] RimWellLogExtractionCurve::performDataExtraction(bool*) at ResInsight/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogExtractionCurve.cpp:433
+[45] RimWellLogExtractionCurve::onLoadDataAndUpdate(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogExtractionCurve.cpp:342
+[46] RimPlotCurve::loadDataAndUpdate(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimPlotCurve.cpp:587
+[47] RimWellLogTrack::onLoadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogTrack.cpp:1213
+[48] RimViewWindow::loadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimViewWindow.cpp:88
+[49] RimDepthTrackPlot::updatePlots() at ResInsight/ApplicationLibCode/ProjectDataModel/RimDepthTrackPlot.cpp:1248
+[50] non-virtual thunk to RimDepthTrackPlot::onLoadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimDepthTrackPlot.h:196
+[51] RimViewWindow::loadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimViewWindow.cpp:88
+[52] non-virtual thunk to RimWellLogPlotCollection::loadDataAndUpdateAllPlots() at ResInsight/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogPlotCollection.h:66
+[53] RiaPlotCollectionScheduler::performScheduledUpdates() at ResInsight/ApplicationLibCode/Application/RiaPlotCollectionScheduler.cpp:69
+[66] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[67] __libc_start_main at :0
+```
+
+**OPM issue:** none found
+
+## Stack #60 — count 1
+
+First seen: `2026-06-15T11:41:43.273Z`  
+Last seen: `2026-06-15T11:41:43.273Z`  
+Versions: `2026.02.2` (1)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[5] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
+[6] cvf::Camera::setProjectionAsPerspective(double, double, double) at ResInsight/Fwk/VizFwk/LibRender/cvfCamera.cpp:206
+[7] caf::Viewer::optimizeClippingPlanes() at ResInsight/Fwk/AppFwk/cafViewer/cafViewer.cpp:465
+[8] caf::Viewer::paintGL() at ResInsight/Fwk/AppFwk/cafViewer/cafViewer.cpp:884
+[12] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[46] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[58] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[64] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[75] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[76] __libc_start_main at :0
+```
+
+**OPM issue:** none found
+
+## Stack #61 — count 1
+
+First seen: `2026-06-02T11:34:47.01Z`  
+Last seen: `2026-06-02T11:34:47.01Z`  
+Versions: `2026.02.2` (1)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[3] caf::PdmObjectHandle::prepareForDelete() at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmObjectHandle.cpp:155
+[4] caf::AsyncPdmObjectVectorDeleter<RimSummaryCase>::AsyncPdmObjectVectorDeleter(std::vector<RimSummaryCase*, std::allocator<RimSummaryCase*> >&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafAsyncObjectDeleter.inl:20
+[5] RicCloseSummaryCaseFeature::deleteSummaryCases(std::vector<RimSummaryCase*, std::allocator<RimSummaryCase*> >) at ResInsight/ApplicationLibCode/Commands/RicCloseSummaryCaseFeature.cpp:99
+[6] RicCloseSummaryCaseInCollectionFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/RicCloseSummaryCaseInCollectionFeature.cpp:79
+[7] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+[16] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[22] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[34] RiuPlotMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp:1058
+[42] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[47] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[58] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[59] __libc_start_main at :0
+```
+
+**OPM issue:** none found
+
+## Stack #62 — count 1
+
+First seen: `2026-06-02T20:12:32.462Z`  
+Last seen: `2026-06-02T20:12:32.462Z`  
+Versions: `2026.02.2` (1)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[3] RigEclipseWellLogExtractor::calculateIntersection() at ResInsight/ApplicationLibCode/ReservoirDataModel/Well/RigEclipseWellLogExtractor.cpp:82
+[4] RigEclipseWellLogExtractor::RigEclipseWellLogExtractor(gsl::not_null<RigEclipseCaseData const*>, gsl::not_null<RigWellPath const*>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) at ResInsight/ApplicationLibCode/ReservoirDataModel/Well/RigEclipseWellLogExtractor.cpp:49
+[5] RigWellPathIntersectionTools::findCellIntersectionInfosAlongPath(RigEclipseCaseData const*, QString const&, std::vector<cvf::Vector3<double>, std::allocator<cvf::Vector3<double> > > const&, std::vector<double, std::allocator<double> > const&) at ResInsight/ApplicationLibCode/ReservoirDataModel/Well/RigWellPathIntersectionTools.cpp:50
+[6] RicWellPathExportMswTableData::generateCellSegments(RimEclipseCase const*, RimWellPath const*) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswTableData.cpp:658
+[7] RicWellPathExportMswTableData::generateFishbonesMswExportInfoForWell(RimEclipseCase const*, RimWellPath const*, RicMswExportInfo*, RicMswBranch*) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportMswTableData.cpp:197
+[8] RicFishbonesTransmissibilityCalculationFeatureImp::findFishboneLateralsWellBoreParts(std::map<unsigned long, std::vector<WellBorePartForTransCalc, std::allocator<WellBorePartForTransCalc> >, std::less<unsigned long>, std::allocator<std::pair<unsigned long const, std::vector<WellBorePartForTransCalc, std::allocator<WellBorePartForTransCalc> > > > >&, RimWellPath const*, RimEclipseCase const*) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicFishbonesTransmissibilityCalculationFeatureImp.cpp:209
+[9] RicFishbonesTransmissibilityCalculationFeatureImp::generateFishboneCompdatValuesUsingAdjustedCellVolume(RimWellPath const*, RicExportCompletionDataSettingsUi const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicFishbonesTransmissibilityCalculationFeatureImp.cpp:92
+[10] RicWellPathExportCompletionDataFeatureImpl::exportCompletions(std::vector<RimWellPath*, std::allocator<RimWellPath*> > const&, RicExportCompletionDataSettingsUi const&) at ResInsight/ApplicationLibCode/Commands/CompletionExportCommands/RicWellPathExportCompletionDataFeatureImpl.cpp:208
+[11] RicfExportWellPathCompletions::execute() at ResInsight/ApplicationLibCode/CommandFileInterface/RicfExportWellPathCompletions.cpp:184
+[12] RiaGrpcCommandService::Execute(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) at ResInsight/GrpcInterface/RiaGrpcCommandService.cpp:92
+[13] grpc::Status std::__invoke_impl<grpc::Status, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*>(std::__invoke_memfun_ref, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*&&, rips::CommandParams const*&&, rips::CommandReply*&&) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/invoke.h:67
+[14] std::function<grpc::Status (RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*)>::operator()(RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:591
+[15] RiaGrpcServerImpl::processAllQueuedRequests() at ResInsight/GrpcInterface/RiaGrpcServer.cpp:200
+[16] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:115
+[17] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:33
+[30] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[31] __libc_start_main at :0
+```
+
+**OPM issue:** [#14185](https://github.com/OPM/ResInsight/issues/14185) — OPEN
+
+## Stack #64 — count 1
+
+First seen: `2026-06-16T07:28:39.146Z`  
+Last seen: `2026-06-16T07:28:39.146Z`  
+Versions: `2026.06.0` (1)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:167
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:263
+[3] RiuMainWindow::subWindowList(QMdiArea::WindowOrder) at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:1185
+[4] RiaSocketServer::findReservoir(int) at ResInsight/ApplicationLibCode/SocketInterface/RiaSocketServer.cpp:155
+[5] RiaGetActiveCellProperty::interpretCommand(RiaSocketServer*, QList<QByteArray> const&, QDataStream&) at ResInsight/ApplicationLibCode/SocketInterface/RiaPropertyDataCommands.cpp:62
+[6] RiaSocketServer::readCommandFromOctave() at ResInsight/ApplicationLibCode/SocketInterface/RiaSocketServer.cpp:231
+[7] RiaSocketServer::slotReadyRead() at ResInsight/ApplicationLibCode/SocketInterface/RiaSocketServer.cpp:293
+[12] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1831
+[21] main at ResInsight/ApplicationExeCode/RiaMain.cpp:258
+[22] __libc_start_main at :0
+```
+
+**OPM issue:** none found
+
+## Stack #69 — count 1
+
+First seen: `2026-06-19T15:16:33.637Z`  
+Last seen: `2026-06-19T15:16:33.637Z`  
+Versions: `2026.06.1-dev.01` (1)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:167
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:263
+[13] ecl_file_view_iget_named_file_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_view.cpp:127
+[14] ecl_file_view_iget_named_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_view.cpp:224
+[15] RifEclipseOutputFileTools::findAvailablePhases(ecl_file_struct const*) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseOutputFileTools.cpp:585
+[16] RifEclipseUnifiedRestartFileAccess::openFile() at ResInsight/ApplicationLibCode/FileInterface/RifEclipseUnifiedRestartFileAccess.cpp:125
+[17] RifEclipseUnifiedRestartFileAccess::extractTimestepsFromEclipse() at ResInsight/ApplicationLibCode/FileInterface/RifEclipseUnifiedRestartFileAccess.cpp:152
+[18] RifEclipseUnifiedRestartFileAccess::timeSteps(std::vector<QDateTime, std::allocator<QDateTime> >*, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseUnifiedRestartFileAccess.cpp:206
+[19] RimEclipseResultCase::importGridAndResultMetaData(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultCase.cpp:216
+[20] RiaImportEclipseCaseTools::openEclipseCaseShowTimeStepFilterImpl(QString const&, bool, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:372
+[21] RiaImportEclipseCaseTools::openEclipseCasesFromFile(QList<QString> const&, bool, std::map<QString, int, std::less<QString>, std::allocator<std::pair<QString const, int> > >*, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:107
+[22] RicImportGeneralDataFeature::openEclipseCaseFromFileNames(QList<QString> const&, bool, std::vector<int, std::allocator<int> >&, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:363
+[23] RicImportGeneralDataFeature::openEclipseFilesFromFileNames(QList<QString> const&, bool, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:105
+[24] RicImportGeneralDataFeature::openEclipseFilesFromFileNames(QList<QString> const&, bool, bool) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:56
+[25] RiaGuiApplication::handleArguments(gsl::not_null<cvf::ProgramOptions*>) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:847
+[26] main at ResInsight/ApplicationExeCode/RiaMain.cpp:202
+[27] __libc_start_main at :0
+```
+
+**OPM issue:** none found
+
+## Stack #71 — count 1
+
+First seen: `2026-05-28T16:12:14.6Z`  
+Last seen: `2026-05-28T16:12:14.6Z`  
+Versions: `2026.02.2` (1)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[10] RiuSummaryPlot::showContextMenu(QPoint) at ResInsight/ApplicationLibCode/UserInterface/RiuSummaryPlot.cpp:210
+[16] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[21] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[32] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[33] __libc_start_main at :0
+```
+
+**OPM issue:** none found
+
+## Stack #72 — count 1
+
+First seen: `2026-05-29T10:15:01.06Z`  
+Last seen: `2026-05-29T10:15:01.06Z`  
+Versions: `2026.02.2` (1)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[4] RimViewController::applyCellFilterCollectionByUserChoice() at ResInsight/ApplicationLibCode/ProjectDataModel/RimViewController.cpp:1105
+[5] RimViewLinker::applyCellFilterCollectionByUserChoice() at ResInsight/ApplicationLibCode/ProjectDataModel/RimViewLinker.cpp:669
+[6] RicDeleteAllLinkedViewsFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/ViewLink/RicDeleteAllLinkedViewsFeature.cpp:81
+[7] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+[8] RiuTreeViewEventFilter::activateFirstEnabledFeature(std::vector<caf::CmdFeature*, std::allocator<caf::CmdFeature*> > const&) at ResInsight/ApplicationLibCode/UserInterface/RiuTreeViewEventFilter.cpp:95
+[9] RiuTreeViewEventFilter::eventFilter(QObject*, QEvent*) at ResInsight/ApplicationLibCode/UserInterface/RiuTreeViewEventFilter.cpp:143
+[13] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[17] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[28] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[29] __libc_start_main at :0
+```
+
+**OPM issue:** none found
+
+## Closed issues
+
+## Stack #2 — count 10
+
+First seen: `2026-05-21T09:39:53.897Z`  
+Last seen: `2026-06-11T06:21:46.27Z`  
+Versions: `2026.02.2` (9), `2026.06.0-RC_1` (1)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[3] ecl_kw_get_data_type at ResInsight/ThirdParty/Ert/lib/ecl/ecl_kw.cpp:1776
+[4] ecl_file_kw_assert_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_kw.cpp:211
+[5] ecl_file_kw_load_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_kw.cpp:244
+[6] ecl_file_view_get_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_view.cpp:149
+[7] RifEclipseOutputFileTools::keywordData(ecl_file_struct const*, QString const&, unsigned long, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseOutputFileTools.cpp:305
+[8] RifEclipseUnifiedRestartFileAccess::results(QString const&, unsigned long, unsigned long, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseUnifiedRestartFileAccess.cpp:248
+[9] RifReaderEclipseOutput::dynamicResult(QString const&, RiaDefines::PorosityModelType, unsigned long, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp:1070
+[10] RigCaseCellResultsData::findOrLoadKnownScalarResult(RigEclipseResultAddress const&) at ResInsight/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp:1538
+[11] RigCaseCellResultsData::ensureKnownResultLoaded(RigEclipseResultAddress const&) at ResInsight/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp:1264
+[12] RimEclipseResultDefinition::loadResult() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:1134
+[13] RimWellLogExtractionCurve::extractEclipseData(RimEclipseCase*, bool*) at ResInsight/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogExtractionCurve.cpp:546
+[14] RimWellLogExtractionCurve::extractData(bool*, std::optional<double> const&, std::optional<double> const&) at ResInsight/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogExtractionCurve.cpp:457
+[15] RimWellLogExtractionCurve::performDataExtraction(bool*) at ResInsight/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogExtractionCurve.cpp:433
+[16] RimWellLogExtractionCurve::onLoadDataAndUpdate(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogExtractionCurve.cpp:342
+[17] RimPlotCurve::loadDataAndUpdate(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimPlotCurve.cpp:587
+[18] RimWellLogTrack::onLoadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogTrack.cpp:1213
+[19] RimDepthTrackPlot::updateDepthAxisVisibility() at ResInsight/ApplicationLibCode/ProjectDataModel/RimDepthTrackPlot.cpp:979
+[20] RimDepthTrackPlot::updatePlots() at ResInsight/ApplicationLibCode/ProjectDataModel/RimDepthTrackPlot.cpp:1244
+[21] RimDepthTrackPlot::onLoadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimDepthTrackPlot.cpp:1233
+[22] RimWellRftPlot::updateCurvesInPlot(std::set<RiaRftPltCurveDefinition, std::less<RiaRftPltCurveDefinition>, std::allocator<RiaRftPltCurveDefinition> > const&, std::set<RiaRftPltCurveDefinition, std::less<RiaRftPltCurveDefinition>, std::allocator<RiaRftPltCurveDefinition> > const&, std::set<RimWellLogCurve*, std::less<RimWellLogCurve*>, std::allocator<RimWellLogCurve*> > const&) at ResInsight/ApplicationLibCode/ProjectDataModel/Flow/RimWellRftPlot.cpp:790
+[23] RimWellRftPlot::syncCurvesFromUiSelection() at ResInsight/ApplicationLibCode/ProjectDataModel/Flow/RimWellRftPlot.cpp:482
+[24] RimWellRftPlot::setOrInitializeDataSources(std::vector<RifDataSourceForRftPlt, std::allocator<RifDataSourceForRftPlt> > const&) at ResInsight/ApplicationLibCode/ProjectDataModel/Flow/RimWellRftPlot.cpp:344
+[25] RimWellRftPlot::initializeDataSources(RimWellRftPlot*) at ResInsight/ApplicationLibCode/ProjectDataModel/Flow/RimWellRftPlot.cpp:1763
+[26] RicCreateRftPlotsFeature::appendRftPlotForWell(QString const&, RimRftPlotCollection*) at ResInsight/ApplicationLibCode/Commands/WellLogCommands/RicCreateRftPlotsFeature.cpp:145
+[27] RicNewRftPlotFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/WellLogCommands/RicNewRftPlotFeature.cpp:62
+[28] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+[37] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[43] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[55] RiuPlotMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp:1058
+[63] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[68] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[79] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[80] __libc_start_main at :0
+```
+
+**OPM issue:** [#14140](https://github.com/OPM/ResInsight/issues/14140) — CLOSED
+
+## Stack #3 — count 7
+
+First seen: `2026-05-27T08:26:30.756Z`  
+Last seen: `2026-06-03T13:27:53.25Z`  
+Versions: `2026.02.2` (7)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[3] caf::PdmUiObjectHandle::uiOrdering(QString const&, caf::PdmUiOrdering&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiObjectHandle.cpp:40
+[4] RimContourMapProjection::defineUiOrdering(QString, caf::PdmUiOrdering&) at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimContourMapProjection.cpp:616
+[5] RimEclipseContourMapProjection::defineUiOrdering(QString, caf::PdmUiOrdering&) at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapProjection.cpp:333
+[6] caf::PdmUiObjectHandle::uiOrdering(QString const&, caf::PdmUiOrdering&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiObjectHandle.cpp:40
+[7] caf::PdmUiFormLayoutObjectEditor::configureAndUpdateUi(QString const&) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiFormLayoutObjectEditor.cpp:670
+[8] caf::PdmUiEditorHandle::updateUi(QString const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiEditorHandle.cpp:66
+[9] caf::PdmUiPropertyView::showProperties(caf::PdmObjectHandle*) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiPropertyView.cpp:213
+[10] RiuMainWindow::selectedObjectsChanged() at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:1530
+[12] caf::PdmUiTreeView::slotOnSelectionChanged() at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeView.cpp:154
+[26] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[32] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[43] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[44] __libc_start_main at :0
+```
+
+**OPM issue:** [#14112](https://github.com/OPM/ResInsight/issues/14112) — CLOSED
+
+## Stack #4 — count 7
+
+First seen: `2026-05-23T09:14:14.466Z`  
+Last seen: `2026-06-11T12:25:22.03Z`  
+Versions: `2026.02.2` (6), `2026.02.3-dev.01` (1)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[4] RimCase::gridFileName() const at ResInsight/ApplicationLibCode/ProjectDataModel/RimCase.cpp:136
+[5] RimReloadCaseTools::findSummaryCaseFromEclipseResultCase(RimEclipseResultCase const*) at ResInsight/ApplicationLibCode/ProjectDataModel/RimReloadCaseTools.cpp:196
+[6] RimReloadCaseTools::reloadEclipseData(RimEclipseCase*, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimReloadCaseTools.cpp:100
+[7] RicReloadCaseFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/RicReloadCaseFeature.cpp:62
+[8] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+[17] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[23] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[35] RiuMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:2056
+[43] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[48] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[59] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[60] __libc_start_main at :0
+```
+
+**OPM issue:** [#14205](https://github.com/OPM/ResInsight/issues/14205) — CLOSED
+
+## Stack #6 — count 6
+
+First seen: `2026-05-25T18:29:50.059Z`  
+Last seen: `2026-06-15T10:48:18.228Z`  
+Versions: `2026.02.2` (6)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[3] ecl_grid_alloc_EGRID__ at ResInsight/ThirdParty/Ert/lib/ecl/ecl_grid.cpp:3085
+[4] ecl_grid_alloc_EGRID_all_grids at ResInsight/ThirdParty/Ert/lib/ecl/ecl_grid.cpp:3106
+[5] RifReaderEclipseOutput::loadAllGrids() const at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp:1161
+[6] RifReaderEclipseOutput::open(QString const&, RigEclipseCaseData*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp:389
+[7] RimEclipseResultCase::importGridAndResultMetaData(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultCase.cpp:261
+[8] RiaImportEclipseCaseTools::openEclipseCaseShowTimeStepFilterImpl(QString const&, bool, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:372
+[9] RiaImportEclipseCaseTools::openEclipseCasesFromFile(QList<QString> const&, bool, std::map<QString, int, std::less<QString>, std::allocator<std::pair<QString const, int> > >*, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:107
+[10] RicImportGeneralDataFeature::openEclipseCaseFromFileNames(QList<QString> const&, bool, std::vector<int, std::allocator<int> >&, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:362
+[11] RicImportEclipseCaseFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/EclipseCommands/RicImportEclipseCaseFeature.cpp:72
+[12] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+[21] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[27] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[38] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[39] __libc_start_main at :0
+```
+
+**OPM issue:** [#14118](https://github.com/OPM/ResInsight/issues/14118) — CLOSED
+
+## Stack #7 — count 6
+
+First seen: `2026-05-28T07:31:55.884Z`  
+Last seen: `2026-06-08T11:26:22.295Z`  
+Versions: `2026.02.2` (6)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[5] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
+[6] cvf::StructGridInterface::oppositeFace(cvf::StructGridInterface::FaceType) at ResInsight/Fwk/AppFwk/CommonCode/cvfStructGrid.cpp:199
+[7] RigCombMultResultAccessor::cellFaceScalar(unsigned long, cvf::StructGridInterface::FaceType) const at ResInsight/ApplicationLibCode/ReservoirDataModel/ResultAccessors/RigCombMultResultAccessor.cpp:77
+[8] RiuResultTextBuilder::cellResultTextAndValueText(RimEclipseResultDefinition*) at ResInsight/ApplicationLibCode/UserInterface/RiuResultTextBuilder.cpp:1106
+[9] RiuResultTextBuilder::cellResultText(std::vector<RimEclipseResultDefinition*, std::allocator<RimEclipseResultDefinition*> > const&, bool) at ResInsight/ApplicationLibCode/UserInterface/RiuResultTextBuilder.cpp:998
+[10] RiuResultTextBuilder::gridResultText() at ResInsight/ApplicationLibCode/UserInterface/RiuResultTextBuilder.cpp:490
+[11] RiuResultTextBuilder::resultTextFromLinkedViews() const at ResInsight/ApplicationLibCode/UserInterface/RiuResultTextBuilder.cpp:829
+[12] RiuResultTextBuilder::gridResultDetails() at ResInsight/ApplicationLibCode/UserInterface/RiuResultTextBuilder.cpp:377
+[13] RiuResultTextBuilder::mainResultText() at ResInsight/ApplicationLibCode/UserInterface/RiuResultTextBuilder.cpp:189
+[14] RiuSelectionChangedHandler::updateResultInfo(RiuSelectionItem const*) const at ResInsight/ApplicationLibCode/UserInterface/RiuSelectionChangedHandler.cpp:389
+[15] RiuSelectionChangedHandler::handleItemAppended(RiuSelectionItem const*) const at ResInsight/ApplicationLibCode/UserInterface/RiuSelectionChangedHandler.cpp:132
+[16] RiuCellAndNncPickEventHandler::handle3dPickEvent(Ric3dPickEvent const&) at ResInsight/ApplicationLibCode/UserInterface/RiuCellAndNncPickEventHandler.cpp:459
+[17] RiuViewerCommands::handlePickAction(int, int, QFlags<Qt::KeyboardModifier>) at ResInsight/ApplicationLibCode/UserInterface/RiuViewerCommands.cpp:702
+[21] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[27] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[38] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[39] __libc_start_main at :0
+```
+
+**OPM issue:** [#14138](https://github.com/OPM/ResInsight/issues/14138) — CLOSED
+
+## Stack #8 — count 5
+
+First seen: `2026-06-02T20:12:31.249Z`  
+Last seen: `2026-06-02T20:12:32.83Z`  
+Versions: `2026.02.2` (5)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[11] RiaTextStringTools::replaceTemplateTextWithValues(QString const&, std::map<QString, QString, std::less<QString>, std::allocator<std::pair<QString const, QString> > > const&) at ResInsight/ApplicationLibCode/Application/Tools/RiaTextStringTools.cpp:178
+[12] RimDepthTrackPlot::createPlotNameFromTemplate(QString const&) const at ResInsight/ApplicationLibCode/ProjectDataModel/RimDepthTrackPlot.cpp:608
+[13] RimDepthTrackPlot::createAutoName() const at ResInsight/ApplicationLibCode/ProjectDataModel/RimDepthTrackPlot.cpp:712
+[14] RimDepthTrackPlot::performAutoNameUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimDepthTrackPlot.cpp:788
+[15] non-virtual thunk to RimDepthTrackPlot::onLoadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimDepthTrackPlot.h:196
+[16] RimViewWindow::loadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimViewWindow.cpp:88
+[17] non-virtual thunk to RimWellLogPlotCollection::loadDataAndUpdateAllPlots() at ResInsight/ApplicationLibCode/ProjectDataModel/WellLog/RimWellLogPlotCollection.h:66
+[18] RiaPlotCollectionScheduler::performScheduledUpdates() at ResInsight/ApplicationLibCode/Application/RiaPlotCollectionScheduler.cpp:69
+[31] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[32] __libc_start_main at :0
+```
+
+**OPM issue:** [#14150](https://github.com/OPM/ResInsight/issues/14150) — CLOSED
+
+## Stack #9 — count 3
+
+First seen: `2026-06-15T10:32:04.243Z`  
+Last seen: `2026-06-17T10:18:08.147Z`  
+Versions: `2026.02.2` (3)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[3] ecl_kw_get_data_type at ResInsight/ThirdParty/Ert/lib/ecl/ecl_kw.cpp:1776
+[4] ecl_file_kw_assert_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_kw.cpp:211
+[5] ecl_file_kw_load_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_kw.cpp:244
+[6] ecl_file_view_get_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_view.cpp:149
+[7] RifEclipseSummaryTools::getRestartRelativeFilePathResdata(QString const&) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseSummaryTools.cpp:336
+[8] RifEclipseSummaryTools::getRestartFileNames(QString const&, bool, std::vector<QString, std::allocator<QString> >&) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseSummaryTools.cpp:220
+[9] RifEclipseSummaryTools::getRestartFileNames(QString const&, std::vector<QString, std::allocator<QString> >&) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseSummaryTools.cpp:164
+[10] operator() at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:190
+[11] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:110
+[12] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+```
+
+**OPM issue:** [#13928](https://github.com/OPM/ResInsight/issues/13928) — CLOSED
+
+## Stack #10 — count 3
+
+First seen: `2026-05-29T14:06:22.726Z`  
+Last seen: `2026-06-08T12:09:14.349Z`  
+Versions: `2026.02.2` (3)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[3] ecl_kw_get_data_type at ResInsight/ThirdParty/Ert/lib/ecl/ecl_kw.cpp:1776
+[4] ecl_file_kw_assert_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_kw.cpp:211
+[5] ecl_file_kw_load_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_kw.cpp:244
+[6] ecl_file_view_get_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_view.cpp:149
+[7] RifEclipseOutputFileTools::keywordData(ecl_file_struct const*, QString const&, unsigned long, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseOutputFileTools.cpp:305
+[8] RifReaderEclipseOutput::staticResult(QString const&, RiaDefines::PorosityModelType, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp:999
+[9] RigCaseCellResultsData::findOrLoadKnownScalarResult(RigEclipseResultAddress const&) at ResInsight/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp:1558
+[10] RigCaseCellResultsData::ensureKnownResultLoaded(RigEclipseResultAddress const&) at ResInsight/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp:1264
+[11] RimEclipseResultDefinition::loadResult() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:1134
+[12] RimEclipseCellColors::loadResult() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCellColors.cpp:260
+[13] RimEclipseResultDefinition::loadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:533
+[14] RimEclipseResultDefinition::fieldChangedByUi(caf::PdmFieldHandle const*, QVariant const&, QVariant const&) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:305
+[15] RimEclipseCellColors::fieldChangedByUi(caf::PdmFieldHandle const*, QVariant const&, QVariant const&) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCellColors.cpp:90
+[16] caf::PdmUiFieldHandle::notifyFieldChanged(QVariant const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiFieldHandle.cpp:74
+[17] caf::PdmFieldUiCap<caf::PdmField<QString> >::setValueFromUiEditor(QVariant const&, bool) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafInternalPdmUiFieldCapability.inl:110
+[18] caf::PdmUiCommandSystemProxy::setUiValueToField(caf::PdmUiFieldHandle*, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiCommandSystemProxy.cpp:122
+[19] caf::PdmUiTreeSelectionQModel::setData(QModelIndex const&, QVariant const&, int) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionQModel.cpp:482
+[21] caf::PdmUiTreeSelectionEditor::currentChanged(QModelIndex const&) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionEditor.cpp:812
+[22] caf::PdmUiTreeSelectionEditor::slotClicked(QModelIndex const&) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionEditor.cpp:759
+[31] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[37] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[48] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[49] __libc_start_main at :0
+```
+
+**OPM issue:** [#14140](https://github.com/OPM/ResInsight/issues/14140) — CLOSED
+
+## Stack #11 — count 3
+
+First seen: `2026-05-29T08:17:06.473Z`  
+Last seen: `2026-06-10T21:56:05.631Z`  
+Versions: `2026.02.2` (3)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[5] RigCaseCellResultsData::hasResultEntry(RigEclipseResultAddress const&) const at ResInsight/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp:1287
+[6] RigEclipseContourMapProjection::generateResults(RigEclipseContourMapProjection const&, RigContourMapGrid const&, RigCaseCellResultsData&, RigEclipseResultAddress const&, RigContourMapCalculator::ResultAggregationType, int, RigFloodingSettings&) at ResInsight/ApplicationLibCode/ReservoirDataModel/ContourMap/RigEclipseContourMapProjection.cpp:103
+[7] RigEclipseContourMapProjection::generateAndSaveResults(RigEclipseResultAddress const&, RigContourMapCalculator::ResultAggregationType, int, RigFloodingSettings&) at ResInsight/ApplicationLibCode/ReservoirDataModel/ContourMap/RigEclipseContourMapProjection.cpp:71
+[8] RimEclipseContourMapProjection::generateAndSaveResults(int) at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapProjection.cpp:213
+[9] RimContourMapProjection::generateResultsIfNecessary(int) at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimContourMapProjection.cpp:164
+[10] RimEclipseContourMapView::updateGeometry() at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapView.cpp:282
+[11] Rim3dView::updateDisplayModelForCurrentTimeStepAndRedraw() at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:673
+[12] RiuViewer::setCurrentFrame(int) at ResInsight/ApplicationLibCode/UserInterface/RiuViewer.cpp:1008
+[13] RimEclipseView::onCreateDisplayModel() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp:791
+[14] RimEclipseContourMapView::onCreateDisplayModel() at ResInsight/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapView.cpp:205
+[15] Rim3dView::createDisplayModelAndRedraw() at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:718
+[16] RiaViewRedrawScheduler::updateAndRedrawScheduledViews() at ResInsight/ApplicationLibCode/Application/RiaViewRedrawScheduler.cpp:93
+[21] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[31] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[32] __libc_start_main at :0
+```
+
+**OPM issue:** [#14007](https://github.com/OPM/ResInsight/issues/14007) — CLOSED
+
+## Stack #12 — count 3
+
+First seen: `2026-06-08T05:51:18.931Z`  
+Last seen: `2026-06-16T10:49:34.724Z`  
+Versions: `2026.02.2` (3)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[3] Rim3dView::scaleZ() const at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:1242
+[4] RimViewController::updateCameraLink() at ResInsight/ApplicationLibCode/ProjectDataModel/RimViewController.cpp:559
+[5] RimViewController::setManagedView(Rim3dView*) at ResInsight/ApplicationLibCode/ProjectDataModel/RimViewController.cpp:443
+[6] RimViewController::fieldChangedByUi(caf::PdmFieldHandle const*, QVariant const&, QVariant const&) at ResInsight/ApplicationLibCode/ProjectDataModel/RimViewController.cpp:226
+[7] caf::PdmUiFieldHandle::notifyFieldChanged(QVariant const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiFieldHandle.cpp:74
+[8] caf::PdmFieldUiCap<caf::PdmPtrField<Rim3dView*> >::setValueFromUiEditor(QVariant const&, bool) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafInternalPdmUiFieldCapability.inl:111
+[9] caf::CmdFieldChangeExec::redo() at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFieldChangeExec.cpp:139
+[11] caf::CmdUiCommandSystemImpl::fieldChangedCommand(std::vector<caf::PdmFieldHandle*, std::allocator<caf::PdmFieldHandle*> > const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdUiCommandSystemImpl.cpp:146
+[12] caf::PdmUiCommandSystemProxy::setUiValueToField(caf::PdmUiFieldHandle*, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiCommandSystemProxy.cpp:113
+[13] caf::PdmUiComboBoxEditor::slotIndexActivated(int) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiComboBoxEditor.cpp:455
+[24] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[30] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[41] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[42] __libc_start_main at :0
+```
+
+**OPM issue:** [#13878](https://github.com/OPM/ResInsight/issues/13878) — CLOSED
+
+## Stack #15 — count 3
+
+First seen: `2026-06-02T20:12:31.674Z`  
+Last seen: `2026-06-02T20:12:32.248Z`  
+Versions: `2026.02.2` (3)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[8] ecl_kw_fread_data at ResInsight/ThirdParty/Ert/lib/ecl/ecl_kw.cpp:1246
+[9] ecl_kw_fread_alloc at ResInsight/ThirdParty/Ert/lib/ecl/ecl_kw.cpp:1562
+[10] ecl_file_kw_load_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_kw.cpp:243
+[11] ecl_file_view_get_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_view.cpp:149
+[17] RifReaderEclipseWell::readWellCells(RifEclipseRestartDataAccess*, RigEclipseCaseData*, std::vector<QDateTime, std::allocator<QDateTime> >, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, bool) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseWell.cpp:464
+[18] RifReaderEclipseOutput::open(QString const&, RigEclipseCaseData*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp:523
+[19] RimEclipseResultCase::importGridAndResultMetaData(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultCase.cpp:261
+[20] RiaImportEclipseCaseTools::openEclipseCaseShowTimeStepFilterImpl(QString const&, bool, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:372
+[21] RiaImportEclipseCaseTools::openEclipseCasesFromFile(QList<QString> const&, bool, std::map<QString, int, std::less<QString>, std::allocator<std::pair<QString const, int> > >*, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:107
+[22] RicImportGeneralDataFeature::openEclipseCaseFromFileNames(QList<QString> const&, bool, std::vector<int, std::allocator<int> >&, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:362
+[23] RicImportGeneralDataFeature::openEclipseFilesFromFileNames(QList<QString> const&, bool, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:104
+[24] RicfLoadCase::execute() at ResInsight/ApplicationLibCode/CommandFileInterface/RicfLoadCase.cpp:77
+[25] RiaGrpcCommandService::Execute(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) at ResInsight/GrpcInterface/RiaGrpcCommandService.cpp:92
+[26] grpc::Status std::__invoke_impl<grpc::Status, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*>(std::__invoke_memfun_ref, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*&&, rips::CommandParams const*&&, rips::CommandReply*&&) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/invoke.h:67
+[27] std::function<grpc::Status (RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*)>::operator()(RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:591
+[28] RiaGrpcServerImpl::processAllQueuedRequests() at ResInsight/GrpcInterface/RiaGrpcServer.cpp:200
+[29] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:115
+[30] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:33
+[43] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[44] __libc_start_main at :0
+```
+
+**OPM issue:** [#14144](https://github.com/OPM/ResInsight/issues/14144) — CLOSED
+
+## Stack #16 — count 2
+
+First seen: `2026-06-02T19:57:19.87Z`  
+Last seen: `2026-06-02T22:18:46.523Z`  
+Versions: `2026.02.2` (2)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[5] RiuMainWindow::customMenuRequested(QPoint const&) at /private/f_resinsight_build/resbuild/qt/6.6.3/gcc_64/include/QtCore/qstring.h:1169
+[13] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[18] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[29] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[30] __libc_start_main at :0
+```
+
+**OPM issue:** [#14155](https://github.com/OPM/ResInsight/issues/14155) — CLOSED
+
+## Stack #17 — count 2
+
+First seen: `2026-05-23T22:42:23.646Z`  
+Last seen: `2026-06-12T14:04:49.292Z`  
+Versions: `2026.02.2` (2)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[13] Opm::EclIO::ESmry::dates() const at ResInsight/ThirdParty/custom-opm-common/opm-common/opm/io/eclipse/ESmry.cpp:1457
+[14] RifHdf5SummaryExporter::writeGeneralSection(RifHdf5Exporter&, Opm::EclIO::ESmry&) at ResInsight/ApplicationLibCode/FileInterface/RifHdf5SummaryExporter.cpp:165
+[15] RifHdf5SummaryExporter::ensureHdf5FileIsCreated(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool, unsigned long&) at ResInsight/ApplicationLibCode/FileInterface/RifHdf5SummaryExporter.cpp:141
+[16] RifReaderEclipseSummary::open(QString const&, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseSummary.cpp:107
+[17] RifSummaryReaderAggregator::createReadersAndImportMetaData(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/FileInterface/RifSummaryReaderAggregator.cpp:156
+[18] RimFileSummaryCase::findRelatedFilesAndCreateReader(QString const&, bool, RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:221
+[19] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:110
+[20] RimFileSummaryCase::createSummaryReaderInterface() at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:129
+[21] RiaSummaryTools::reloadSummaryCaseAndUpdateConnectedPlots(RimSummaryCase*) at ResInsight/ApplicationLibCode/Application/Tools/Summary/RiaSummaryTools.cpp:409
+[22] RicReloadSummaryCaseFeature::reloadSelectedCasesAndUpdate() at ResInsight/ApplicationLibCode/Commands/RicReloadSummaryCaseFeature.cpp:148
+[23] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+[32] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[38] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[50] RiuPlotMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp:1058
+[58] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[63] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[74] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[75] __libc_start_main at :0
+```
+
+**OPM issue:** [#14213](https://github.com/OPM/ResInsight/issues/14213) — CLOSED
+
+## Stack #18 — count 2
+
+First seen: `2026-05-25T14:11:16.015Z`  
+Last seen: `2026-06-02T07:05:17.144Z`  
+Versions: `2026.02.2` (2)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[5] caf::TickMarkGenerator::roundUpToLog_1_2_5_10(double) at ResInsight/Fwk/AppFwk/CommonCode/cafTickMarkGenerator.h:74
+[6] caf::OverlayScaleLegend::updateFromCamera(cvf::Camera const*) at ResInsight/Fwk/AppFwk/cafVizExtensions/cafOverlayScaleLegend.cpp:762
+[7] RiuViewer::optimizeClippingPlanes() at ResInsight/ApplicationLibCode/UserInterface/RiuViewer.cpp:1062
+[8] caf::Viewer::paintGL() at ResInsight/Fwk/AppFwk/cafViewer/cafViewer.cpp:884
+[12] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[18] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[26] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[34] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[44] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[51] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[59] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[67] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[76] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[85] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[94] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[103] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[121] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[126] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[137] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[138] __libc_start_main at :0
+```
+
+**OPM issue:** [#14146](https://github.com/OPM/ResInsight/issues/14146) — CLOSED
+
+## Stack #20 — count 2
+
+First seen: `2026-06-01T08:24:29.915Z`  
+Last seen: `2026-06-04T10:43:28.121Z`  
+Versions: `2026.02.2` (2)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[5] caf::PdmUiSliderEditor::writeValueToField() at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiSliderEditor.cpp:190
+[14] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[20] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[31] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[32] __libc_start_main at :0
+```
+
+**OPM issue:** [#14178](https://github.com/OPM/ResInsight/issues/14178) — CLOSED
+
+## Stack #22 — count 2
+
+First seen: `2026-05-26T07:35:50.673Z`  
+Last seen: `2026-05-26T12:34:51.666Z`  
+Versions: `2026.02.2` (2)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[3] RimEclipseCase::eclipseCaseData() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCase.cpp:179
+[4] RigSimulationWellCenterLineCalculator::calculateWellPipeStaticCenterline(RimSimWellInView const*, std::vector<std::vector<cvf::Vector3<double>, std::allocator<cvf::Vector3<double> > >, std::allocator<std::vector<cvf::Vector3<double>, std::allocator<cvf::Vector3<double> > > > >&, std::vector<std::vector<RigWellResultPoint, std::allocator<RigWellResultPoint> >, std::allocator<std::vector<RigWellResultPoint, std::allocator<RigWellResultPoint> > > >&) at ResInsight/ApplicationLibCode/ReservoirDataModel/Well/RigSimulationWellCenterLineCalculator.cpp:132
+[5] RigSimulationWellCenterLineCalculator::calculateWellPipeStaticCenterline(RimSimWellInView const*) at ResInsight/ApplicationLibCode/ReservoirDataModel/Well/RigSimulationWellCenterLineCalculator.cpp:51
+[6] RimSimWellInView::wellBranchesForVisualization() const at ResInsight/ApplicationLibCode/ProjectDataModel/RimSimWellInView.cpp:190
+[7] RivSimWellPipesPartMgr::buildWellPipeParts(caf::DisplayCoordTransform const*, bool, double, int, unsigned long) at ResInsight/ApplicationLibCode/ModelVisualization/RivSimWellPipesPartMgr.cpp:169
+[8] RivSimWellPipesPartMgr::appendDynamicGeometryPartsToModel(cvf::ModelBasicList*, unsigned long, caf::DisplayCoordTransform const*) at ResInsight/ApplicationLibCode/ModelVisualization/RivSimWellPipesPartMgr.cpp:98
+[9] RivReservoirSimWellsPartMgr::appendDynamicGeometryPartsToModel(cvf::ModelBasicList*, unsigned long) at ResInsight/ApplicationLibCode/ModelVisualization/RivReservoirSimWellsPartMgr.cpp:110
+[10] RimEclipseView::appendWellsAndFracturesToModel() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp:1093
+[11] RimEclipseView::onUpdateDisplayModelForCurrentTimeStep() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp:897
+[12] Rim3dView::updateDisplayModelForCurrentTimeStepAndRedraw() at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:673
+[13] RiuViewer::setCurrentFrame(int) at ResInsight/ApplicationLibCode/UserInterface/RiuViewer.cpp:1008
+[14] RiuViewer::slotSetCurrentFrame(int) at ResInsight/ApplicationLibCode/UserInterface/RiuViewer.cpp:348
+[16] caf::FrameAnimationControl::changeFrame(int) at ResInsight/cmakebuild/Fwk/AppFwk/cafAnimControl/cafAnimControl_autogen/EWIEGA46WW/moc_cafFrameAnimationControl.cpp:321
+[26] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[32] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[43] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[44] __libc_start_main at :0
+```
+
+**OPM issue:** [#14161](https://github.com/OPM/ResInsight/issues/14161) — CLOSED
+
+## Stack #25 — count 1
+
+First seen: `2026-06-01T21:47:26.942Z`  
+Last seen: `2026-06-01T21:47:26.942Z`  
+Versions: `2026.02.2` (1)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[3] cvf::ref<RigFaultsPrCellAccumulator>::isNull() const at ResInsight/Fwk/VizFwk/LibCore/cvfObject.inl:327
+[4] RiuViewerCommands::displayContextMenu(QMouseEvent*) at ResInsight/ApplicationLibCode/UserInterface/RiuViewerCommands.cpp:425
+[8] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[14] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[25] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[26] __libc_start_main at :0
+```
+
+**OPM issue:** [#14193](https://github.com/OPM/ResInsight/issues/14193) — CLOSED
+
+## Stack #26 — count 1
+
+First seen: `2026-06-03T13:27:47.881Z`  
+Last seen: `2026-06-03T13:27:47.881Z`  
+Versions: `2026.02.2` (1)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[3] RiaSummaryCurveDefinition::summaryAddressY() const at ResInsight/ApplicationLibCode/Application/Tools/Summary/RiaSummaryCurveDefinition.cpp:114
+[4] RimCorrelationPlotCollection::applyFirstEnsembleFieldAddressesToReport(RimCorrelationReportPlot*, std::vector<QString, std::allocator<QString> > const&, QString const&) at ResInsight/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationPlotCollection.cpp:325
+[5] RimCorrelationPlotCollection::createCorrelationReportPlot(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/CorrelationPlots/RimCorrelationPlotCollection.cpp:153
+[6] RicNewCorrelationReportPlotFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/CorrelationPlotCommands/RicNewCorrelationReportPlotFeature.cpp:78
+[7] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+[16] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[22] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[34] RiuPlotMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp:1058
+[42] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[47] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[58] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[59] __libc_start_main at :0
+```
+
+**OPM issue:** [#14174](https://github.com/OPM/ResInsight/issues/14174) — CLOSED
+
+## Stack #27 — count 1
+
+First seen: `2026-06-01T11:02:54.109Z`  
+Last seen: `2026-06-01T11:02:54.109Z`  
+Versions: `2026.02.2` (1)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[6] operator() at ResInsight/ApplicationLibCode/ProjectDataModel/Flow/RimWellAllocationOverTimePlot.cpp:813
+[7] RimWellAllocationOverTimePlot::setValidTimeStepRangeForCase() at ResInsight/ApplicationLibCode/ProjectDataModel/Flow/RimWellAllocationOverTimePlot.cpp:815
+[8] RimWellAllocationOverTimePlot::setFromSimulationWell(RimSimWellInView*) at ResInsight/ApplicationLibCode/ProjectDataModel/Flow/RimWellAllocationOverTimePlot.cpp:164
+[9] RicShowWellAllocationPlotFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/FlowCommands/RicShowWellAllocationPlotFeature.cpp:99
+[10] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+[19] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[25] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[37] RiuMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:2056
+[45] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[50] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[61] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[62] __libc_start_main at :0
+```
+
+**OPM issue:** [#14155](https://github.com/OPM/ResInsight/issues/14155) — CLOSED
+
+## Stack #33 — count 1
+
+First seen: `2026-06-15T15:40:28.364Z`  
+Last seen: `2026-06-15T15:40:28.364Z`  
+Versions: `2026.02.2` (1)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[3] ecl_grid_alloc_EGRID__ at ResInsight/ThirdParty/Ert/lib/ecl/ecl_grid.cpp:3085
+[4] ecl_grid_alloc_EGRID_all_grids at ResInsight/ThirdParty/Ert/lib/ecl/ecl_grid.cpp:3106
+[5] RifReaderEclipseOutput::loadAllGrids() const at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp:1161
+[6] RifReaderEclipseOutput::open(QString const&, RigEclipseCaseData*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp:389
+[7] RimEclipseResultCase::importGridAndResultMetaData(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultCase.cpp:261
+[8] RimEclipseCase::openReservoirCase() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCase.cpp:1060
+[9] RimEclipseView::onLoadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp:1188
+[10] RimViewWindow::loadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimViewWindow.cpp:88
+[11] RimEclipseViewCollection::addView(RimEclipseCase*) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseViewCollection.cpp:112
+[12] RicNewViewFeature::createReservoirView(RimEclipseCase*, RimGeoMechCase*, RimEclipseViewCollection*) at ResInsight/ApplicationLibCode/Commands/RicNewViewFeature.cpp:134
+[13] RicNewViewFeature::addReservoirView(RimEclipseCase*, RimGeoMechCase*, RimEclipseViewCollection*) at ResInsight/ApplicationLibCode/Commands/RicNewViewFeature.cpp:47
+[14] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+[23] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[29] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[41] RiuMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:2056
+[49] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[54] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[65] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[66] __libc_start_main at :0
+```
+
+**OPM issue:** [#14118](https://github.com/OPM/ResInsight/issues/14118) — CLOSED
+
+## Stack #34 — count 1
+
+First seen: `2026-05-26T13:23:28.149Z`  
+Last seen: `2026-05-26T13:23:28.149Z`  
+Versions: `2026.02.2` (1)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[5] RifHdf5Exporter::createGroup(H5::Group*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) at ResInsight/ApplicationLibCode/FileInterface/RifHdf5Exporter.cpp:117
+[6] RifHdf5SummaryExporter::writeGeneralSection(RifHdf5Exporter&, Opm::EclIO::ESmry&) at ResInsight/ApplicationLibCode/FileInterface/RifHdf5SummaryExporter.cpp:167
+[7] RifHdf5SummaryExporter::ensureHdf5FileIsCreated(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool, unsigned long&) at ResInsight/ApplicationLibCode/FileInterface/RifHdf5SummaryExporter.cpp:141
+[8] RifReaderEclipseSummary::open(QString const&, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseSummary.cpp:107
+[9] RifSummaryReaderAggregator::createReadersAndImportMetaData(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/FileInterface/RifSummaryReaderAggregator.cpp:156
+[10] RimFileSummaryCase::findRelatedFilesAndCreateReader(QString const&, bool, RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:221
+[11] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:110
+[12] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+```
+
+**OPM issue:** [#14213](https://github.com/OPM/ResInsight/issues/14213) — CLOSED
+
+## Stack #35 — count 1
+
+First seen: `2026-05-27T10:59:13.448Z`  
+Last seen: `2026-05-27T10:59:13.448Z`  
+Versions: `2026.02.2` (1)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[3] ecl_kw_get_data_type at ResInsight/ThirdParty/Ert/lib/ecl/ecl_kw.cpp:1776
+[4] ecl_file_kw_assert_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_kw.cpp:211
+[5] ecl_file_kw_load_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_kw.cpp:244
+[6] ecl_file_view_get_kw at ResInsight/ThirdParty/Ert/lib/ecl/ecl_file_view.cpp:149
+[7] RifEclipseOutputFileTools::keywordData(ecl_file_struct const*, QString const&, unsigned long, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseOutputFileTools.cpp:305
+[8] RifEclipseUnifiedRestartFileAccess::results(QString const&, unsigned long, unsigned long, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseUnifiedRestartFileAccess.cpp:248
+[9] RifReaderEclipseOutput::dynamicResult(QString const&, RiaDefines::PorosityModelType, unsigned long, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp:1070
+[10] RigCaseCellResultsData::findOrLoadKnownScalarResult(RigEclipseResultAddress const&) at ResInsight/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp:1538
+[11] RigCaseCellResultsData::findOrLoadKnownScalarResult(RigEclipseResultAddress const&) at ResInsight/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp:1473
+[12] RigCaseCellResultsData::ensureKnownResultLoaded(RigEclipseResultAddress const&) at ResInsight/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp:1264
+[13] RimEclipseResultDefinition::loadResult() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:1134
+[14] RimEclipseCellColors::loadResult() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCellColors.cpp:260
+[15] RimEclipseResultDefinition::loadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:533
+[16] RimEclipseResultDefinition::fieldChangedByUi(caf::PdmFieldHandle const*, QVariant const&, QVariant const&) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:305
+[17] RimEclipseCellColors::fieldChangedByUi(caf::PdmFieldHandle const*, QVariant const&, QVariant const&) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCellColors.cpp:90
+[18] caf::PdmUiFieldHandle::notifyFieldChanged(QVariant const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiFieldHandle.cpp:74
+[19] caf::PdmFieldUiCap<caf::PdmField<QString> >::setValueFromUiEditor(QVariant const&, bool) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafInternalPdmUiFieldCapability.inl:110
+[20] caf::PdmUiCommandSystemProxy::setUiValueToField(caf::PdmUiFieldHandle*, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiCommandSystemProxy.cpp:122
+[21] caf::PdmUiTreeSelectionQModel::setData(QModelIndex const&, QVariant const&, int) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionQModel.cpp:482
+[32] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[38] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[49] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[50] __libc_start_main at :0
+```
+
+**OPM issue:** [#14140](https://github.com/OPM/ResInsight/issues/14140) — CLOSED
+
+## Stack #36 — count 1
+
+First seen: `2026-06-02T20:12:31.674Z`  
+Last seen: `2026-06-02T20:12:31.674Z`  
+Versions: `2026.02.2` (1)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[3] cvf::Vector3<double>::operator=(cvf::Vector3<double> const&) at ResInsight/Fwk/VizFwk/LibCore/cvfVector3.inl:140
+[4] cvf::BoundingBoxTree::buildTreeFromBoundingBoxes(std::vector<cvf::BoundingBox, std::allocator<cvf::BoundingBox> > const&, std::vector<unsigned long, std::allocator<unsigned long> > const*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:948
+[5] RigMainGrid::buildCellSearchTree() const at ResInsight/ApplicationLibCode/ReservoirDataModel/RigMainGrid.cpp:939
+[6] RigMainGrid::doBuildCellSearchTree(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*) const at ResInsight/ApplicationLibCode/ReservoirDataModel/RigMainGrid.cpp:870
+[7] RigMainGrid::computeCachedData(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*) at ResInsight/ApplicationLibCode/ReservoirDataModel/RigMainGrid.cpp:277
+[8] RimEclipseCase::computeCachedData() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCase.cpp:714
+[9] RimEclipseResultCase::importGridAndResultMetaData(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultCase.cpp:297
+[10] RiaImportEclipseCaseTools::openEclipseCaseShowTimeStepFilterImpl(QString const&, bool, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:372
+[11] RiaImportEclipseCaseTools::openEclipseCasesFromFile(QList<QString> const&, bool, std::map<QString, int, std::less<QString>, std::allocator<std::pair<QString const, int> > >*, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:107
+[12] RicImportGeneralDataFeature::openEclipseCaseFromFileNames(QList<QString> const&, bool, std::vector<int, std::allocator<int> >&, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:362
+[13] RicImportGeneralDataFeature::openEclipseFilesFromFileNames(QList<QString> const&, bool, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:104
+[14] RicfLoadCase::execute() at ResInsight/ApplicationLibCode/CommandFileInterface/RicfLoadCase.cpp:77
+[15] RiaGrpcCommandService::Execute(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) at ResInsight/GrpcInterface/RiaGrpcCommandService.cpp:92
+[16] grpc::Status std::__invoke_impl<grpc::Status, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*>(std::__invoke_memfun_ref, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*&&, rips::CommandParams const*&&, rips::CommandReply*&&) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/invoke.h:67
+[17] std::function<grpc::Status (RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*)>::operator()(RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:591
+[18] RiaGrpcServerImpl::processAllQueuedRequests() at ResInsight/GrpcInterface/RiaGrpcServer.cpp:200
+[19] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:115
+[20] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:33
+[33] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[34] __libc_start_main at :0
+```
+
+**OPM issue:** [#14179](https://github.com/OPM/ResInsight/issues/14179) — CLOSED
+
+## Stack #38 — count 1
+
+First seen: `2026-05-28T09:06:55.276Z`  
+Last seen: `2026-05-28T09:06:55.276Z`  
+Versions: `2026.02.2` (1)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[5] RiuPlotMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp:107
+[13] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[18] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[29] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[30] __libc_start_main at :0
+```
+
+**OPM issue:** [#14174](https://github.com/OPM/ResInsight/issues/14174) — CLOSED
+
+## Stack #40 — count 1
+
+First seen: `2026-06-16T13:04:51.343Z`  
+Last seen: `2026-06-16T13:04:51.343Z`  
+Versions: `2026.02.2` (1)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[3] RimWellFlowRateCurve::updateCurveAppearance() at ResInsight/ApplicationLibCode/ProjectDataModel/Flow/RimWellFlowRateCurve.cpp:227
+[4] RimWellFlowRateCurve::onLoadDataAndUpdate(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Flow/RimWellFlowRateCurve.cpp:164
+[5] RimPlotCurve::loadDataAndUpdate(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimPlotCurve.cpp:587
+[6] non-virtual thunk to RimWellFlowRateCurve::fieldChangedByUi(caf::PdmFieldHandle const*, QVariant const&, QVariant const&) at ResInsight/ApplicationLibCode/ProjectDataModel/Flow/RimWellFlowRateCurve.h:63
+[7] caf::PdmUiFieldHandle::notifyFieldChanged(QVariant const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiFieldHandle.cpp:74
+[8] caf::PdmFieldUiCap<caf::PdmField<bool> >::setValueFromUiEditor(QVariant const&, bool) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafInternalPdmUiFieldCapability.inl:110
+[9] caf::CmdFieldChangeExec::redo() at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFieldChangeExec.cpp:139
+[11] caf::CmdUiCommandSystemImpl::fieldChangedCommand(std::vector<caf::PdmFieldHandle*, std::allocator<caf::PdmFieldHandle*> > const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdUiCommandSystemImpl.cpp:146
+[12] caf::PdmUiCommandSystemProxy::setUiValueToField(caf::PdmUiFieldHandle*, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiCommandSystemProxy.cpp:113
+[13] caf::PdmUiTreeViewQModel::setData(QModelIndex const&, QVariant const&, int) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeViewQModel.cpp:761
+[24] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[30] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[41] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[42] __libc_start_main at :0
+```
+
+**OPM issue:** [#14011](https://github.com/OPM/ResInsight/issues/14011) — CLOSED
+
+## Stack #42 — count 1
+
+First seen: `2026-05-29T06:57:22.879Z`  
+Last seen: `2026-05-29T06:57:22.879Z`  
+Versions: `2026.02.2` (1)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[8] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:164
+[9] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[25] RifEclipseUnifiedRestartFileAccess::results(QString const&, unsigned long, unsigned long, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifEclipseUnifiedRestartFileAccess.cpp:248
+[26] RifReaderEclipseOutput::dynamicResult(QString const&, RiaDefines::PorosityModelType, unsigned long, std::vector<double, std::allocator<double> >*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp:1070
+[27] RigCaseCellResultsData::findOrLoadKnownScalarResult(RigEclipseResultAddress const&) [clone .localalias] at :0
+[28] RigCaseCellResultsData::ensureKnownResultLoaded(RigEclipseResultAddress const&) at :0
+[29] RimEclipseResultDefinition::loadResult() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:1134
+[30] RimEclipseCellColors::loadResult() [clone .localalias] at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCellColors.cpp:260
+[31] RimEclipseResultDefinition::loadDataAndUpdate() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:533
+[32] RimEclipseResultDefinition::fieldChangedByUi(caf::PdmFieldHandle const*, QVariant const&, QVariant const&) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinition.cpp:305
+[33] RimEclipseCellColors::fieldChangedByUi(caf::PdmFieldHandle const*, QVariant const&, QVariant const&) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCellColors.cpp:90
+[34] caf::PdmUiFieldHandle::notifyFieldChanged(QVariant const&, QVariant const&) at :0
+[35] caf::PdmFieldUiCap<caf::PdmField<QString> >::setValueFromUiEditor(QVariant const&, bool) at :0
+[36] caf::PdmUiCommandSystemProxy::setUiValueToField(caf::PdmUiFieldHandle*, QVariant const&) at :0
+[37] caf::PdmUiTreeSelectionQModel::setData(QModelIndex const&, QVariant const&, int) at :0
+[48] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[54] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[65] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[66] __libc_start_main at :0
+```
+
+**OPM issue:** [#14140](https://github.com/OPM/ResInsight/issues/14140) — CLOSED
+
+## Stack #43 — count 1
+
+First seen: `2026-06-02T20:12:32.867Z`  
+Last seen: `2026-06-02T20:12:32.867Z`  
+Versions: `2026.02.2` (1)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[3] cvf::Vector3<double>::operator=(cvf::Vector3<double> const&) at ResInsight/Fwk/VizFwk/LibCore/cvfVector3.inl:140
+[4] void std::_Construct<cvf::BoundingBox, cvf::BoundingBox&>(cvf::BoundingBox*, cvf::BoundingBox&) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/stl_construct.h:119
+[5] __gnu_cxx::__normal_iterator<cvf::BoundingBox*, std::vector<cvf::BoundingBox, std::allocator<cvf::BoundingBox> > > std::vector<cvf::BoundingBox, std::allocator<cvf::BoundingBox> >::insert<__gnu_cxx::__normal_iterator<cvf::BoundingBox*, std::vector<cvf::BoundingBox, std::allocator<cvf::BoundingBox> > >, void>(__gnu_cxx::__normal_iterator<cvf::BoundingBox const*, std::vector<cvf::BoundingBox, std::allocator<cvf::BoundingBox> > >, __gnu_cxx::__normal_iterator<cvf::BoundingBox*, std::vector<cvf::BoundingBox, std::allocator<cvf::BoundingBox> > >, __gnu_cxx::__normal_iterator<cvf::BoundingBox*, std::vector<cvf::BoundingBox, std::allocator<cvf::BoundingBox> > >) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/stl_vector.h:1486
+[7] RigMainGrid::buildCellSearchTree() const at ResInsight/ApplicationLibCode/ReservoirDataModel/RigMainGrid.cpp:894
+[8] RigMainGrid::doBuildCellSearchTree(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*) const at ResInsight/ApplicationLibCode/ReservoirDataModel/RigMainGrid.cpp:870
+[9] RigMainGrid::computeCachedData(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*) at ResInsight/ApplicationLibCode/ReservoirDataModel/RigMainGrid.cpp:277
+[10] RimEclipseCase::computeCachedData() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCase.cpp:714
+[11] RimEclipseResultCase::importGridAndResultMetaData(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultCase.cpp:297
+[12] RiaImportEclipseCaseTools::openEclipseCaseShowTimeStepFilterImpl(QString const&, bool, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:372
+[13] RiaImportEclipseCaseTools::openEclipseCasesFromFile(QList<QString> const&, bool, std::map<QString, int, std::less<QString>, std::allocator<std::pair<QString const, int> > >*, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:107
+[14] RicImportGeneralDataFeature::openEclipseCaseFromFileNames(QList<QString> const&, bool, std::vector<int, std::allocator<int> >&, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:362
+[15] RicImportGeneralDataFeature::openEclipseFilesFromFileNames(QList<QString> const&, bool, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:104
+[16] RicfLoadCase::execute() at ResInsight/ApplicationLibCode/CommandFileInterface/RicfLoadCase.cpp:77
+[17] RiaGrpcCommandService::Execute(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) at ResInsight/GrpcInterface/RiaGrpcCommandService.cpp:92
+[18] grpc::Status std::__invoke_impl<grpc::Status, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*>(std::__invoke_memfun_ref, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*&&, rips::CommandParams const*&&, rips::CommandReply*&&) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/invoke.h:67
+[19] std::function<grpc::Status (RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*)>::operator()(RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:591
+[20] RiaGrpcServerImpl::processAllQueuedRequests() at ResInsight/GrpcInterface/RiaGrpcServer.cpp:200
+[21] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:115
+[22] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:33
+[35] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[36] __libc_start_main at :0
+```
+
+**OPM issue:** [#14179](https://github.com/OPM/ResInsight/issues/14179) — CLOSED
+
+## Stack #45 — count 1
+
+First seen: `2026-05-22T10:49:44.2Z`  
+Last seen: `2026-05-22T10:49:44.2Z`  
+Versions: `2026.02.2` (1)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[3] RigFemPartResultsCollection::stepListIndexToTimeStepAndDataFrameIndex(int) const at ResInsight/ApplicationLibCode/GeoMech/GeoMechDataModel/RigFemPartResultsCollection.cpp:999
+[4] RimGeoMechView::onClampCurrentTimestep() at ResInsight/ApplicationLibCode/ProjectDataModel/GeoMech/RimGeoMechView.cpp:817
+[5] Rim3dView::createDisplayModelAndRedraw() at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:714
+[6] RiaViewRedrawScheduler::updateAndRedrawScheduledViews() at ResInsight/ApplicationLibCode/Application/RiaViewRedrawScheduler.cpp:93
+[11] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[21] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[22] __libc_start_main at :0
+```
+
+**OPM issue:** [#14116](https://github.com/OPM/ResInsight/issues/14116) — CLOSED
+
+## Stack #46 — count 1
+
+First seen: `2026-06-11T10:55:17.861Z`  
+Last seen: `2026-06-11T10:55:17.861Z`  
+Versions: `2026.06.0-RC_3` (1)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:167
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:263
+[5] caf::PdmFieldUiCap<caf::PdmField<QString> >::setValueFromUiEditor(QVariant const&, bool) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafInternalPdmUiFieldCapability.inl:30
+[6] caf::PdmUiCommandSystemProxy::setUiValueToField(caf::PdmUiFieldHandle*, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiCommandSystemProxy.cpp:122
+[7] caf::PdmUiTreeSelectionQModel::setData(QModelIndex const&, QVariant const&, int) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionQModel.cpp:482
+[9] caf::PdmUiTreeSelectionEditor::currentChanged(QModelIndex const&) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionEditor.cpp:829
+[10] caf::PdmUiTreeSelectionEditor::slotClicked(QModelIndex const&) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionEditor.cpp:776
+[19] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1828
+[25] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1828
+[36] main at ResInsight/ApplicationExeCode/RiaMain.cpp:258
+[37] __libc_start_main at :0
+```
+
+**OPM issue:** [#14140](https://github.com/OPM/ResInsight/issues/14140) — CLOSED
+
+## Stack #54 — count 1
+
+First seen: `2026-06-05T12:19:36.531Z`  
+Last seen: `2026-06-05T12:19:36.531Z`  
+Versions: `2026.02.2` (1)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[5] RigCaseCellResultsData::statistics(RigEclipseResultAddress const&) at ResInsight/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp:3063
+[6] RigCaseCellResultsData::setStatisticsDataCacheNumBins(RigEclipseResultAddress const&, unsigned long) at ResInsight/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp:3204
+[7] RimHistogramCalculator::histogramData(RimEclipseView*, RimEclipseResultDefinition*, RimHistogramCalculator::StatisticsCellRangeType, RimHistogramCalculator::StatisticsTimeRangeType, int) at ResInsight/ApplicationLibCode/ProjectDataModel/RimHistogramCalculator.cpp:259
+[8] RimGridStatisticsHistogramDataSource::createStatisticsData() const at ResInsight/ApplicationLibCode/ProjectDataModel/Histogram/RimGridStatisticsHistogramDataSource.cpp:209
+[9] RimGridStatisticsHistogramDataSource::compute(RimHistogramPlot::GraphType, RimHistogramPlot::FrequencyType) const at ResInsight/ApplicationLibCode/ProjectDataModel/Histogram/RimGridStatisticsHistogramDataSource.cpp:165
+[10] RimHistogramCurve::onLoadDataAndUpdate(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Histogram/RimHistogramCurve.cpp:278
+[11] RimPlotCurve::loadDataAndUpdate(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimPlotCurve.cpp:587
+[12] RimHistogramCurve::loadAndUpdateDataAndPlot() at ResInsight/ApplicationLibCode/ProjectDataModel/Histogram/RimHistogramCurve.cpp:440
+[13] std::function<void (caf::SignalEmitter const*)>::operator()(caf::SignalEmitter const*) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:591
+[14] RicCreateGridStatisticsPlotFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/RicCreateGridStatisticsPlotFeature.cpp:45
+[15] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+[24] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[30] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[42] RiuViewerCommands::displayContextMenu(QMouseEvent*) at ResInsight/ApplicationLibCode/UserInterface/RiuViewerCommands.cpp:648
+[46] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[52] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[63] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[64] __libc_start_main at :0
+```
+
+**OPM issue:** [#14168](https://github.com/OPM/ResInsight/issues/14168) — CLOSED
+
+## Stack #55 — count 1
+
+First seen: `2026-05-21T11:50:13.645Z`  
+Last seen: `2026-05-21T11:50:13.645Z`  
+Versions: `2026.02.2` (1)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[3] Rim3dView::scaleZ() const at ResInsight/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp:1242
+[4] RimViewController::updateCameraLink() at ResInsight/ApplicationLibCode/ProjectDataModel/RimViewController.cpp:559
+[5] RimViewController::fieldChangedByUi(caf::PdmFieldHandle const*, QVariant const&, QVariant const&) at ResInsight/ApplicationLibCode/ProjectDataModel/RimViewController.cpp:167
+[6] caf::PdmUiFieldHandle::notifyFieldChanged(QVariant const&, QVariant const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiFieldHandle.cpp:74
+[7] caf::PdmField<bool>::setValueWithFieldChanged(bool const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmDataValueField.h:299
+[8] RicToggleItemsFeatureImpl::setObjectToggleStateForSelection(RicToggleItemsFeatureImpl::SelectionToggleType) at ResInsight/ApplicationLibCode/Commands/ToggleCommands/RicToggleItemsFeatureImpl.cpp:137
+[9] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+[18] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[24] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[36] RiuMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:2056
+[44] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[49] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[60] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[61] __libc_start_main at :0
+```
+
+**OPM issue:** [#13878](https://github.com/OPM/ResInsight/issues/13878) — CLOSED
+
+## Stack #58 — count 1
+
+First seen: `2026-06-08T21:16:36.133Z`  
+Last seen: `2026-06-08T21:16:36.133Z`  
+Versions: `2026.02.2` (1)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[5] cvf::AssertHandlerConsole::handleAssert(char const*, int, char const*, char const*) at ResInsight/Fwk/VizFwk/LibCore/cvfAssert.cpp:125
+[6] cvf::Frustum::isOutside(cvf::BoundingBox const&) const at ResInsight/Fwk/VizFwk/LibGeometry/cvfFrustum.cpp:203
+[7] cvf::ModelBasicList::partVisible(cvf::Part*, cvf::Camera const*, cvf::CullSettings const*, unsigned int, double*) at ResInsight/Fwk/VizFwk/LibViewing/cvfModelBasicList.cpp:215
+[8] cvf::ModelBasicList::findVisibleParts(cvf::PartRenderHintCollection*, cvf::Camera const&, cvf::CullSettings const&, unsigned int) at ResInsight/Fwk/VizFwk/LibViewing/cvfModelBasicList.cpp:181
+[9] cvf::Scene::findVisibleParts(cvf::PartRenderHintCollection*, cvf::Camera const&, cvf::CullSettings const&, unsigned int) at ResInsight/Fwk/VizFwk/LibViewing/cvfScene.cpp:87
+[10] cvf::Rendering::render(cvf::OpenGLContext*) at ResInsight/Fwk/VizFwk/LibViewing/cvfRendering.cpp:182
+[11] cvf::RenderSequence::render(cvf::OpenGLContext*) at ResInsight/Fwk/VizFwk/LibViewing/cvfRenderSequence.cpp:211
+[12] caf::Viewer::paintGL() at ResInsight/Fwk/AppFwk/cafViewer/cafViewer.cpp:901
+[16] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[22] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[32] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[33] __libc_start_main at :0
+```
+
+**OPM issue:** [#13930](https://github.com/OPM/ResInsight/issues/13930) — CLOSED
+
+## Stack #63 — count 1
+
+First seen: `2026-05-29T13:31:33.488Z`  
+Last seen: `2026-05-29T13:31:33.488Z`  
+Versions: `2026.02.2` (1)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[5] RifHdf5Exporter::createGroup(H5::Group*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) at ResInsight/ApplicationLibCode/FileInterface/RifHdf5Exporter.cpp:117
+[6] RifHdf5SummaryExporter::writeGeneralSection(RifHdf5Exporter&, Opm::EclIO::ESmry&) at ResInsight/ApplicationLibCode/FileInterface/RifHdf5SummaryExporter.cpp:167
+[7] RifHdf5SummaryExporter::ensureHdf5FileIsCreated(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool, unsigned long&) at ResInsight/ApplicationLibCode/FileInterface/RifHdf5SummaryExporter.cpp:141
+[8] RifReaderEclipseSummary::open(QString const&, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseSummary.cpp:107
+[9] RimFileSummaryCase::findRelatedFilesAndCreateReader(QString const&, bool, RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:238
+[10] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:110
+[11] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) [clone ._omp_fn.0] at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:567
+[13] RimSummaryCaseMainCollection::loadFileSummaryCaseData(std::vector<RimFileSummaryCase*, std::allocator<RimFileSummaryCase*> > const&, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:561
+[14] RimSummaryCaseMainCollection::loadSummaryCaseData(std::vector<RimSummaryCase*, std::allocator<RimSummaryCase*> > const&, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:457
+[15] RimSummaryCaseMainCollection::createSummaryCasesFromFileInfos(std::vector<RifSummaryCaseFileResultInfo, std::allocator<RifSummaryCaseFileResultInfo> > const&, bool, bool) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp:712
+[16] RiaEnsembleImportTools::createSummaryCasesFromFiles(QList<QString> const&, RiaEnsembleImportTools::CreateConfig) at ResInsight/ApplicationLibCode/Application/Tools/Ensemble/RiaEnsembleImportTools.cpp:82
+[17] RicImportSummaryCasesFeature::createAndAddSummaryCasesFromFiles(QList<QString> const&, bool) at ResInsight/ApplicationLibCode/Commands/RicImportSummaryCasesFeature.cpp:126
+[18] RicImportGeneralDataFeature::openSummaryCaseFromFileNames(QList<QString> const&, bool) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:378
+[19] RicImportGeneralDataFeature::openEclipseFilesFromFileNames(QList<QString> const&, bool, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:122
+[20] RicImportGeneralDataFeature::openEclipseFilesFromFileNames(QList<QString> const&, bool, bool) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:55
+[21] RicImportGeneralDataFeature::openFileDialog(RiaDefines::ImportFileType) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:339
+[22] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+[31] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[37] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[49] RiuPlotMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp:1058
+[57] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[62] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[73] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[74] __libc_start_main at :0
+```
+
+**OPM issue:** [#14213](https://github.com/OPM/ResInsight/issues/14213) — CLOSED
+
+## Stack #65 — count 1
+
+First seen: `2026-06-04T11:15:23.138Z`  
+Last seen: `2026-06-04T11:15:23.138Z`  
+Versions: `2026.02.2` (1)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[8] std::__new_allocator<std::_Rb_tree_node<caf::PdmUiEditorHandle*> >::deallocate(std::_Rb_tree_node<caf::PdmUiEditorHandle*>*, unsigned long) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/new_allocator.h:172
+[9] std::_Rb_tree<caf::PdmUiEditorHandle*, caf::PdmUiEditorHandle*, std::_Identity<caf::PdmUiEditorHandle*>, std::less<caf::PdmUiEditorHandle*>, std::allocator<caf::PdmUiEditorHandle*> >::erase(caf::PdmUiEditorHandle* const&) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/stl_tree.h:1255
+[10] caf::PdmUiEditorHandle::~PdmUiEditorHandle() at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiEditorHandle.cpp:55
+[11] caf::PdmUiTreeItemEditor::~PdmUiTreeItemEditor() at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeItemEditor.h:53
+[12] caf::PdmUiTreeOrdering::~PdmUiTreeOrdering() at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiTreeOrdering.cpp:233
+[13] void qDeleteAll<QList<caf::PdmUiTreeOrdering*>::const_iterator>(QList<caf::PdmUiTreeOrdering*>::const_iterator, QList<caf::PdmUiTreeOrdering*>::const_iterator) at /private/f_resinsight_build/resbuild/qt/6.6.3/gcc_64/include/QtCore/qalgorithms.h:27
+[14] void qDeleteAll<QList<caf::PdmUiTreeOrdering*>::const_iterator>(QList<caf::PdmUiTreeOrdering*>::const_iterator, QList<caf::PdmUiTreeOrdering*>::const_iterator) at /private/f_resinsight_build/resbuild/qt/6.6.3/gcc_64/include/QtCore/qalgorithms.h:27
+[15] void qDeleteAll<QList<caf::PdmUiTreeOrdering*>::const_iterator>(QList<caf::PdmUiTreeOrdering*>::const_iterator, QList<caf::PdmUiTreeOrdering*>::const_iterator) at /private/f_resinsight_build/resbuild/qt/6.6.3/gcc_64/include/QtCore/qalgorithms.h:27
+[16] void qDeleteAll<QList<caf::PdmUiTreeOrdering*>::const_iterator>(QList<caf::PdmUiTreeOrdering*>::const_iterator, QList<caf::PdmUiTreeOrdering*>::const_iterator) at /private/f_resinsight_build/resbuild/qt/6.6.3/gcc_64/include/QtCore/qalgorithms.h:27
+[17] caf::PdmUiTreeOrdering::removeChildren(int, int) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiTreeOrdering.cpp:390
+[18] caf::PdmUiTreeViewQModel::updateSubTreeRecursive(QModelIndex const&, caf::PdmUiTreeOrdering*, caf::PdmUiTreeOrdering*, bool) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeViewQModel.cpp:269
+[19] caf::PdmUiTreeViewQModel::updateSubTree(caf::PdmUiItem*, bool) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeViewQModel.cpp:202
+[20] caf::PdmUiTreeViewEditor::updateMySubTree(caf::PdmUiItem*, bool) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeViewEditor.cpp:332
+[21] caf::PdmUiEditorHandle::updateUi() at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiEditorHandle.cpp:82
+[22] caf::PdmUiItem::updateConnectedEditors() const at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiItem.cpp:491
+[23] RicDeleteSummaryCaseCollectionFeature::onActionTriggered(bool) at ResInsight/ApplicationLibCode/Commands/RicDeleteSummaryCaseCollectionFeature.cpp:130
+[24] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+[25] RiuTreeViewEventFilter::activateFirstEnabledFeature(std::vector<caf::CmdFeature*, std::allocator<caf::CmdFeature*> > const&) at ResInsight/ApplicationLibCode/UserInterface/RiuTreeViewEventFilter.cpp:95
+[26] RiuTreeViewEventFilter::eventFilter(QObject*, QEvent*) at ResInsight/ApplicationLibCode/UserInterface/RiuTreeViewEventFilter.cpp:143
+[30] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[34] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[45] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[46] __libc_start_main at :0
+```
+
+**OPM issue:** [#14175](https://github.com/OPM/ResInsight/issues/14175) — CLOSED
+
+## Stack #66 — count 1
+
+First seen: `2026-06-04T10:38:47.12Z`  
+Last seen: `2026-06-04T10:38:47.12Z`  
+Versions: `2026.02.2` (1)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[3] std::vector<cvf::Vector3<double>, std::allocator<cvf::Vector3<double> > >::size() const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/stl_vector.h:993
+[4] caf::PdmUiEditorHandle::updateUi() at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiEditorHandle.cpp:82
+[5] RicWellPathGeometry3dEditor::configureAndUpdateUi(QString const&) at ResInsight/ApplicationLibCode/Commands/WellPathCommands/PointTangentManipulator/RicWellPathGeometry3dEditor.cpp:78
+[6] caf::PdmUiEditorHandle::updateUi() at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiEditorHandle.cpp:82
+[7] caf::PdmUiItem::updateConnectedEditors() const at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiItem.cpp:491
+[8] RicCreateWellTargetsPickEventHandler::handle3dPickEvent(Ric3dPickEvent const&) at ResInsight/ApplicationLibCode/Commands/WellPathCommands/RicCreateWellTargetsPickEventHandler.cpp:183
+[9] RiuViewerCommands::handlePickAction(int, int, QFlags<Qt::KeyboardModifier>) at ResInsight/ApplicationLibCode/UserInterface/RiuViewerCommands.cpp:695
+[13] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[19] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[30] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[31] __libc_start_main at :0
+```
+
+**OPM issue:** [#14172](https://github.com/OPM/ResInsight/issues/14172) — CLOSED
+
+## Stack #67 — count 1
+
+First seen: `2026-06-18T06:55:30.718Z`  
+Last seen: `2026-06-18T06:55:30.718Z`  
+Versions: `2026.06.0` (1)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:167
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:263
+[5] caf::PdmUiEditorHandle::updateUi(QString const&) at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiEditorHandle.cpp:65
+[6] caf::PdmUiPropertyView::showProperties(caf::PdmObjectHandle*) at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiPropertyView.cpp:213
+[7] RiuMainWindow::selectedObjectsChanged() at ResInsight/ApplicationLibCode/UserInterface/RiuMainWindow.cpp:1539
+[9] caf::PdmUiTreeView::slotOnSelectionChanged() at ResInsight/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeView.cpp:154
+[23] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1831
+[29] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1831
+[40] main at ResInsight/ApplicationExeCode/RiaMain.cpp:258
+[41] __libc_start_main at :0
+```
+
+**OPM issue:** [#14175](https://github.com/OPM/ResInsight/issues/14175) — CLOSED
+
+## Stack #68 — count 1
+
+First seen: `2026-06-02T20:12:32.595Z`  
+Last seen: `2026-06-02T20:12:32.595Z`  
+Versions: `2026.02.2` (1)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[3] cvf::BoundingBox::addValid(cvf::BoundingBox const&) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBox.cpp:210
+[4] cvf::AABBTree::buildTree(cvf::AABBTreeNodeInternal*, unsigned long, unsigned long, int, int) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:573
+[5] cvf::AABBTree::buildTree(cvf::AABBTreeNodeInternal*, unsigned long, unsigned long, int, int) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:595
+[6] cvf::AABBTree::buildTree(cvf::AABBTreeNodeInternal*, unsigned long, unsigned long, int, int) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:595
+[7] cvf::AABBTree::buildTree() at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:489
+[8] cvf::BoundingBoxTreeImpl::buildTree(std::vector<cvf::BoundingBox, std::allocator<cvf::BoundingBox> > const&, std::vector<std::vector<int, std::allocator<int> >, std::allocator<std::vector<int, std::allocator<int> > > > const&) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:816
+[9] cvf::BoundingBoxTree::buildTreeFromBoundingBoxes(std::vector<cvf::BoundingBox, std::allocator<cvf::BoundingBox> > const&, std::vector<unsigned long, std::allocator<unsigned long> > const*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:948
+[10] RigMainGrid::buildCellSearchTree() const at ResInsight/ApplicationLibCode/ReservoirDataModel/RigMainGrid.cpp:939
+[11] RigMainGrid::doBuildCellSearchTree(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*) const at ResInsight/ApplicationLibCode/ReservoirDataModel/RigMainGrid.cpp:870
+[12] RigMainGrid::computeCachedData(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*) at ResInsight/ApplicationLibCode/ReservoirDataModel/RigMainGrid.cpp:277
+[13] RimEclipseCase::computeCachedData() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCase.cpp:714
+[14] RimEclipseResultCase::importGridAndResultMetaData(bool) at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultCase.cpp:297
+[15] RiaImportEclipseCaseTools::openEclipseCaseShowTimeStepFilterImpl(QString const&, bool, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:372
+[16] RiaImportEclipseCaseTools::openEclipseCasesFromFile(QList<QString> const&, bool, std::map<QString, int, std::less<QString>, std::allocator<std::pair<QString const, int> > >*, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Application/Tools/RiaImportEclipseCaseTools.cpp:107
+[17] RicImportGeneralDataFeature::openEclipseCaseFromFileNames(QList<QString> const&, bool, std::vector<int, std::allocator<int> >&, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:362
+[18] RicImportGeneralDataFeature::openEclipseFilesFromFileNames(QList<QString> const&, bool, bool, RifReaderSettings&) at ResInsight/ApplicationLibCode/Commands/RicImportGeneralDataFeature.cpp:104
+[19] RicfLoadCase::execute() at ResInsight/ApplicationLibCode/CommandFileInterface/RicfLoadCase.cpp:77
+[20] RiaGrpcCommandService::Execute(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) at ResInsight/GrpcInterface/RiaGrpcCommandService.cpp:92
+[21] grpc::Status std::__invoke_impl<grpc::Status, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*>(std::__invoke_memfun_ref, grpc::Status (RiaGrpcCommandService::*&)(grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*), RiaGrpcCommandService&, grpc::ServerContext*&&, rips::CommandParams const*&&, rips::CommandReply*&&) at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/invoke.h:67
+[22] std::function<grpc::Status (RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*)>::operator()(RiaGrpcCommandService&, grpc::ServerContext*, rips::CommandParams const*, rips::CommandReply*) const at /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/std_function.h:591
+[23] RiaGrpcServerImpl::processAllQueuedRequests() at ResInsight/GrpcInterface/RiaGrpcServer.cpp:200
+[24] RiaGrpcApplicationInterface::processRequests() at ResInsight/GrpcInterface/RiaGrpcApplicationInterface.cpp:115
+[25] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:33
+[38] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[39] __libc_start_main at :0
+```
+
+**OPM issue:** [#14183](https://github.com/OPM/ResInsight/issues/14183) — CLOSED
+
+## Stack #70 — count 1
+
+First seen: `2026-06-09T12:48:39.467Z`  
+Last seen: `2026-06-09T12:48:39.467Z`  
+Versions: `2026.02.2` (1)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[13] Opm::EclIO::ESmry::dates() const at ResInsight/ThirdParty/custom-opm-common/opm-common/opm/io/eclipse/ESmry.cpp:1457
+[14] RifHdf5SummaryExporter::writeGeneralSection(RifHdf5Exporter&, Opm::EclIO::ESmry&) at ResInsight/ApplicationLibCode/FileInterface/RifHdf5SummaryExporter.cpp:165
+[15] RifHdf5SummaryExporter::ensureHdf5FileIsCreated(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool, unsigned long&) at ResInsight/ApplicationLibCode/FileInterface/RifHdf5SummaryExporter.cpp:141
+[16] RifReaderEclipseSummary::open(QString const&, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/FileInterface/RifReaderEclipseSummary.cpp:107
+[17] RimFileSummaryCase::findRelatedFilesAndCreateReader(QString const&, bool, RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:238
+[18] RimFileSummaryCase::createSummaryReaderInterfaceThreadSafe(RifEnsembleImportConfig, RiaThreadSafeLogger*) at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:110
+[19] RimFileSummaryCase::createSummaryReaderInterface() at ResInsight/ApplicationLibCode/ProjectDataModel/Summary/RimFileSummaryCase.cpp:129
+[20] RiaSummaryTools::reloadSummaryCaseAndUpdateConnectedPlots(RimSummaryCase*) at ResInsight/ApplicationLibCode/Application/Tools/Summary/RiaSummaryTools.cpp:409
+[21] RicReloadSummaryCaseFeature::reloadSelectedCasesAndUpdate() at ResInsight/ApplicationLibCode/Commands/RicReloadSummaryCaseFeature.cpp:148
+[22] caf::CmdFeature::actionTriggered(bool) at ResInsight/Fwk/AppFwk/cafCommand/cafCmdFeature.cpp:176
+[31] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[37] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[49] RiuPlotMainWindow::customMenuRequested(QPoint const&) at ResInsight/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp:1058
+[57] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[62] RiaGuiApplication::notify(QObject*, QEvent*) at ResInsight/ApplicationLibCode/Application/RiaGuiApplication.cpp:1823
+[73] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[74] __libc_start_main at :0
+```
+
+**OPM issue:** [#14213](https://github.com/OPM/ResInsight/issues/14213) — CLOSED
+
+## Stack #73 — count 1
+
+First seen: `2026-06-02T20:12:32.193Z`  
+Last seen: `2026-06-02T20:12:32.193Z`  
+Versions: `2026.02.2` (1)
+
+```
+[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147
+[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227
+[3] cvf::AABBTree::deleteInternalNodesBottomUp(cvf::AABBTreeNode*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:796
+[4] cvf::AABBTree::deleteInternalNodesBottomUp(cvf::AABBTreeNode*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:802
+[5] cvf::AABBTree::deleteInternalNodesBottomUp(cvf::AABBTreeNode*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:801
+[6] cvf::AABBTree::deleteInternalNodesBottomUp(cvf::AABBTreeNode*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:801
+[7] cvf::AABBTree::deleteInternalNodesBottomUp(cvf::AABBTreeNode*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:802
+[8] cvf::AABBTree::deleteInternalNodesBottomUp(cvf::AABBTreeNode*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:802
+[9] cvf::AABBTree::deleteInternalNodesBottomUp(cvf::AABBTreeNode*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:801
+[10] cvf::AABBTree::deleteInternalNodesBottomUp(cvf::AABBTreeNode*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:802
+[11] cvf::AABBTree::deleteInternalNodesBottomUp(cvf::AABBTreeNode*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:801
+[12] cvf::AABBTree::deleteInternalNodesBottomUp(cvf::AABBTreeNode*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:802
+[13] cvf::AABBTree::deleteInternalNodesBottomUp(cvf::AABBTreeNode*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:802
+[14] cvf::AABBTree::deleteInternalNodesBottomUp(cvf::AABBTreeNode*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:801
+[15] cvf::AABBTree::deleteInternalNodesBottomUp(cvf::AABBTreeNode*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:801
+[16] cvf::AABBTree::deleteInternalNodesBottomUp(cvf::AABBTreeNode*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:801
+[17] cvf::AABBTree::deleteInternalNodesBottomUp(cvf::AABBTreeNode*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:802
+[18] cvf::AABBTree::deleteInternalNodesBottomUp(cvf::AABBTreeNode*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:802
+[19] cvf::AABBTree::deleteInternalNodesBottomUp(cvf::AABBTreeNode*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:802
+[20] cvf::AABBTree::deleteInternalNodesBottomUp(cvf::AABBTreeNode*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:802
+[21] cvf::AABBTree::deleteInternalNodesBottomUp(cvf::AABBTreeNode*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:802
+[22] cvf::AABBTree::deleteInternalNodesBottomUp(cvf::AABBTreeNode*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:801
+[23] cvf::AABBTree::deleteInternalNodesBottomUp(cvf::AABBTreeNode*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:801
+[24] cvf::AABBTree::deleteInternalNodesBottomUp(cvf::AABBTreeNode*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:801
+[25] cvf::AABBTree::deleteInternalNodesBottomUp(cvf::AABBTreeNode*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:801
+[26] cvf::AABBTree::deleteInternalNodesBottomUp(cvf::AABBTreeNode*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:801
+[27] cvf::AABBTree::deleteInternalNodesBottomUp(cvf::AABBTreeNode*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:801
+[28] cvf::AABBTree::deleteInternalNodesBottomUp(cvf::AABBTreeNode*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:801
+[29] cvf::AABBTree::deleteInternalNodesBottomUp(cvf::AABBTreeNode*) at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:802
+[30] cvf::AABBTree::freeThis() at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:614
+[31] cvf::AABBTree::~AABBTree() at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:453
+[32] cvf::BoundingBoxTreeImpl::~BoundingBoxTreeImpl() at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:219
+[33] cvf::BoundingBoxTree::~BoundingBoxTree() at ResInsight/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp:913
+[34] cvf::Object::release() const at ResInsight/Fwk/VizFwk/LibCore/cvfObject.inl:90
+[35] RigMainGrid::~RigMainGrid() at ResInsight/ApplicationLibCode/ReservoirDataModel/RigMainGrid.cpp:58
+[36] cvf::Object::release() const at ResInsight/Fwk/VizFwk/LibCore/cvfObject.inl:90
+[37] RigEclipseCaseData::~RigEclipseCaseData() at ResInsight/ApplicationLibCode/ReservoirDataModel/RigEclipseCaseData.cpp:70
+[38] cvf::Object::release() const at ResInsight/Fwk/VizFwk/LibCore/cvfObject.inl:90
+[39] RimEclipseResultCase::~RimEclipseResultCase() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseResultCase.cpp:585
+[40] caf::PdmChildArrayField<RimEclipseCase*>::deleteChildren() at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmChildArrayField.inl:181
+[41] RimEclipseCaseCollection::close() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCaseCollection.cpp:73
+[42] RimEclipseCaseCollection::~RimEclipseCaseCollection() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCaseCollection.cpp:63
+[43] RimEclipseCaseCollection::~RimEclipseCaseCollection() at ResInsight/ApplicationLibCode/ProjectDataModel/RimEclipseCaseCollection.cpp:64
+[44] caf::PdmChildField<RimEclipseCaseCollection*>::~PdmChildField() at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmChildField.inl:80
+[45] RimOilField::~RimOilField() at ResInsight/ApplicationLibCode/ProjectDataModel/RimOilField.cpp:113
+[46] caf::PdmChildArrayField<RimOilField*>::deleteChildren() at ResInsight/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmChildArrayField.inl:181
+[47] RimProject::close() at ResInsight/ApplicationLibCode/ProjectDataModel/RimProject.cpp:257
+[48] RiaApplication::closeProject() at ResInsight/ApplicationLibCode/Application/RiaApplication.cpp:1021
+[49] RiaGrpcConsoleApplication::doIdleProcessing() at ResInsight/ApplicationExeCode/RiaGrpcConsoleApplication.cpp:36
+[62] main at ResInsight/ApplicationExeCode/RiaMain.cpp:226
+[63] __libc_start_main at :0
+```
+
+**OPM issue:** [#14182](https://github.com/OPM/ResInsight/issues/14182) — CLOSED


### PR DESCRIPTION
Weekly crash telemetry for 2026-06-20.

- **Total crash reports:** 223
- **Unique call stacks:** 73
- **Rows skipped (old version):** 74
- **Issue linking:** 1 signature linked → OPM/ResInsight #14175 (CLOSED), `caf::PdmUiEditorHandle::updateUi`

Top unlinked signatures for investigation: `RifActiveCellsReader::applyActiveCellsToAllGrids` (6), `cvf::GeometryUtils::tesselatePatchAsTriangles` (5), `caf::PdmFieldUiCap<RimSummaryEnsemble*>::setValueFromUiEditor` (5).

Files: new CSV + weekly report, updated `registry.json`, `index.md`, `incoming-csvs.md`.