### PR TITLE
Rank crash worklist by current-release impact

### DIFF
--- a/stacktrace-reports/README.md
+++ b/stacktrace-reports/README.md
@@ -13,7 +13,7 @@ Weekly ResInsight crash telemetry, deduplicated by call-stack signature and cros
 - [Incoming CSVs](./incoming-csvs.md) — every raw CSV received, with row counts and a link to its weekly report.
 - [Weekly reports](./index.md) — list of per-week analyses, newest first.
 - `registry.json` — **the source of truth.** One entry per unique crash signature, carrying its occurrence counts per week (broken down by reporting `APPversion`), the linked OPM issue and its open/closed state, any fix PR, an investigation status, and notes. State persists across weeks here, not in the Markdown.
-- [registry.py](./registry.py) — folds a weekly CSV into `registry.json` (`update`), regenerates the latest report and the index pages from it (`render`), lists unlinked signatures by impact (`worklist`), and records an investigation outcome (`set`).
+- [registry.py](./registry.py) — folds a weekly CSV into `registry.json` (`update`), regenerates the latest report and the index pages from it (`render`), lists unlinked signatures latest-version-first (`worklist`), and records an investigation outcome (`set`).
 - [link_issues.py](./link_issues.py) — searches OPM/ResInsight for each unlinked signature's top frame and links the issue when it confidently matches; refreshes the open/closed state of already-linked issues.
 - [process_week.py](./process_week.py) — one-shot driver chaining update → link → render → worklist.
 - [Analyzer](./analyze_crashes.py) — the original grouping library; `registry.py` reuses its CSV parsing and frame helpers.
