### PR TITLE
Crash triage: link 20dc100c5afe to issue 14429 and PR 14430

### DIFF
--- a/stacktrace-reports/registry.json
+++ b/stacktrace-reports/registry.json
@@ -2017,10 +2017,10 @@
     },
     "20dc100c5afe": {
       "last_updated": "2026-07-31",
-      "notes": "",
+      "notes": "Fixed by PR #14430 (merged 2026-07-31): cell visibility array is ignored when its size does not match the reservoir cell count.",
       "opm_issue": {
         "number": 14429,
-        "state": "OPEN",
+        "state": "CLOSED",
         "url": "https://github.com/OPM/ResInsight/issues/14429"
       },
       "pr": {
@@ -2055,7 +2055,7 @@
         "RimTypedPlotCollection<RimGridCrossPlot>::loadDataAndUpdateAllPlots"
       ],
       "signature_id": "20dc100c5afe",
-      "status": "pr-open",
+      "status": "resolved",
       "top_frame": "RigEclipseCrossPlotDataExtractor::extract",
       "weeks": {
         "2026-04-29": {

--- a/stacktrace-reports/registry.json
+++ b/stacktrace-reports/registry.json
@@ -2016,10 +2016,18 @@
       }
     },
     "20dc100c5afe": {
-      "last_updated": "2026-06-11",
+      "last_updated": "2026-07-31",
       "notes": "",
-      "opm_issue": null,
-      "pr": null,
+      "opm_issue": {
+        "number": 14429,
+        "state": "OPEN",
+        "url": "https://github.com/OPM/ResInsight/issues/14429"
+      },
+      "pr": {
+        "branch": "fix-14429-cross-plot-cell-visibility",
+        "number": 14430,
+        "url": "https://github.com/OPM/ResInsight/pull/14430"
+      },
       "representative_stack": [
         "[0] performCrashLogging at ResInsight/ApplicationExeCode/RiaMainTools.cpp:147",
         "[1] manageSegFailureSA(int, siginfo_t*, void*) at ResInsight/ApplicationExeCode/RiaMainTools.cpp:227",
@@ -2047,7 +2055,7 @@
         "RimTypedPlotCollection<RimGridCrossPlot>::loadDataAndUpdateAllPlots"
       ],
       "signature_id": "20dc100c5afe",
-      "status": "new",
+      "status": "pr-open",
       "top_frame": "RigEclipseCrossPlotDataExtractor::extract",
       "weeks": {
         "2026-04-29": {


### PR DESCRIPTION
Signature `20dc100c5afe` (`RigEclipseCrossPlotDataExtractor::extract`): unchecked index into the cell visibility array. Filed OPM/ResInsight#14429 and PR OPM/ResInsight#14430.