@@ -53,10 +53,16 @@ That performs, in order:
    re-rendered: previous weeks' pages are frozen snapshots of what was known
    at the time, so do **not** use `render --all` (it rewrites their stack
    listings and issue states with today's registry contents).
-4. **`registry.py worklist`** — prints the signatures still unlinked, ranked by
-   total occurrences. These are the candidates for investigation.
+4. **`registry.py worklist`** — prints the signatures still unlinked, **ranked by
+   how many times they crashed the newest released `APPversion` or later**
+   (`cur` column), with all-time occurrences (`all`) only as the tie-breaker.
+   Ranking on the all-time total alone would promote bugs whose volume comes
+   from a superseded version — often already fixed — above the ones users hit
+   today. Pre-release builds (`-dev.NN`, `-RC_N`) never define the current line,
+   but crashes reported *by* a build newer than it do count; `--from-version`
+   pins the line manually. These are the candidates for investigation.
 
-Then **investigate the top unlinked signatures** with the `crash-triage` skill
+Then **investigate the unlinked signatures top-down** with the `crash-triage` skill
 in the ResInsight repo: it locates the crash site in source, proposes and
 build-verifies a fix, and — after a human gate — files the OPM issue, pushes a
 fix branch to the `magnesj` fork, opens the PR, and writes the issue/PR back

--- a/stacktrace-reports/analyzer-README.md
+++ b/stacktrace-reports/analyzer-README.md
@@ -18,7 +18,7 @@ per-signature state.
 |---|---|
 | `update --csv FILE [--date D] [--signature-depth N] [--min-version VER]` | Fold a weekly CSV into `registry.json`. Idempotent per week. |
 | `render [--date D \| --all]` | Regenerate report(s) + `index.md` + `incoming-csvs.md` from the registry. Default: latest week. Use the default in the weekly workflow — older reports are frozen snapshots, so avoid `--all`. |
-| `worklist [--all]` | Print unlinked signatures, highest total count first. |
+| `worklist [--all] [--from-version VER]` | Print unlinked signatures, those still crashing the newest released `APPversion` first (ties broken by total count). `--from-version` overrides which version line counts as current. |
 | `set --id SID [--issue N --state S] [--pr N --branch B] [--status S] [--note "..."]` | Record an investigation outcome (used by the `crash-triage` skill). |
 
 Typical run is via `process_week.py`, which chains `update` → `link_issues.py`

--- a/stacktrace-reports/process_week.py
+++ b/stacktrace-reports/process_week.py
@@ -7,7 +7,8 @@ dropped into `csv/`, it:
   2. links/refreshes OPM issues for every signature (link_issues.py)
   3. regenerates the week's report + index pages    (registry.py render)
   4. prints the investigation worklist - unlinked   (registry.py worklist)
-     signatures ranked by total occurrence count
+     signatures, those still crashing the newest
+     released version first
 
 After it finishes, hand the worklist to the `crash-triage` workflow in the
 ResInsight repo to investigate the top unlinked signatures (step 3 of the
@@ -59,13 +60,14 @@ def main() -> None:
         render_args += ["--date", args.date]
     run("registry.py", *render_args)
 
-    print("\n=== Investigation worklist (unlinked signatures by impact) ===")
+    print("\n=== Investigation worklist (unlinked signatures, latest version first) ===")
     run("registry.py", "worklist")
 
     print(
-        "\nNext: investigate the top unlinked signatures with the `crash-triage` "
-        "workflow in the ResInsight repo, then commit the CSV, registry.json, the "
-        "regenerated report and the two index pages together."
+        "\nNext: investigate the worklist top-down with the `crash-triage` workflow "
+        "in the ResInsight repo - the `cur` column is what the current release is "
+        "still crashing on, so take those first. Then commit the CSV, registry.json, "
+        "the regenerated report and the two index pages together."
     )
 
 

--- a/stacktrace-reports/registry.py
+++ b/stacktrace-reports/registry.py
@@ -26,7 +26,7 @@ Subcommands
 -----------
     update      Fold a weekly CSV into registry.json.
     render      Regenerate reports/<date>.md (one or all weeks) + the indexes.
-    worklist    Print unlinked signatures ranked by total occurrence count.
+    worklist    Print unlinked signatures, latest-version crashes first.
 
 Usage
 -----
@@ -52,6 +52,7 @@ from analyze_crashes import (
     is_handler_frame,
     is_resinsight_frame,
     parse_csv,
+    parse_version,
 )
 
 HERE = Path(__file__).resolve().parent
@@ -258,6 +259,55 @@ def global_last_seen(entry: dict) -> str:
     return max((w["last_seen"] for w in entry["weeks"].values() if w["last_seen"]), default="")
 
 
+def entry_versions(entry: dict) -> dict[str, int]:
+    """All-weeks occurrence count per reporting APPversion for one signature."""
+    totals: dict[str, int] = {}
+    for wk in entry["weeks"].values():
+        for ver, count in (wk.get("versions") or {}).items():
+            totals[ver] = totals.get(ver, 0) + count
+    return totals
+
+
+def latest_release_version(reg: dict) -> tuple[tuple[int, ...] | None, str]:
+    """Newest *released* APPversion seen anywhere in the registry.
+
+    Pre-release builds (`-dev.NN`, `-RC_N`) are ignored when picking the line:
+    a single developer's `2026.06.2-dev.01` report must not become the yardstick
+    everything else is ranked against. Crashes *on* those newer pre-release
+    builds still count towards the line, since their base sorts at or above it.
+
+    Returns (base_tuple, version_string); (None, "") when the registry carries
+    no parseable release version (weeks folded before APPversion was exported).
+    """
+    best: tuple[int, ...] | None = None
+    best_str = ""
+    for entry in reg["signatures"].values():
+        for ver in entry_versions(entry):
+            base, has_dev = parse_version(ver)
+            if base is None or has_dev:
+                continue
+            if best is None or base > best:
+                best, best_str = base, ver
+    return best, best_str
+
+
+def count_from_version(entry: dict, min_base: tuple[int, ...] | None) -> int:
+    """Occurrences reported by builds at or newer than `min_base`.
+
+    Comparison is on the parsed base only, so `2026.06.1`, `2026.06.1-dev.02`
+    and `2026.06.2-dev.01` all count towards a `2026.06.1` line. Unparseable
+    versions are excluded - they cannot be shown to be current.
+    """
+    if min_base is None:
+        return 0
+    total = 0
+    for ver, count in entry_versions(entry).items():
+        base, _ = parse_version(ver)
+        if base is not None and base >= min_base:
+            total += count
+    return total
+
+
 def issue_is_closed(entry: dict) -> bool:
     iss = entry.get("opm_issue")
     return bool(iss and iss.get("state") == "CLOSED")
@@ -444,10 +494,28 @@ def cmd_worklist(args: argparse.Namespace) -> None:
         if e["status"] in ("no-fix-found",) and not args.all:
             continue
         rows.append(e)
-    rows.sort(key=lambda e: -total_count(e))
+
+    # Triage order is "still crashing the current release first". Ranking on the
+    # all-time total instead would put bugs whose volume comes from a superseded
+    # version - often already fixed - above ones users hit today.
+    if args.from_version:
+        min_base, min_label = parse_version(args.from_version)[0], args.from_version
+        if min_base is None:
+            raise SystemExit(f"Error: cannot parse --from-version: {args.from_version}")
+    else:
+        min_base, min_label = latest_release_version(reg)
+
+    if min_base is None:
+        print("(no APPversion data in registry - ranking by total count)")
+    else:
+        print(f"Ranked by occurrences on {min_label} or newer, then by total count.")
+    print(f"{'cur':>4}  {'all':>4}  signature     status            top frame")
+
+    rows.sort(key=lambda e: (-count_from_version(e, min_base), -total_count(e)))
     for e in rows:
         print(
-            f"{total_count(e):4d}  {e['signature_id']}  [{e['status']}]  {e['top_frame']}"
+            f"{count_from_version(e, min_base):4d}  {total_count(e):4d}  "
+            f"{e['signature_id']}  [{e['status']}]  {e['top_frame']}"
         )
     if not rows:
         print("(no unlinked signatures)")
@@ -513,8 +581,11 @@ def main() -> None:
     g.add_argument("--all", action="store_true", help="render every week")
     rd.set_defaults(func=cmd_render)
 
-    wl = sub.add_parser("worklist", help="unlinked signatures by impact")
+    wl = sub.add_parser("worklist", help="unlinked signatures, latest version first")
     wl.add_argument("--all", action="store_true", help="include no-fix-found signatures")
+    wl.add_argument("--from-version", metavar="VER",
+                    help="count VER and newer as current "
+                         "(default: newest released APPversion in the registry)")
     wl.set_defaults(func=cmd_worklist)
 
     st = sub.add_parser("set", help="record investigation outcome for a signature")


### PR DESCRIPTION
`registry.py worklist` ranked signatures by all-time occurrence count, which promotes bugs whose volume comes from a superseded version — often already fixed — above the ones users hit on the release in the field today.

Ranking is now by occurrences on the newest released `APPversion` or later (new `cur` column), with the all-time total (`all`) only as tie-breaker.

- Pre-release builds (`-dev.NN`, `-RC_N`) never define the current line, so a single developer build cannot become the yardstick — but crashes reported *by* a build newer than the line do count towards it.
- `--from-version VER` pins the line manually; unparseable values error out.
- Registries with no `APPversion` data fall back to total-count order and say so.

Docs updated: `README.md` workflow step 4, `analyzer-README.md` subcommand table, and `process_week.py`'s banner and next-step text. The `crash-triage` skill in the ResInsight repo was updated to match, but `.claude` is gitignored there so that change is local-only.

No report or index was re-rendered.
